### PR TITLE
ci: simplify CI by removing gfortran matrix variants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,6 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        compiler: [gfortran-11, gfortran-12, gfortran-13, gfortran-14]
     
     steps:
     - uses: actions/checkout@v4
@@ -44,23 +40,12 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y ${{ matrix.compiler }} cmake make ffmpeg pngcheck python3-pil
+        sudo apt-get install -y gfortran cmake make ffmpeg pngcheck python3-pil
 
     - name: Set compiler
       run: |
-        if [ "${{ matrix.compiler }}" = "gfortran-11" ]; then
-          echo "FC=gfortran-11" >> $GITHUB_ENV
-          echo "FPM_FC=gfortran-11" >> $GITHUB_ENV
-        elif [ "${{ matrix.compiler }}" = "gfortran-12" ]; then
-          echo "FC=gfortran-12" >> $GITHUB_ENV
-          echo "FPM_FC=gfortran-12" >> $GITHUB_ENV
-        elif [ "${{ matrix.compiler }}" = "gfortran-13" ]; then
-          echo "FC=gfortran-13" >> $GITHUB_ENV
-          echo "FPM_FC=gfortran-13" >> $GITHUB_ENV
-        elif [ "${{ matrix.compiler }}" = "gfortran-14" ]; then
-          echo "FC=gfortran-14" >> $GITHUB_ENV
-          echo "FPM_FC=gfortran-14" >> $GITHUB_ENV
-        fi
+        echo "FC=gfortran" >> $GITHUB_ENV
+        echo "FPM_FC=gfortran" >> $GITHUB_ENV
 
     - name: Build project
       run: |


### PR DESCRIPTION
## Problem
Current CI runs 4 separate jobs for different gfortran versions (gfortran-11, 12, 13, 14), causing:
- Slower feedback (4x the job queue time)
- Unnecessary CI resource usage
- Complex matrix configuration maintenance

## Solution
- Remove matrix strategy and use single default gfortran
- Simplify dependency installation (no version-specific packages)
- Streamline compiler environment setup
- Reduce CI job count from 4 to 1

## Benefits
- Faster CI feedback (single job vs 4 parallel jobs)
- Reduced GitHub Actions usage
- Simpler CI configuration to maintain
- Still maintains essential testing (core functionality + coverage)

The essential test suite already covers the critical functionality, and the coverage job provides comprehensive validation.