### PR TITLE
fix: PDF files not deployed to GitHub Pages

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -4,7 +4,7 @@
 - [ ] #224: PDF files not deployed to GitHub Pages (404 errors)
 
 ## DOING (Current Work)
-- [x] #223: ASCII backend generates empty plots (only frames/borders) (branch: fix/ascii-empty-plots-223)
 
 ## DONE (Completed)
+- [x] #223: ASCII backend generates empty plots (only frames/borders)
 - [x] #220: Fix ASCII backend generating PDF binary content instead of text output

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,9 +1,9 @@
 # Development Backlog
 
 ## TODO (Ordered by Priority)
-- [ ] #224: PDF files not deployed to GitHub Pages (404 errors)
 
 ## DOING (Current Work)
+- [x] #224: PDF files not deployed to GitHub Pages (404 errors) (branch: fix/pdf-deployment-224)
 
 ## DONE (Completed)
 - [x] #223: ASCII backend generates empty plots (only frames/borders)

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,9 @@ run-release:
 
 # Build documentation with FORD
 doc:
-	# Copy example media files to doc build directory BEFORE running FORD for proper linking
+	# Run FORD first to generate documentation structure
+	ford README.md
+	# Copy example media files to doc build directory AFTER running FORD
 	mkdir -p build/doc/media/examples
 	# Copy from doc/media if it exists (GitHub Actions workflow populates this)
 	if [ -d doc/media/examples ]; then cp -r doc/media/examples/* build/doc/media/examples/ 2>/dev/null || true; fi
@@ -105,8 +107,6 @@ doc:
 			cp "$$dir"*.mp4 "build/doc/media/examples/$$example_name/" 2>/dev/null || true; \
 		fi; \
 	done
-	# Now run FORD after media files are in place
-	ford README.md
 
 # Generate coverage report
 coverage:


### PR DESCRIPTION
## Summary

- Fixed PDF deployment issue where files were missing from GitHub Pages (404 errors)
- Root cause: FORD was wiping build/doc directory before media files could be preserved
- Solution: Moved media file copying to occur AFTER FORD generation in make doc target

## Technical Details

The `make doc` target was copying media files to `build/doc/media/examples` before running FORD, but FORD clears the entire `build/doc` directory when generating documentation. This meant PDF files were copied and then immediately removed.

**Before:**
1. Copy media files to build/doc/media/examples
2. Run FORD (wipes build/doc directory)
3. Media files are gone

**After:**
1. Run FORD to generate documentation structure  
2. Copy media files to build/doc/media/examples
3. Media files are preserved in final deployment

## Testing

Verified locally that:
- `make example ARGS="scale_examples"` generates PDFs in output/
- `make doc` preserves PDFs in build/doc/media/examples/
- URL structure matches GitHub Pages expectations

The example PDF mentioned in issue #224:
`https://lazy-fortran.github.io/fortplot/media/examples/scale_examples/log_scale.pdf`

Should now be accessible once deployed.

## Impact

Fixes all PDF download links in the documentation that were returning 404 errors.

Closes #224