### PR TITLE
plan: add PNG generation bug issue #227 to BACKLOG.md

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -3,8 +3,8 @@
 ## TODO (Ordered by Priority)
 
 ## DOING (Current Work)
-- [x] #224: PDF files not deployed to GitHub Pages (404 errors) (branch: fix/pdf-deployment-224)
 
 ## DONE (Completed)
+- [x] #224: PDF files not deployed to GitHub Pages (404 errors)
 - [x] #223: ASCII backend generates empty plots (only frames/borders)
 - [x] #220: Fix ASCII backend generating PDF binary content instead of text output

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,6 +1,7 @@
 # Development Backlog
 
 ## TODO (Ordered by Priority)
+- [ ] #227: PNG backend generates ASCII text instead of binary PNG data
 
 ## DOING (Current Work)
 


### PR DESCRIPTION
## Summary
- Add issue #227 (PNG backend generates ASCII text instead of binary PNG data) to BACKLOG.md as high priority
- This critical bug affects all documentation images, making visual examples non-functional

## Changes
- Updated BACKLOG.md TODO section with new issue #227 as top priority
- Issue properly documented with detailed problem analysis and acceptance criteria

## Context
The PNG generation bug severely impacts user experience by breaking all documentation images. PNG files are being generated as ASCII text instead of binary image data, causing images to not display in browsers.

Generated with Claude Code