### PR TITLE
fix: resolve pcolormesh GitHub Pages visibility issue - fixes #334

### DIFF
--- a/doc/examples/pcolormesh_demo.md
+++ b/doc/examples/pcolormesh_demo.md
@@ -33,3 +33,141 @@ make example ARGS="pcolormesh_demo"
 
 ## Output
 
+### Basic Linear Gradient
+
+![pcolormesh_basic.png](../../media/examples/pcolormesh_demo/pcolormesh_basic.png)
+
+ASCII output:
+```
+
+                       Basic Pcolormesh - Linear Gradient
++--------------------------------------------------------------------------------+
+|1.20                                                                            |
+| .                                                                              |
+|                                                                                |
+|                                                                                |
+|1.00                                                                            |
+|        +               *              #              %               @         |
+|                                                                                |
+| .                                                                              |
+|                                                                                |
+|.800                                                                            |
+|                                                                                |
+|                                                                                |
+| .      -               =              +              *               #         |
+|                                                                                |
+|.600                                                                            |
+|                                                                                |
+|                                                                                |
+|                                                                                |
+| .      .               :              -              =               +         |
+|.400                                                                            |
+|                                                                                |
+|                                                                                |
+|                                                                                |
+| .                                                                              |
+|.200                                                                            |
+|                                       .              :               -         |
+|                                                                                |
+|                                                                                |
+| .       .        .       .        .       .        .       .        .        . |
+|0                  .500                1.00                1.50            2.00 |
++--------------------------------------------------------------------------------+
+                                  X coordinate
+Y coordinate
+```
+
+[Download PDF](../../media/examples/pcolormesh_demo/pcolormesh_basic.pdf)
+
+### Sinusoidal Pattern
+
+![pcolormesh_sinusoidal.png](../../media/examples/pcolormesh_demo/pcolormesh_sinusoidal.png)
+
+ASCII output:
+```
+
+                        Pcolormesh - Sinusoidal Pattern
++--------------------------------------------------------------------------------+
+|1.20                                                                            |
+| .                                                                              |
+|                                                                                |
+|    =       =       =      =       =       =       =      =                     |
+|1.00                                                                            |
+|        +               *              #              %               @         |
+|                                                                                |
+| .  #       :              +       %       =              :                     |
+|                                                                                |
+|.800                                                                            |
+|    *       -       .      +       #       =       .      -                     |
+|                                                                                |
+| .      -               =              +              *               #         |
+|    :       +       #      -       .       =       #      +                     |
+|.600                                                                            |
+|                                                                                |
+|                                                                                |
+|    .       *       %      -               =       %      *                     |
+| .      .               :              -              =               +         |
+|.400                                                                            |
+|    =       =       =      =       =       =       =      =                     |
+|                                                                                |
+|                                                                                |
+| .  #       :              +       @       =              :                     |
+|.200                                                                            |
+|                                       .              :               -         |
+|                                                                                |
+|    *       -       .      +       #       =       .      -                     |
+| .       .        .       .        .       .        .       .        .        . |
+|0                  .500                1.00                1.50            2.00 |
++--------------------------------------------------------------------------------+
+                                  X coordinate
+Y coordinate
+```
+
+[Download PDF](../../media/examples/pcolormesh_demo/pcolormesh_sinusoidal.pdf)
+
+### Radial Pattern with Plasma Colormap
+
+![pcolormesh_plasma.png](../../media/examples/pcolormesh_demo/pcolormesh_plasma.png)
+
+ASCII output:
+```
+
+                      Pcolormesh - Radial Pattern (Plasma)
++--------------------------------------------------------------------------------+
+|1.20                                                                            |
+| .                                                                              |
+|                                                                                |
+|                                                                                |
+|    = -     =     + =      = #     =     # =       =+     =                     |
+|1.00                                                                            |
+| .      +               *              #              %               @         |
+|    #       :              +       %       =              :                     |
+|                                                                                |
+|                                                                                |
+|.800  -           *          @           %          +                           |
+|    *       -       .      +       #       =       .      -                     |
+|        -               =              +              *               #         |
+|                                                                                |
+|    :       +       #      -       .       =       #      +                     |
+|.600  :           =          +           +          =                           |
+|                                                                                |
+|    .       *       %      -               =       %      *                     |
+|                                                                                |
+|.400    .               :              -              =               +         |
+|    = .     =     : =      = :     =     : =       =:     =                     |
+|                                                                                |
+|                                                                                |
+|                                                                                |
+|.200#       :              +       @       =              :                     |
+|                                       .              :               -         |
+|                                                                                |
+|    *       -       .      +       #       =       .      -                     |
+| .       .        .       .        .       .        .       .        .        . |
+|0                  .500                1.00                1.50            2.00 |
++--------------------------------------------------------------------------------+
+                                  X coordinate
+Y coordinate
+```
+
+[Download PDF](../../media/examples/pcolormesh_demo/pcolormesh_plasma.pdf)
+


### PR DESCRIPTION
## Summary
- Fixed missing image references in pcolormesh_demo.md causing no visual output on GitHub Pages
- Added comprehensive documentation content with PNG images, ASCII outputs, and PDF download links
- Verified local documentation build includes proper image embedding

## Root Cause Analysis
The issue was that while the pcolormesh_demo example was running correctly and generating PNG files during GitHub Actions, the documentation file `doc/examples/pcolormesh_demo.md` was missing the actual image references and content. This resulted in an empty documentation page with no visual showcase.

## Changes Made
1. **Added PNG Image References**: Properly referenced all three generated images:
   - `pcolormesh_basic.png` - Linear gradient visualization
   - `pcolormesh_sinusoidal.png` - Sinusoidal pattern with coolwarm colormap
   - `pcolormesh_plasma.png` - Radial pattern with plasma colormap

2. **Added ASCII Output Content**: Included full ASCII art output for all examples to provide text-based alternatives

3. **Added PDF Download Links**: Consistent with other example documentation format

## Verification
- ✅ Local documentation build confirms images are properly embedded
- ✅ PNG files are correctly copied to `build/doc/media/examples/pcolormesh_demo/`
- ✅ HTML generation includes proper `<img>` tags with correct paths
- ✅ Documentation format matches other working examples (basic_plots, etc.)

## Test Plan
1. Check GitHub Pages after merge to verify pcolormesh images are visible
2. Confirm ASCII fallback content displays correctly
3. Verify PDF download links are functional

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>