### PR TITLE
fix: prevent empty labels from creating legend entries

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -13,7 +13,6 @@
 **Critical Infrastructure Issues (High Priority)**
 
 **User-Facing Issues (Medium Priority)**
-- [ ] #328: Fix - One legend entry too much in basic_plots.html second plot
 - [ ] #327: Fix - MP4 link not showing on animation.html
 - [ ] #347: Fix - Remove funny header from https://lazy-fortran.github.io/fortplot/
 
@@ -29,6 +28,7 @@
 - [ ] #360: Refactor - split fortplot_raster.f90 to comply with file size limits
 
 ## DOING (Current Work)
+- [ ] #328: Fix - One legend entry too much in basic_plots.html second plot
 
 ## BLOCKED (Infrastructure Issues)
 

--- a/src/fortplot_figure_base.f90
+++ b/src/fortplot_figure_base.f90
@@ -375,9 +375,10 @@ contains
         
         ! Set label
         if (present(label)) then
-            self%subplots(subplot_idx)%plots(plot_idx)%label = label
-        else
-            self%subplots(subplot_idx)%plots(plot_idx)%label = ''
+            if (len_trim(label) > 0) then
+                self%subplots(subplot_idx)%plots(plot_idx)%label = label
+            end if
+            ! If label is empty or not provided, leave it unallocated
         end if
         
         ! Set linestyle 

--- a/src/fortplot_figure_core.f90
+++ b/src/fortplot_figure_core.f90
@@ -376,21 +376,24 @@ contains
         
         ! Add legend entries from plots
         do i = 1, self%plot_count
+            ! Only add legend entry if label is allocated and not empty
             if (allocated(self%plots(i)%label)) then
-                if (allocated(self%plots(i)%linestyle)) then
-                    if (allocated(self%plots(i)%marker)) then
-                        call self%legend_data%add_entry(self%plots(i)%label, &
-                                                       self%plots(i)%color, &
-                                                       self%plots(i)%linestyle, &
-                                                       self%plots(i)%marker)
+                if (len_trim(self%plots(i)%label) > 0) then
+                    if (allocated(self%plots(i)%linestyle)) then
+                        if (allocated(self%plots(i)%marker)) then
+                            call self%legend_data%add_entry(self%plots(i)%label, &
+                                                           self%plots(i)%color, &
+                                                           self%plots(i)%linestyle, &
+                                                           self%plots(i)%marker)
+                        else
+                            call self%legend_data%add_entry(self%plots(i)%label, &
+                                                           self%plots(i)%color, &
+                                                           self%plots(i)%linestyle)
+                        end if
                     else
                         call self%legend_data%add_entry(self%plots(i)%label, &
-                                                       self%plots(i)%color, &
-                                                       self%plots(i)%linestyle)
+                                                       self%plots(i)%color)
                     end if
-                else
-                    call self%legend_data%add_entry(self%plots(i)%label, &
-                                                   self%plots(i)%color)
                 end if
             end if
         end do

--- a/src/fortplot_plotting.f90
+++ b/src/fortplot_plotting.f90
@@ -555,7 +555,7 @@ contains
         self%subplots(subplot_idx)%plots(plot_idx)%y_grid = y
         self%subplots(subplot_idx)%plots(plot_idx)%z_grid = z
         
-        if (present(label)) then
+        if (present(label) .and. len_trim(label) > 0) then
             self%subplots(subplot_idx)%plots(plot_idx)%label = label
         end if
     end subroutine add_surface_plot_data
@@ -588,7 +588,7 @@ contains
             self%subplots(subplot_idx)%plots(plot_idx)%contour_levels = levels
         end if
         
-        if (present(label)) then
+        if (present(label) .and. len_trim(label) > 0) then
             self%subplots(subplot_idx)%plots(plot_idx)%label = label
         end if
     end subroutine add_contour_plot_data
@@ -630,7 +630,7 @@ contains
             self%subplots(subplot_idx)%plots(plot_idx)%show_colorbar = show_colorbar
         end if
         
-        if (present(label)) then
+        if (present(label) .and. len_trim(label) > 0) then
             self%subplots(subplot_idx)%plots(plot_idx)%label = label
         end if
     end subroutine add_colored_contour_plot_data
@@ -712,7 +712,7 @@ contains
             self%subplots(subplot_idx)%plots(plot_idx)%color = color
         end if
         
-        if (present(label)) then
+        if (present(label) .and. len_trim(label) > 0) then
             self%subplots(subplot_idx)%plots(plot_idx)%label = label
         end if
     end subroutine add_bar_plot_data
@@ -775,7 +775,7 @@ contains
             self%subplots(subplot_idx)%plots(plot_idx)%color = color
         end if
         
-        if (present(label)) then
+        if (present(label) .and. len_trim(label) > 0) then
             self%subplots(subplot_idx)%plots(plot_idx)%label = label
         end if
     end subroutine add_histogram_plot_data
@@ -814,7 +814,7 @@ contains
             self%subplots(subplot_idx)%plots(plot_idx)%color = color
         end if
         
-        if (present(label)) then
+        if (present(label) .and. len_trim(label) > 0) then
             self%subplots(subplot_idx)%plots(plot_idx)%label = label
         end if
     end subroutine add_boxplot_data
@@ -889,7 +889,7 @@ contains
         
         ! Note: alpha not directly supported in plot_data_t structure
         
-        if (present(label)) then
+        if (present(label) .and. len_trim(label) > 0) then
             self%subplots(subplot_idx)%plots(plot_idx)%label = label
         end if
     end subroutine add_scatter_plot_data

--- a/src/fortplot_plotting.f90
+++ b/src/fortplot_plotting.f90
@@ -317,8 +317,12 @@ contains
         plot_data%marker = 'o'
         if (present(marker)) plot_data%marker = trim(marker)
         
-        plot_data%label = ''
-        if (present(label)) plot_data%label = trim(label)
+        ! Only set label if provided and non-empty
+        if (present(label)) then
+            if (len_trim(label) > 0) then
+                plot_data%label = trim(label)
+            end if
+        end if
         
         ! Set color
         color_idx = mod(self%plot_count, size(self%colors, 2)) + 1
@@ -465,9 +469,10 @@ contains
         
         ! Set properties
         if (present(label)) then
-            self%subplots(subplot_idx)%plots(plot_idx)%label = label
-        else
-            self%subplots(subplot_idx)%plots(plot_idx)%label = ''
+            if (len_trim(label) > 0) then
+                self%subplots(subplot_idx)%plots(plot_idx)%label = label
+            end if
+            ! If label is empty or not provided, leave it unallocated
         end if
         
         if (present(linestyle)) then

--- a/test/test_legend_empty_label_fix.f90
+++ b/test/test_legend_empty_label_fix.f90
@@ -1,0 +1,56 @@
+program test_legend_empty_label_fix
+    !! Test that empty labels don't create legend entries (Issue #328)
+    use fortplot
+    implicit none
+    
+    real(wp), dimension(10) :: x, y1, y2, y3
+    integer :: i
+    
+    print *, "Testing fix for Issue #328: Empty legend entries"
+    print *, "-------------------------------------------------"
+    
+    ! Generate test data
+    x = [(real(i, wp), i=1, 10)]
+    y1 = x
+    y2 = 2.0_wp * x
+    y3 = 3.0_wp * x
+    
+    ! Test 1: Mix of labeled and unlabeled plots
+    print *, "Test 1: Legend with mixed labeled/unlabeled plots"
+    call figure()
+    call plot(x, y1, label='Line 1')
+    call plot(x, y2, label='Line 2')
+    call plot(x, y3)  ! No label - should not create legend entry
+    call legend()
+    call savefig('test_empty_label_1.png')
+    print *, "  ✓ Created test_empty_label_1.png (should show 2 legend entries)"
+    
+    ! Test 2: Empty string labels should not create entries
+    print *, "Test 2: Empty string labels"
+    call figure()
+    call plot(x, y1, label='Valid Label')
+    call plot(x, y2, label='')  ! Empty label - should not create entry
+    call plot(x, y3)  ! No label
+    call legend()
+    call savefig('test_empty_label_2.png')
+    print *, "  ✓ Created test_empty_label_2.png (should show 1 legend entry)"
+    
+    ! Test 3: All unlabeled plots
+    print *, "Test 3: All unlabeled plots"
+    call figure()
+    call plot(x, y1)
+    call plot(x, y2)
+    call plot(x, y3)
+    call legend()
+    call savefig('test_empty_label_3.png')
+    print *, "  ✓ Created test_empty_label_3.png (should show no legend)"
+    
+    print *, ""
+    print *, "========================================="
+    print *, "Issue #328 fix validation complete"
+    print *, "Check the generated PNG files to verify:"
+    print *, "  - test_empty_label_1.png: 2 legend entries"
+    print *, "  - test_empty_label_2.png: 1 legend entry"
+    print *, "  - test_empty_label_3.png: no legend box"
+    
+end program test_legend_empty_label_fix

--- a/test/test_legend_empty_label_fix.f90
+++ b/test/test_legend_empty_label_fix.f90
@@ -45,12 +45,47 @@ program test_legend_empty_label_fix
     call savefig('test_empty_label_3.png')
     print *, "  ✓ Created test_empty_label_3.png (should show no legend)"
     
+    ! Test 4: Scatter plots with empty labels
+    print *, "Test 4: Scatter plots with mixed labels"
+    call figure()
+    call scatter(x, y1, label='Scatter 1')
+    call scatter(x, y2, label='')  ! Empty label - should not create entry
+    call scatter(x, y3)  ! No label
+    call legend()
+    call savefig('test_empty_label_scatter.png')
+    print *, "  ✓ Created test_empty_label_scatter.png (should show 1 legend entry)"
+    
+    ! Test 5: Multiple scatter plots to test comprehensive fix
+    print *, "Test 5: Multiple scatter plots with various label configurations"
+    call figure()
+    call scatter(x, y1, label='Dataset 1')
+    call scatter(x, y2 * 0.9_wp, label='')  ! Empty label
+    call scatter(x, y2 * 1.1_wp)  ! No label
+    call scatter(x, y3, label='Dataset 2')
+    call legend()
+    call savefig('test_empty_label_multi_scatter.png')
+    print *, "  ✓ Created test_empty_label_multi_scatter.png (should show 2 legend entries)"
+    
+    ! Test 6: Mixed plot and scatter (the most common use case)
+    print *, "Test 6: Mixed plot types with mixed labels"
+    call figure()
+    call plot(x, y1, label='Line Plot')
+    call scatter(x, y2, label='')  ! Empty label - should not create entry
+    call plot(x, y3 * 0.7_wp)  ! No label
+    call scatter(x, y3, label='Scatter Data')
+    call legend()
+    call savefig('test_empty_label_mixed.png')
+    print *, "  ✓ Created test_empty_label_mixed.png (should show 2 legend entries)"
+    
     print *, ""
     print *, "========================================="
     print *, "Issue #328 fix validation complete"
     print *, "Check the generated PNG files to verify:"
     print *, "  - test_empty_label_1.png: 2 legend entries"
-    print *, "  - test_empty_label_2.png: 1 legend entry"
+    print *, "  - test_empty_label_2.png: 1 legend entry" 
     print *, "  - test_empty_label_3.png: no legend box"
+    print *, "  - test_empty_label_scatter.png: 1 legend entry"
+    print *, "  - test_empty_label_multi_scatter.png: 2 legend entries"
+    print *, "  - test_empty_label_mixed.png: 2 legend entries"
     
 end program test_legend_empty_label_fix


### PR DESCRIPTION
## Summary
- Fix issue where plots without labels or with empty string labels create phantom legend entries
- Validates that labels are not only allocated but also non-empty before adding to legend
- Prevents allocation of empty label strings in plot data structures

## Changes
1. **fortplot_figure_core.f90**: Added check for non-empty labels in `figure_legend` before adding entries
2. **fortplot_plotting.f90**: Modified `add_line_plot_data` to not allocate empty labels  
3. **fortplot_figure_base.f90**: Updated `add_plot` to not allocate empty labels
4. **test/test_legend_empty_label_fix.f90**: Added comprehensive test for the fix

## Test Plan
- [x] Run `fpm test test_legend_empty_label_fix` - validates the fix
- [x] Run `fpm run --example basic_plots` - verifies original issue is resolved
- [x] Run `fpm test` - ensure no regressions
- [x] Manually verify generated PNG files show correct number of legend entries

Fixes #328