### PR TITLE
fix: remove duplicate project header from FORD documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,3 +64,26 @@ If GitHub Pages shows broken images:
 ## 🔒 DO NOT TOUCH UNLESS YOU UNDERSTAND THE FULL PIPELINE
 
 The user explicitly requested this visual showcase. Breaking it again will cause significant frustration.
+
+## FORD Configuration Notes
+
+### Main Page Configuration
+
+The FORD documentation configuration is split between two locations:
+
+1. **`fpm.toml`**: Contains the basic FORD settings under `[extra.ford]` section including project name
+2. **`doc.md`**: Contains additional FORD configuration and the main page content
+
+**IMPORTANT**: The `doc.md` file should NOT use Markdown headers for FORD configuration directives. FORD directives like `project:`, `summary:`, `author:` etc. should be plain text at the beginning of the file, NOT formatted as Markdown headers.
+
+❌ **Don't do this in doc.md**:
+```markdown
+# project: fortplotlib
+```
+
+✅ **Do this in doc.md**:
+```
+project: fortplotlib
+```
+
+The project name is already defined in `fpm.toml` as `project = "fortplot"`, so it doesn't need to be duplicated in `doc.md`. Having it in both places can cause redundant headers on the GitHub Pages site.

--- a/doc.md
+++ b/doc.md
@@ -1,4 +1,3 @@
-project: fortplotlib
 summary: Modern Fortran plotting library with multiple backends
 author: Plasma Theory Group, TU Graz
 author_description: Computational plasma physics research group


### PR DESCRIPTION
## Summary
- Remove duplicate 'project: fortplotlib' line from doc.md that was creating a redundant header on GitHub Pages
- Document in CLAUDE.md that FORD configuration directives should not use Markdown header formatting

## Changes
- Removed the first line `project: fortplotlib` from `doc.md` since the project name is already configured in `fpm.toml` under `[extra.ford]` section
- Added documentation in CLAUDE.md explaining the proper FORD configuration format

## Test plan
- [ ] GitHub Actions should pass and generate documentation
- [ ] After merge and deployment, verify that https://lazy-fortran.github.io/fortplot/ no longer shows the duplicate project header
- [ ] Documentation should still build correctly with `make doc`

Fixes #347