### PR TITLE
refactor: extract epsilon constants to shared module

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -15,7 +15,6 @@
 **User-Facing Issues (Medium Priority)**
 
 **Infrastructure & Documentation Issues (Lower Priority)**
-- [ ] #324: Refactor - define epsilon constant for numerical comparisons
 - [ ] #342: Refactor - complete symlog tick generation implementation
 - [ ] #343: Refactor - extract label positioning constants
 - [ ] #344: Refactor - add format threshold constants in axes module
@@ -25,7 +24,7 @@
 - [ ] #360: Refactor - split fortplot_raster.f90 to comply with file size limits
 
 ## DOING (Current Work)
-- [ ] #323: Test - add edge case tests for PDF heatmap color validation
+- [ ] #324: Refactor - define epsilon constant for numerical comparisons
 
 ## BLOCKED (Infrastructure Issues)
 

--- a/src/fortplot.f90
+++ b/src/fortplot.f90
@@ -55,6 +55,7 @@ module fortplot
     
     ! Core types and constants
     use fortplot_figure_core, only: figure_t
+    use fortplot_constants, only: EPSILON_COMPARE, EPSILON_GEOMETRY
     
     ! Animation functionality
     use fortplot_animation, only: animation_t, FuncAnimation
@@ -101,6 +102,9 @@ module fortplot
     
     ! Core types and constants
     public :: figure_t, wp
+    
+    ! Numerical constants
+    public :: EPSILON_COMPARE, EPSILON_GEOMETRY
     
     ! Coordinate system constants for annotations
     public :: COORD_DATA, COORD_FIGURE, COORD_AXIS

--- a/src/fortplot_ascii.f90
+++ b/src/fortplot_ascii.f90
@@ -11,6 +11,7 @@ module fortplot_ascii
     use fortplot_logging, only: log_info, log_error
     use fortplot_latex_parser, only: process_latex_in_text
     ! use fortplot_unicode, only: unicode_to_ascii
+    use fortplot_constants, only: EPSILON_COMPARE
     use, intrinsic :: iso_fortran_env, only: wp => real64
     implicit none
     
@@ -596,7 +597,7 @@ contains
                 if (px >= 2 .and. px <= this%plot_width - 1 .and. py >= 2 .and. py <= this%plot_height - 1) then
                     ! Normalize z value to character index
                     ! z_grid is (ny, nx) so access as z_grid(j, i)
-                    if (abs(z_max - z_min) > 1e-10_wp) then
+                    if (abs(z_max - z_min) > EPSILON_COMPARE) then
                         z_normalized = (z_grid(j, i) - z_min) / (z_max - z_min)
                     else
                         z_normalized = 0.5_wp

--- a/src/fortplot_colormap.f90
+++ b/src/fortplot_colormap.f90
@@ -3,6 +3,7 @@ module fortplot_colormap
     !! Provides color interpolation for different colormaps like matplotlib
     
     use, intrinsic :: iso_fortran_env, only: wp => real64
+    use fortplot_constants, only: EPSILON_COMPARE
     implicit none
     
     private
@@ -47,7 +48,7 @@ contains
         
         real(wp) :: normalized_value
         
-        if (abs(z_max - z_min) < 1e-10_wp) then
+        if (abs(z_max - z_min) < EPSILON_COMPARE) then
             normalized_value = 0.5_wp
         else
             normalized_value = (z_value - z_min) / (z_max - z_min)

--- a/src/fortplot_constants.f90
+++ b/src/fortplot_constants.f90
@@ -1,0 +1,46 @@
+module fortplot_constants
+    !! Numerical and physical constants for the fortplot library
+    !!
+    !! This module provides centralized definitions for commonly used constants
+    !! throughout the fortplot codebase, ensuring consistency and maintainability.
+    !!
+    !! = Numerical Constants =
+    !! - EPSILON_COMPARE: Standard epsilon for floating-point comparisons
+    !! - EPSILON_GEOMETRY: Higher precision epsilon for geometric calculations
+    !!
+    !! = Usage Examples =
+    !!   use fortplot_constants, only: EPSILON_COMPARE
+    !!   if (abs(value1 - value2) < EPSILON_COMPARE) then
+    !!       ! Values are considered equal
+    !!   end if
+    
+    use iso_fortran_env, only: wp => real64
+    implicit none
+    private
+    
+    ! ========================================================================
+    ! NUMERICAL COMPARISON CONSTANTS
+    ! ========================================================================
+    
+    !! Standard epsilon for numerical comparisons in plotting operations
+    !! 
+    !! This constant is used for:
+    !! - Range validation (checking if z_max - z_min is significant)
+    !! - Coordinate comparisons in interpolation
+    !! - General floating-point equality testing
+    !! 
+    !! Value chosen to be appropriate for typical plotting data precision
+    !! while avoiding false positives from numerical noise.
+    real(wp), parameter, public :: EPSILON_COMPARE = 1e-10_wp
+    
+    !! High-precision epsilon for geometric calculations
+    !! 
+    !! This constant is used for:
+    !! - Contour region calculations requiring higher precision
+    !! - Vector length calculations in drawing operations
+    !! - Fine geometric operations where more stringent tolerances are needed
+    !! 
+    !! Smaller value provides better precision for critical geometric operations.
+    real(wp), parameter, public :: EPSILON_GEOMETRY = 1e-12_wp
+
+end module fortplot_constants

--- a/src/fortplot_contour_regions.f90
+++ b/src/fortplot_contour_regions.f90
@@ -16,6 +16,7 @@ module fortplot_contour_regions
     !! Author: fortplot contributors
     
     use iso_fortran_env, only: wp => real64
+    use fortplot_constants, only: EPSILON_GEOMETRY
     implicit none
     
     private
@@ -264,7 +265,7 @@ contains
         case (1)  ! Bottom edge (corners 1-2)
             v1 = corner_values(1)
             v2 = corner_values(2)
-            if (abs(v2 - v1) > 1e-12_wp) then
+            if (abs(v2 - v1) > EPSILON_GEOMETRY) then
                 t = (level - v1) / (v2 - v1)
             else
                 t = 0.5_wp
@@ -275,7 +276,7 @@ contains
         case (2)  ! Right edge (corners 2-3)
             v1 = corner_values(2)
             v2 = corner_values(3)
-            if (abs(v2 - v1) > 1e-12_wp) then
+            if (abs(v2 - v1) > EPSILON_GEOMETRY) then
                 t = (level - v1) / (v2 - v1)
             else
                 t = 0.5_wp
@@ -286,7 +287,7 @@ contains
         case (3)  ! Top edge (corners 3-4)
             v1 = corner_values(3)
             v2 = corner_values(4)
-            if (abs(v2 - v1) > 1e-12_wp) then
+            if (abs(v2 - v1) > EPSILON_GEOMETRY) then
                 t = (level - v1) / (v2 - v1)
             else
                 t = 0.5_wp
@@ -297,7 +298,7 @@ contains
         case (4)  ! Left edge (corners 4-1)
             v1 = corner_values(4)
             v2 = corner_values(1)
-            if (abs(v2 - v1) > 1e-12_wp) then
+            if (abs(v2 - v1) > EPSILON_GEOMETRY) then
                 t = (level - v1) / (v2 - v1)
             else
                 t = 0.5_wp

--- a/src/fortplot_interpolation.f90
+++ b/src/fortplot_interpolation.f90
@@ -7,6 +7,7 @@ module fortplot_interpolation
     !! Author: fortplot contributors
     
     use, intrinsic :: iso_fortran_env, only: wp => real64
+    use fortplot_constants, only: EPSILON_COMPARE
     implicit none
     
     private
@@ -92,7 +93,7 @@ contains
             z_value = z11
         else if (i1 == i2) then
             ! Linear interpolation in Y direction only
-            if (abs(y2 - y1) > 1e-10_wp) then
+            if (abs(y2 - y1) > EPSILON_COMPARE) then
                 dy_norm = (world_y - y1) / (y2 - y1)
                 z_value = z11 + dy_norm * (z12 - z11)
             else
@@ -100,7 +101,7 @@ contains
             end if
         else if (j1 == j2) then
             ! Linear interpolation in X direction only
-            if (abs(x2 - x1) > 1e-10_wp) then
+            if (abs(x2 - x1) > EPSILON_COMPARE) then
                 dx_norm = (world_x - x1) / (x2 - x1)
                 z_value = z11 + dx_norm * (z21 - z11)
             else
@@ -108,7 +109,7 @@ contains
             end if
         else
             ! Full bilinear interpolation
-            if (abs(x2 - x1) > 1e-10_wp .and. abs(y2 - y1) > 1e-10_wp) then
+            if (abs(x2 - x1) > EPSILON_COMPARE .and. abs(y2 - y1) > EPSILON_COMPARE) then
                 dx_norm = (world_x - x1) / (x2 - x1)
                 dy_norm = (world_y - y1) / (y2 - y1)
                 

--- a/src/fortplot_pdf.f90
+++ b/src/fortplot_pdf.f90
@@ -16,6 +16,7 @@ module fortplot_pdf
     use fortplot_legend, only: legend_entry_t
     use fortplot_latex_parser, only: process_latex_in_text
     use fortplot_margins, only: plot_margins_t, plot_area_t, calculate_plot_area
+    use fortplot_constants, only: EPSILON_COMPARE
     use, intrinsic :: iso_fortran_env, only: wp => real64
     implicit none
     
@@ -272,7 +273,7 @@ contains
                 value = z_grid(i, j)
                 
                 ! Handle edge case where z_max == z_min
-                if (abs(z_max - z_min) > 1e-10_wp) then
+                if (abs(z_max - z_min) > EPSILON_COMPARE) then
                     norm_value = (value - z_min) / (z_max - z_min)
                 else
                     norm_value = 0.5_wp

--- a/src/fortplot_raster.f90
+++ b/src/fortplot_raster.f90
@@ -1,6 +1,7 @@
 module fortplot_raster
     use iso_c_binding
     use fortplot_context, only: plot_context, setup_canvas
+    use fortplot_constants, only: EPSILON_COMPARE, EPSILON_GEOMETRY
     use fortplot_text, only: render_text_to_image, calculate_text_width, calculate_text_height
     use fortplot_latex_parser, only: process_latex_in_text
     ! use fortplot_unicode, only: unicode_to_ascii
@@ -646,7 +647,7 @@ contains
         ! Precompute denominator for barycentric coordinates
         denom = (y2 - y3) * (x1 - x3) + (x3 - x2) * (y1 - y3)
         
-        if (abs(denom) < 1e-10_wp) return  ! Degenerate triangle
+        if (abs(denom) < EPSILON_COMPARE) return  ! Degenerate triangle
         
         ! Check each pixel in bounding box
         do y = y_min, y_max
@@ -756,7 +757,7 @@ contains
         
         ! Validate input dimensions - z_grid should be (ny, nx)
         if (size(z_grid, 1) /= ny .or. size(z_grid, 2) /= nx) return
-        if (abs(z_max - z_min) < 1e-10_wp) return
+        if (abs(z_max - z_min) < EPSILON_COMPARE) return
         
         ! Get data bounds
         x_min = minval(x_grid)

--- a/src/fortplot_raster_drawing.f90
+++ b/src/fortplot_raster_drawing.f90
@@ -7,6 +7,7 @@ module fortplot_raster_drawing
     !! Author: fortplot contributors
     
     use, intrinsic :: iso_fortran_env, only: wp => real64
+    use fortplot_constants, only: EPSILON_GEOMETRY, EPSILON_COMPARE
     use fortplot_markers, only: get_marker_size, MARKER_CIRCLE, MARKER_SQUARE, MARKER_DIAMOND, MARKER_CROSS
     implicit none
     
@@ -45,7 +46,7 @@ contains
         dy = y2 - y1
         length_sq = dx * dx + dy * dy
         
-        if (length_sq < 1e-12_wp) then
+        if (length_sq < EPSILON_GEOMETRY) then
             distance = sqrt((px - x1)**2 + (py - y1)**2)
             return
         end if
@@ -376,7 +377,7 @@ contains
                 if ((y_quad(i) <= y_real .and. y_real < y_quad(j)) .or. &
                     (y_quad(j) <= y_real .and. y_real < y_quad(i))) then
                     
-                    if (abs(y_quad(j) - y_quad(i)) > 1e-10_wp) then
+                    if (abs(y_quad(j) - y_quad(i)) > EPSILON_COMPARE) then
                         num_intersect = num_intersect + 1
                         x_intersect(num_intersect) = x_quad(i) + &
                             (y_real - y_quad(i)) * (x_quad(j) - x_quad(i)) / (y_quad(j) - y_quad(i))

--- a/src/fortplot_streamplot_core.f90
+++ b/src/fortplot_streamplot_core.f90
@@ -5,6 +5,7 @@ module fortplot_streamplot_core
     !! following SOLID principles and size constraints.
     
     use, intrinsic :: iso_fortran_env, only: wp => real64
+    use fortplot_constants, only: EPSILON_COMPARE
     use fortplot_figure_base, only: figure_t
     use fortplot_plot_data, only: arrow_data_t
     use fortplot_streamplot_matplotlib
@@ -183,7 +184,7 @@ contains
                                               u_field, v_field, arrow_x, arrow_y, arrow_dx, arrow_dy, speed_mag)
                 
                 ! Skip if velocity is too small
-                if (speed_mag < 1e-10_wp) cycle
+                if (speed_mag < EPSILON_COMPARE) cycle
                 
                 ! Store arrow data
                 call store_arrow_data(fig, arrow_count, arrow_x, arrow_y, arrow_dx, arrow_dy, &

--- a/test/test_simple_validation.f90
+++ b/test/test_simple_validation.f90
@@ -4,6 +4,7 @@ program test_simple_validation
     
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_figure
+    use fortplot_constants, only: EPSILON_COMPARE
     implicit none
     
     logical :: all_tests_passed = .true.
@@ -86,7 +87,7 @@ contains
             linear_result = apply_scale_transform(5.0_wp, 'linear', 1.0_wp)
             log_result = apply_scale_transform(10.0_wp, 'log', 1.0_wp)
             
-            if (abs(linear_result - 5.0_wp) < 1e-10_wp .and. abs(log_result - 1.0_wp) < 1e-10_wp) then
+            if (abs(linear_result - 5.0_wp) < EPSILON_COMPARE .and. abs(log_result - 1.0_wp) < EPSILON_COMPARE) then
                 write(*, '(A)') '  ✅ Scale transformations working'
             else
                 write(*, '(A)') '  ❌ Scale transformations failed'


### PR DESCRIPTION
## Summary

- Create centralized `fortplot_constants` module with `EPSILON_COMPARE` (1e-10_wp) and `EPSILON_GEOMETRY` (1e-12_wp)
- Replace hardcoded epsilon values across 9 source files with consistent constants
- Export constants through main fortplot module for external use

## Files Modified

- **Core Module**: `fortplot_constants.f90` - new constants module with comprehensive documentation
- **Range Validation**: `fortplot_pdf.f90`, `fortplot_colormap.f90`, `fortplot_raster.f90`, `fortplot_ascii.f90` - z-range checks
- **Geometric Operations**: `fortplot_contour_regions.f90`, `fortplot_raster_drawing.f90`, `fortplot_interpolation.f90` - coordinate and geometry calculations  
- **Physics Calculations**: `fortplot_streamplot_core.f90` - velocity magnitude thresholds
- **Public Interface**: `fortplot.f90` - export constants for external use
- **Test Update**: `test_simple_validation.f90` - use constants instead of hardcoded values

## Benefits

1. **Consistency**: Single source of truth for epsilon values across entire codebase
2. **Maintainability**: Easy to adjust precision requirements in one location
3. **Documentation**: Clear intent and usage examples for numerical comparisons
4. **Type Safety**: Prevents inconsistent epsilon values between related operations

## Testing

- Build verification: All source files compile successfully with new constants
- Functional test: Constants accessible through public interface and work as expected
- No behavior changes: All comparisons use same values as before, just through constants

Fixes #324

🤖 Generated with [Claude Code](https://claude.ai/code)