### PR TITLE
refactor: extract label positioning constants to shared module

### DIFF
--- a/src/fortplot.f90
+++ b/src/fortplot.f90
@@ -55,7 +55,9 @@ module fortplot
     
     ! Core types and constants
     use fortplot_figure_core, only: figure_t
-    use fortplot_constants, only: EPSILON_COMPARE, EPSILON_GEOMETRY
+    use fortplot_constants, only: EPSILON_COMPARE, EPSILON_GEOMETRY, &
+                                  XLABEL_VERTICAL_OFFSET, YLABEL_HORIZONTAL_OFFSET, &
+                                  TICK_MARK_LENGTH
     
     ! Animation functionality
     use fortplot_animation, only: animation_t, FuncAnimation
@@ -104,7 +106,8 @@ module fortplot
     public :: figure_t, wp
     
     ! Numerical constants
-    public :: EPSILON_COMPARE, EPSILON_GEOMETRY
+    public :: EPSILON_COMPARE, EPSILON_GEOMETRY, &
+              XLABEL_VERTICAL_OFFSET, YLABEL_HORIZONTAL_OFFSET, TICK_MARK_LENGTH
     
     ! Coordinate system constants for annotations
     public :: COORD_DATA, COORD_FIGURE, COORD_AXIS

--- a/src/fortplot_constants.f90
+++ b/src/fortplot_constants.f90
@@ -43,4 +43,35 @@ module fortplot_constants
     !! Smaller value provides better precision for critical geometric operations.
     real(wp), parameter, public :: EPSILON_GEOMETRY = 1e-12_wp
 
+    ! ========================================================================
+    ! LABEL POSITIONING CONSTANTS
+    ! ========================================================================
+
+    !! X-axis label vertical offset below plot area (pixels)
+    !!
+    !! This constant defines the vertical distance between the bottom of the
+    !! plot area and the baseline of the x-axis label text.
+    !! 
+    !! Used by raster backend for xlabel positioning to ensure consistent
+    !! spacing below tick labels while avoiding overlap.
+    integer, parameter, public :: XLABEL_VERTICAL_OFFSET = 30
+
+    !! Y-axis label horizontal offset from left edge (pixels)
+    !!
+    !! This constant defines the horizontal distance from the left edge of
+    !! the figure to the left edge of the y-axis label text.
+    !!
+    !! Used by raster backend for ylabel positioning to ensure consistent
+    !! left margin spacing and readability.
+    integer, parameter, public :: YLABEL_HORIZONTAL_OFFSET = 10
+
+    !! Tick mark length extending from axis line (pixels)
+    !!
+    !! This constant defines the length of tick marks extending from the
+    !! axis lines into the plot area or margin.
+    !!
+    !! Used by raster backend for drawing consistent tick marks across
+    !! all axes while maintaining visual hierarchy.
+    integer, parameter, public :: TICK_MARK_LENGTH = 5
+
 end module fortplot_constants

--- a/src/fortplot_raster.f90
+++ b/src/fortplot_raster.f90
@@ -1,7 +1,9 @@
 module fortplot_raster
     use iso_c_binding
     use fortplot_context, only: plot_context, setup_canvas
-    use fortplot_constants, only: EPSILON_COMPARE, EPSILON_GEOMETRY
+    use fortplot_constants, only: EPSILON_COMPARE, EPSILON_GEOMETRY, &
+                                  XLABEL_VERTICAL_OFFSET, YLABEL_HORIZONTAL_OFFSET, &
+                                  TICK_MARK_LENGTH
     use fortplot_text, only: render_text_to_image, calculate_text_width, calculate_text_height
     use fortplot_latex_parser, only: process_latex_in_text
     ! use fortplot_unicode, only: unicode_to_ascii
@@ -983,7 +985,7 @@ contains
         call this%line(x_min, y_min, x_min, y_max)
         
         ! Generate and draw tick marks and labels
-        tick_length = 5  ! Tick length in pixels
+        tick_length = TICK_MARK_LENGTH  ! Tick length in pixels
         
         ! X-axis ticks
         call compute_scale_ticks(xscale, x_min, x_max, symlog_threshold, x_tick_positions, num_x_ticks)
@@ -1055,7 +1057,7 @@ contains
                 text_width = calculate_text_width(trim(escaped_text))
                 ! Center horizontally in plot area, position below tick labels
                 px = this%plot_area%left + this%plot_area%width / 2 - text_width / 2
-                py = this%plot_area%bottom + this%plot_area%height + 30  ! 30 pixels below plot area
+                py = this%plot_area%bottom + this%plot_area%height + XLABEL_VERTICAL_OFFSET  ! Pixels below plot area
                 call render_text_to_image(this%raster%image_data, this%width, this%height, &
                                         px, py, trim(escaped_text), text_r, text_g, text_b)
             end if
@@ -1069,7 +1071,7 @@ contains
                 text_width = calculate_text_width(trim(escaped_text))
                 text_height = calculate_text_height(trim(escaped_text))
                 ! Position to the left of plot area, centered vertically
-                px = 10  ! 10 pixels from left edge
+                px = YLABEL_HORIZONTAL_OFFSET  ! Pixels from left edge
                 py = this%plot_area%bottom + this%plot_area%height / 2 - text_height / 2
                 call render_text_to_image(this%raster%image_data, this%width, this%height, &
                                         px, py, trim(escaped_text), text_r, text_g, text_b)


### PR DESCRIPTION
## Summary

- Extract hardcoded pixel values for label positioning into named constants in `fortplot_constants.f90`
- Replace magic numbers (30, 10, 5 pixels) with descriptive constant names in `fortplot_raster.f90`
- Export new positioning constants through main `fortplot.f90` module for public API access

## Changes Made

### New Constants Added to `fortplot_constants.f90`:
- `XLABEL_VERTICAL_OFFSET = 30` - X-axis label vertical offset below plot area  
- `YLABEL_HORIZONTAL_OFFSET = 10` - Y-axis label horizontal offset from left edge
- `TICK_MARK_LENGTH = 5` - Tick mark length extending from axis lines

### Files Modified:
- `/src/fortplot_constants.f90` - Added label positioning constants with documentation
- `/src/fortplot_raster.f90` - Replaced hardcoded values with named constants
- `/src/fortplot.f90` - Export new constants for public API access

## Testing

- Build compiles successfully with no errors
- Targeted tests (`test_label_positioning`, `test_raster_ylabel`) pass
- Basic plots example runs and generates expected output
- Label positioning remains functionally identical

## Benefits

- **Maintainability**: Centralized positioning configuration
- **Readability**: Self-documenting constant names replace magic numbers  
- **Consistency**: Single source of truth for positioning values
- **Flexibility**: Easy to adjust positioning across entire codebase

This refactoring addresses the technical debt identified in issue #343 during code review of PR #341.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>