### PR TITLE
docs: fix colormap documentation to match crest default

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -15,12 +15,12 @@
 **User-Facing Issues (Medium Priority)**
 
 **Infrastructure & Documentation Issues (Lower Priority)**
-- [ ] #357: Docs - standardize colormap documentation across examples
 - [ ] #358: Refactor - consolidate ASCII output formatting in example docs
 - [ ] #360: Refactor - split fortplot_raster.f90 to comply with file size limits
 - [ ] #355: Fix - First plot is empty
 
 ## DOING (Current Work)
+- [ ] #357: Docs - standardize colormap documentation across examples
 
 ## BLOCKED (Infrastructure Issues)
 

--- a/doc/examples/colored_contours.md
+++ b/doc/examples/colored_contours.md
@@ -23,13 +23,13 @@ make example ARGS="colored_contours"
 ## Features Demonstrated
 
 - **Filled contours**: Continuous color gradients
-- **Multiple colormaps**: viridis, jet, coolwarm, inferno, plasma
+- **Multiple colormaps**: crest, jet, coolwarm, inferno, plasma
 - **Custom levels**: Control contour density
 - **Various functions**: Gaussian, ripple, saddle point patterns
 
 ## Available Colormaps
 
-- `viridis` - Default, perceptually uniform
+- `crest` - Default, perceptually uniform colorblind-safe
 - `jet` - Classic rainbow colormap
 - `coolwarm` - Blue to red diverging
 - `inferno` - Black to yellow sequential


### PR DESCRIPTION
## Summary
- Fixed colormap documentation inconsistency in colored_contours.md
- Changed 'viridis' references to 'crest' to match actual code implementation
- Lines 26 and 32 updated to reflect the correct default colormap

## Changes
- Line 26: Updated colormap list from "viridis, jet, coolwarm, inferno, plasma" to "crest, jet, coolwarm, inferno, plasma"
- Line 32: Changed "viridis - Default, perceptually uniform" to "crest - Default, perceptually uniform colorblind-safe"

## Verification
- Confirmed code in `colored_contours.f90` line 37 uses default crest colormap
- Documentation now accurately reflects implementation
- No functional changes, documentation fix only

fixes #357