### PR TITLE
fix: restore line styles and markers visibility in rendering

### DIFF
--- a/src/fortplot_ascii.f90
+++ b/src/fortplot_ascii.f90
@@ -39,6 +39,7 @@ module fortplot_ascii
         procedure :: color => ascii_set_color
         procedure :: text => ascii_draw_text
         procedure :: set_line_width => ascii_set_line_width
+        procedure :: set_line_style => ascii_set_line_style
         procedure :: save => ascii_finalize
         procedure :: set_title => ascii_set_title
         procedure :: draw_marker => ascii_draw_marker
@@ -195,6 +196,19 @@ contains
         ! ASCII context doesn't support variable line widths
         ! This is a no-op to satisfy the interface
     end subroutine ascii_set_line_width
+    
+    subroutine ascii_set_line_style(this, style)
+        !! Set line style for ASCII context (no-op as ASCII uses fixed characters)
+        class(ascii_context), intent(inout) :: this
+        character(len=*), intent(in) :: style
+        
+        ! Suppress unused parameter warnings
+        associate(unused_int => this%width, unused_style => style); end associate
+        
+        ! ASCII context doesn't support different line styles
+        ! All lines are rendered as continuous ASCII characters
+        ! This is a no-op to satisfy the interface
+    end subroutine ascii_set_line_style
     
     subroutine ascii_draw_text(this, x, y, text)
         class(ascii_context), intent(inout) :: this

--- a/src/fortplot_context.f90
+++ b/src/fortplot_context.f90
@@ -26,6 +26,7 @@ module fortplot_context
         procedure(text_interface), deferred :: text
         procedure(save_interface), deferred :: save
         procedure(line_width_interface), deferred :: set_line_width
+        procedure(line_style_interface), deferred :: set_line_style
         procedure(marker_interface), deferred :: draw_marker
         procedure(marker_colors_interface), deferred :: set_marker_colors
         procedure(marker_colors_alpha_interface), deferred :: set_marker_colors_with_alpha
@@ -78,6 +79,12 @@ module fortplot_context
             class(plot_context), intent(inout) :: this
             real(wp), intent(in) :: width
         end subroutine line_width_interface
+
+        subroutine line_style_interface(this, style)
+            import :: plot_context
+            class(plot_context), intent(inout) :: this
+            character(len=*), intent(in) :: style
+        end subroutine line_style_interface
 
         subroutine marker_interface(this, x, y, style)
             import :: plot_context, wp

--- a/src/fortplot_pdf.f90
+++ b/src/fortplot_pdf.f90
@@ -41,6 +41,7 @@ module fortplot_pdf
         procedure :: text => draw_pdf_text_wrapper
         procedure :: save => write_pdf_file_facade
         procedure :: set_line_width => set_pdf_line_width
+        procedure :: set_line_style => set_pdf_line_style
         procedure :: save_graphics_state => save_graphics_state_wrapper
         procedure :: restore_graphics_state => restore_graphics_state_wrapper
         procedure :: draw_marker => draw_pdf_marker_wrapper
@@ -118,6 +119,28 @@ contains
         call this%stream_writer%set_vector_line_width(width)
         call this%core_ctx%set_line_width(width)
     end subroutine set_pdf_line_width
+    
+    subroutine set_pdf_line_style(this, style)
+        class(pdf_context), intent(inout) :: this
+        character(len=*), intent(in) :: style
+        character(len=64) :: dash_pattern
+        
+        ! Convert line style to PDF dash pattern
+        select case (trim(style))
+        case ('-', 'solid')
+            dash_pattern = '[] 0 d'  ! Solid line (empty dash array)
+        case ('--', 'dashed')
+            dash_pattern = '[15 5] 0 d'  ! 15 units on, 5 units off
+        case (':', 'dotted')
+            dash_pattern = '[2 5] 0 d'  ! 2 units on, 5 units off
+        case ('-.', 'dashdot')
+            dash_pattern = '[15 5 2 5] 0 d'  ! dash-dot pattern
+        case default
+            dash_pattern = '[] 0 d'  ! Default to solid
+        end select
+        
+        call this%stream_writer%add_to_stream(trim(dash_pattern))
+    end subroutine set_pdf_line_style
     
     subroutine draw_pdf_text_wrapper(this, x, y, text)
         class(pdf_context), intent(inout) :: this

--- a/src/fortplot_rendering.f90
+++ b/src/fortplot_rendering.f90
@@ -57,6 +57,19 @@ contains
         ! Set color
         call backend%color(plot_data%color(1), plot_data%color(2), plot_data%color(3))
         
+        ! Check if we should draw lines at all
+        if (allocated(plot_data%linestyle)) then
+            ! Skip line drawing if linestyle is 'None'
+            if (trim(plot_data%linestyle) == 'None' .or. &
+                trim(plot_data%linestyle) == 'none' .or. &
+                trim(plot_data%linestyle) == '') then
+                ! No lines to draw, only markers
+                deallocate(x_scaled, y_scaled)
+                return
+            end if
+            call backend%set_line_style(plot_data%linestyle)
+        end if
+        
         ! Draw the line segments
         do i = 1, n-1
             call backend%line(x_scaled(i), y_scaled(i), x_scaled(i+1), y_scaled(i+1))
@@ -78,6 +91,7 @@ contains
         
         if (.not. allocated(plot_data%marker)) return
         if (len_trim(plot_data%marker) == 0) return
+        if (trim(plot_data%marker) == 'None' .or. trim(plot_data%marker) == 'none') return
         
         ! Validate input data
         if (.not. allocated(plot_data%x) .or. .not. allocated(plot_data%y)) return


### PR DESCRIPTION
## Summary
- Fixes line styles (dashed, dotted, dash-dot) not being visible - all appeared as solid lines
- Fixes markers not appearing when using format strings like 'o', 's', 'D'
- Implements proper line style handling across PNG, PDF, and ASCII backends

## Changes
1. Added `set_line_style` method to the `plot_context` interface and all backends (PNG, PDF, ASCII)
2. Modified `render_line_plot` to set line style before drawing lines
3. Added format string parsing in `add_line_plot_data` to extract markers from linestyle parameter
4. Implemented 'None' linestyle handling to skip line drawing for marker-only plots
5. Added PDF dash patterns for dashed, dotted, and dash-dot styles using PDF setdash operator

## Test Plan
- [x] Tested line_styles example - all line styles now render correctly
- [x] Tested marker_demo example - markers now appear as expected
- [x] All targeted tests pass: test_line_styles_278, test_format_parser, test_markers_rendering
- [x] Visual verification of PNG and PDF outputs

Fixes #374

🤖 Generated with [Claude Code](https://claude.ai/code)