### PR TITLE
fix: pass colormap parameter through matplotlib API wrapper functions

### DIFF
--- a/src/fortplot_matplotlib.f90
+++ b/src/fortplot_matplotlib.f90
@@ -92,7 +92,8 @@ contains
         logical, intent(in), optional :: show_colorbar
         
         call ensure_global_figure_initialized()
-        call fig%add_contour_filled(x, y, z, levels=levels, label=label)
+        call fig%add_contour_filled(x, y, z, levels=levels, colormap=colormap, &
+                                   show_colorbar=show_colorbar, label=label)
     end subroutine contour_filled
 
     subroutine pcolormesh(x, y, z, shading, colormap, show_colorbar, label)
@@ -103,7 +104,7 @@ contains
         logical, intent(in), optional :: show_colorbar
         
         call ensure_global_figure_initialized()
-        call fig%add_pcolormesh(x, y, z)
+        call fig%add_pcolormesh(x, y, z, colormap=colormap)
     end subroutine pcolormesh
 
     subroutine streamplot(x, y, u, v, density, linewidth_scale, arrow_scale, colormap, label)
@@ -347,7 +348,8 @@ contains
         logical, intent(in), optional :: show_colorbar
         
         call ensure_global_figure_initialized()
-        call fig%add_contour_filled(x, y, z, levels=levels, label=label)
+        call fig%add_contour_filled(x, y, z, levels=levels, colormap=colormap, &
+                                   show_colorbar=show_colorbar, label=label)
     end subroutine add_contour_filled
 
     subroutine add_pcolormesh(x, y, z, shading, colormap, show_colorbar, label)
@@ -358,7 +360,7 @@ contains
         logical, intent(in), optional :: show_colorbar
         
         call ensure_global_figure_initialized()
-        call fig%add_pcolormesh(x, y, z)
+        call fig%add_pcolormesh(x, y, z, colormap=colormap)
     end subroutine add_pcolormesh
 
     subroutine add_errorbar(x, y, xerr, yerr, fmt, label, capsize, linestyle, marker, color)


### PR DESCRIPTION
## Summary
Fixes #372 - all colormaps look the same on colored_contours.html

The colormap and show_colorbar parameters were not being passed to the underlying figure methods in the matplotlib API wrapper functions. This caused all colormaps to render with the default colors regardless of the specified colormap parameter.

## Changes
- Fixed `contour_filled()` to pass colormap and show_colorbar parameters
- Fixed `add_contour_filled()` to pass colormap and show_colorbar parameters  
- Fixed `pcolormesh()` to pass colormap parameter
- Fixed `add_pcolormesh()` to pass colormap parameter

## Test Results
Verified fix with:
- Ran `colored_contours` example - now produces visually distinct colormaps
- Created test to verify different colormaps produce different RGB values
- Tested plasma, jet, inferno, coolwarm, and crest colormaps

All colormaps now produce correct, visually distinct color schemes as expected.