### PR TITLE
fix: resolve pcolormesh segmentation fault with array bounds checking

### DIFF
--- a/test/test_pcolormesh_430_regression.f90
+++ b/test/test_pcolormesh_430_regression.f90
@@ -1,0 +1,214 @@
+program test_pcolormesh_430_regression
+    !! Regression test for issue #430 - segmentation fault fix
+    !! Verifies that all previously crashing scenarios now handle gracefully
+    
+    use fortplot_pcolormesh, only: pcolormesh_t
+    use fortplot_errors, only: fortplot_error_t
+    use iso_fortran_env, only: wp => real64, error_unit
+    implicit none
+    
+    logical :: all_tests_passed
+    integer :: total_tests, passed_tests
+    
+    all_tests_passed = .true.
+    total_tests = 0
+    passed_tests = 0
+    
+    print *, "=== REGRESSION TEST: Issue #430 Segmentation Fault ==="
+    print *, ""
+    print *, "Testing scenarios that previously caused segmentation fault"
+    print *, "All tests should now handle gracefully with proper error messages"
+    print *, ""
+    
+    ! Test original bug scenario
+    call test_original_bug_scenario()
+    
+    ! Test unallocated array access
+    call test_unallocated_array_scenarios()
+    
+    ! Test boundary conditions  
+    call test_boundary_conditions()
+    
+    ! Test successful operations still work
+    call test_successful_operations()
+    
+    print *, ""
+    print *, "=== REGRESSION TEST SUMMARY ==="
+    write(*, '(A, I0, A, I0, A)') "Passed: ", passed_tests, "/", total_tests, " tests"
+    
+    if (all_tests_passed) then
+        print *, ""
+        print *, "SUCCESS: Issue #430 segmentation fault has been COMPLETELY FIXED!"
+        print *, "All previously crashing scenarios now handle gracefully."
+        stop 0
+    else
+        print *, ""
+        print *, "FAILURE: Some tests failed - segmentation fault not completely fixed!"
+        stop 1
+    end if
+    
+contains
+
+    subroutine run_test(test_name, test_result, description)
+        character(len=*), intent(in) :: test_name, description
+        logical, intent(in) :: test_result
+        
+        total_tests = total_tests + 1
+        
+        if (test_result) then
+            passed_tests = passed_tests + 1
+            print *, "✓ PASS: " // trim(test_name)
+        else
+            all_tests_passed = .false.
+            print *, "✗ FAIL: " // trim(test_name) // " - " // trim(description)
+        end if
+    end subroutine run_test
+    
+    subroutine test_original_bug_scenario()
+        !! Test the exact scenario from issue #430 bug report
+        type(pcolormesh_t) :: mesh
+        real(wp) :: x_coords(6), y_coords(5), c_data(5,4)
+        type(fortplot_error_t) :: error
+        logical :: test_result
+        integer :: i, j
+        
+        print *, "1. Testing original bug scenario: x(6), y(5), c(5,4)"
+        
+        ! Initialize the problematic data from bug report
+        do i = 1, 6
+            x_coords(i) = real(i-1, wp)
+        end do
+        
+        do i = 1, 5  
+            y_coords(i) = real(i-1, wp)
+        end do
+        
+        do i = 1, 5
+            do j = 1, 4
+                c_data(i, j) = real(i * j, wp)
+            end do
+        end do
+        
+        ! This should fail gracefully, NOT crash
+        call mesh%initialize_regular_grid(x_coords, y_coords, c_data, error=error)
+        
+        test_result = error%is_error()  ! Should have caught the dimension mismatch
+        call run_test("Original segfault case", test_result, &
+            "Should catch dimension mismatch x(6) with c(5,4)")
+            
+        ! Verify specific error message
+        test_result = index(error%message, "x_coords size must be nx+1") > 0
+        call run_test("Correct error message", test_result, &
+            "Error message should mention x_coords size requirement")
+    end subroutine test_original_bug_scenario
+    
+    subroutine test_unallocated_array_scenarios()
+        !! Test scenarios with unallocated arrays
+        type(pcolormesh_t) :: mesh
+        real(wp) :: x_quad(4), y_quad(4)
+        logical :: test_result
+        
+        print *, ""
+        print *, "2. Testing unallocated array access scenarios"
+        
+        ! Test get_data_range on empty mesh
+        call mesh%get_data_range()
+        test_result = (mesh%vmin == 0.0_wp .and. mesh%vmax == 1.0_wp)
+        call run_test("Unallocated get_data_range", test_result, &
+            "Should set safe defaults for unallocated c_values")
+        
+        ! Test get_quad_vertices on empty mesh
+        call mesh%get_quad_vertices(1, 1, x_quad, y_quad)
+        test_result = all(x_quad == 0.0_wp) .and. all(y_quad == 0.0_wp)
+        call run_test("Unallocated get_quad_vertices", test_result, &
+            "Should return zeros for unallocated vertex arrays")
+        
+        ! Test with zero-size arrays
+        allocate(mesh%c_values(0, 0))
+        call mesh%get_data_range()
+        test_result = (mesh%vmin == 0.0_wp .and. mesh%vmax == 1.0_wp)
+        call run_test("Zero-size array handling", test_result, &
+            "Should handle zero-size arrays safely")
+    end subroutine test_unallocated_array_scenarios
+    
+    subroutine test_boundary_conditions()
+        !! Test edge cases and boundary conditions
+        type(pcolormesh_t) :: mesh
+        real(wp) :: x_quad(4), y_quad(4)
+        logical :: test_result
+        
+        print *, ""
+        print *, "3. Testing boundary conditions and edge cases"
+        
+        ! Setup small mesh for boundary testing
+        mesh%nx = 1
+        mesh%ny = 1
+        allocate(mesh%x_vertices(2, 2))
+        allocate(mesh%y_vertices(2, 2))
+        allocate(mesh%c_values(1, 1))
+        
+        mesh%x_vertices = reshape([0.0_wp, 1.0_wp, 0.0_wp, 1.0_wp], [2, 2])
+        mesh%y_vertices = reshape([0.0_wp, 0.0_wp, 1.0_wp, 1.0_wp], [2, 2])
+        mesh%c_values(1, 1) = 5.0_wp
+        
+        ! Test valid access
+        call mesh%get_quad_vertices(1, 1, x_quad, y_quad)
+        test_result = (x_quad(1) == 0.0_wp)  ! Should work
+        call run_test("Valid boundary access", test_result, &
+            "Should allow valid quad access in small mesh")
+        
+        ! Test out-of-bounds access
+        call mesh%get_quad_vertices(2, 2, x_quad, y_quad)  ! Invalid
+        test_result = all(x_quad == 0.0_wp) .and. all(y_quad == 0.0_wp)
+        call run_test("Out-of-bounds access", test_result, &
+            "Should return zeros for invalid indices")
+        
+        ! Test negative indices
+        call mesh%get_quad_vertices(-1, -1, x_quad, y_quad)
+        test_result = all(x_quad == 0.0_wp) .and. all(y_quad == 0.0_wp)
+        call run_test("Negative index handling", test_result, &
+            "Should handle negative indices safely")
+    end subroutine test_boundary_conditions
+    
+    subroutine test_successful_operations()
+        !! Verify that normal operations still work correctly
+        type(pcolormesh_t) :: mesh
+        real(wp) :: x_coords(3), y_coords(3), c_data(2,2)
+        real(wp) :: x_quad(4), y_quad(4)
+        type(fortplot_error_t) :: error
+        logical :: test_result
+        
+        print *, ""
+        print *, "4. Testing successful operations after safety fixes"
+        
+        ! Initialize valid data
+        x_coords = [0.0_wp, 1.0_wp, 2.0_wp]
+        y_coords = [0.0_wp, 1.0_wp, 2.0_wp]
+        c_data = reshape([1.0_wp, 2.0_wp, 3.0_wp, 4.0_wp], [2, 2])
+        
+        ! This should succeed
+        call mesh%initialize_regular_grid(x_coords, y_coords, c_data, error=error)
+        test_result = .not. error%is_error()
+        call run_test("Valid initialization", test_result, &
+            "Should succeed with correct dimensions")
+        
+        ! Test data range computation
+        test_result = (mesh%vmin == 1.0_wp .and. mesh%vmax == 4.0_wp)
+        call run_test("Data range computation", test_result, &
+            "Should compute correct data range")
+        
+        ! Test quad vertices retrieval
+        call mesh%get_quad_vertices(1, 1, x_quad, y_quad)
+        test_result = (abs(x_quad(1) - 0.0_wp) < 1e-10_wp)
+        call run_test("Quad vertices retrieval", test_result, &
+            "Should retrieve correct quad vertices")
+        
+        ! Test all four corners of first quad
+        test_result = (abs(x_quad(2) - 1.0_wp) < 1e-10_wp .and. &  ! bottom-right
+                      abs(x_quad(3) - 1.0_wp) < 1e-10_wp .and. &  ! top-right  
+                      abs(x_quad(4) - 0.0_wp) < 1e-10_wp)         ! top-left
+        call run_test("Complete quad geometry", test_result, &
+            "Should have correct geometry for all quad vertices")
+    end subroutine test_successful_operations
+
+end program test_pcolormesh_430_regression

--- a/test/test_pcolormesh_bounds_safety.f90
+++ b/test/test_pcolormesh_bounds_safety.f90
@@ -1,0 +1,167 @@
+program test_pcolormesh_bounds_safety
+    !! Test comprehensive bounds checking in pcolormesh functions
+    !! Verifies memory safety fixes for issue #430
+    
+    use fortplot_pcolormesh, only: pcolormesh_t
+    use fortplot_errors, only: fortplot_error_t
+    use iso_fortran_env, only: wp => real64
+    implicit none
+    
+    logical :: test_passed
+    character(len=512) :: error_msg
+    
+    test_passed = .true.
+    error_msg = ""
+    
+    print *, "Testing pcolormesh bounds safety (issue #430 fix)..."
+    print *, ""
+    
+    ! Test get_data_range safety
+    call test_get_data_range_safety()
+    
+    ! Test get_quad_vertices safety  
+    call test_get_quad_vertices_safety()
+    
+    ! Test successful case still works
+    call test_normal_operation()
+    
+    if (test_passed) then
+        print *, ""
+        print *, "PASS: All bounds safety tests passed"
+        print *, "SUCCESS: Memory safety fixes for issue #430 verified!"
+        stop 0
+    else
+        print *, "FAIL: ", trim(error_msg)
+        stop 1
+    end if
+    
+contains
+
+    subroutine test_get_data_range_safety()
+        !! Test get_data_range with unallocated arrays
+        type(pcolormesh_t) :: mesh
+        
+        print *, "Testing get_data_range safety with unallocated arrays..."
+        
+        ! Call on completely uninitialized mesh
+        call mesh%get_data_range()
+        
+        ! Should have set safe default values
+        if (mesh%vmin /= 0.0_wp .or. mesh%vmax /= 1.0_wp) then
+            test_passed = .false.
+            error_msg = "get_data_range did not set safe defaults for unallocated arrays"
+            return
+        end if
+        
+        print *, "  GOOD: get_data_range handled unallocated arrays safely"
+        
+        ! Test with zero-size allocated array
+        allocate(mesh%c_values(0, 0))
+        call mesh%get_data_range()
+        
+        if (mesh%vmin /= 0.0_wp .or. mesh%vmax /= 1.0_wp) then
+            test_passed = .false.
+            error_msg = "get_data_range did not handle zero-size array safely"
+            return
+        end if
+        
+        print *, "  GOOD: get_data_range handled zero-size arrays safely"
+    end subroutine test_get_data_range_safety
+    
+    subroutine test_get_quad_vertices_safety()
+        !! Test get_quad_vertices with various unsafe conditions
+        type(pcolormesh_t) :: mesh
+        real(wp) :: x_quad(4), y_quad(4)
+        integer :: i
+        
+        print *, ""
+        print *, "Testing get_quad_vertices safety..."
+        
+        ! Test with unallocated vertex arrays
+        call mesh%get_quad_vertices(1, 1, x_quad, y_quad)
+        
+        ! Should return all zeros safely
+        do i = 1, 4
+            if (x_quad(i) /= 0.0_wp .or. y_quad(i) /= 0.0_wp) then
+                test_passed = .false.
+                error_msg = "get_quad_vertices did not return zeros for unallocated arrays"
+                return
+            end if
+        end do
+        
+        print *, "  GOOD: get_quad_vertices handled unallocated arrays safely"
+        
+        ! Test with allocated but small arrays and out-of-bounds access
+        mesh%nx = 2
+        mesh%ny = 2
+        allocate(mesh%x_vertices(2, 2))
+        allocate(mesh%y_vertices(2, 2))
+        
+        ! Initialize small arrays
+        mesh%x_vertices = reshape([0.0_wp, 1.0_wp, 0.0_wp, 1.0_wp], [2, 2])
+        mesh%y_vertices = reshape([0.0_wp, 0.0_wp, 1.0_wp, 1.0_wp], [2, 2])
+        
+        ! Try to access beyond bounds
+        call mesh%get_quad_vertices(3, 3, x_quad, y_quad)  ! Invalid indices
+        
+        ! Should return zeros for out-of-bounds access
+        do i = 1, 4
+            if (x_quad(i) /= 0.0_wp .or. y_quad(i) /= 0.0_wp) then
+                test_passed = .false.
+                error_msg = "get_quad_vertices did not handle out-of-bounds access safely"
+                return
+            end if
+        end do
+        
+        print *, "  GOOD: get_quad_vertices handled out-of-bounds access safely"
+        
+        ! Test boundary case (accessing last valid quad)
+        call mesh%get_quad_vertices(1, 1, x_quad, y_quad)  ! Should work with 2x2 arrays
+        
+        print *, "  GOOD: get_quad_vertices handled boundary case correctly"
+    end subroutine test_get_quad_vertices_safety
+    
+    subroutine test_normal_operation()
+        !! Verify that normal operation still works correctly
+        type(pcolormesh_t) :: mesh
+        real(wp) :: x_coords(3), y_coords(3), c_data(2,2)
+        real(wp) :: x_quad(4), y_quad(4)
+        type(fortplot_error_t) :: error
+        
+        print *, ""
+        print *, "Testing that normal operation still works..."
+        
+        ! Initialize valid data
+        x_coords = [0.0_wp, 1.0_wp, 2.0_wp]
+        y_coords = [0.0_wp, 1.0_wp, 2.0_wp] 
+        c_data = reshape([1.0_wp, 2.0_wp, 3.0_wp, 4.0_wp], [2, 2])
+        
+        call mesh%initialize_regular_grid(x_coords, y_coords, c_data, error=error)
+        
+        if (error%is_error()) then
+            test_passed = .false.
+            error_msg = "Normal initialization failed: " // trim(error%message)
+            return
+        end if
+        
+        ! Test data range computation
+        if (mesh%vmin /= 1.0_wp .or. mesh%vmax /= 4.0_wp) then
+            test_passed = .false.
+            error_msg = "Data range computation incorrect after safety fixes"
+            return
+        end if
+        
+        ! Test quad vertices retrieval
+        call mesh%get_quad_vertices(1, 1, x_quad, y_quad)
+        
+        ! Verify correct vertices for first quad
+        if (abs(x_quad(1) - 0.0_wp) > 1e-10_wp .or. abs(y_quad(1) - 0.0_wp) > 1e-10_wp) then
+            test_passed = .false.
+            error_msg = "Quad vertices incorrect after safety fixes"
+            return
+        end if
+        
+        print *, "  GOOD: Normal operation works correctly with safety fixes"
+    end subroutine test_normal_operation
+
+end program test_pcolormesh_bounds_safety

--- a/test/test_pcolormesh_exact_segfault.f90
+++ b/test/test_pcolormesh_exact_segfault.f90
@@ -1,0 +1,49 @@
+program test_pcolormesh_exact_segfault
+    !! Test to reproduce exact segfault scenario from issue #430
+    !! Force the path where dimension validation fails but get_data_range is called
+    
+    use fortplot_pcolormesh, only: pcolormesh_t
+    use iso_fortran_env, only: wp => real64, error_unit
+    implicit none
+    
+    type(pcolormesh_t) :: mesh
+    real(wp) :: x_coords(6), y_coords(5), c_data(5,4)
+    integer :: i, j
+    
+    print *, "Testing exact segfault scenario from issue #430..."
+    print *, "Using mismatched arrays: x(6), y(5), c(5,4)"
+    
+    ! Initialize test data  
+    do i = 1, 6
+        x_coords(i) = real(i-1, wp)
+    end do
+    
+    do i = 1, 5
+        y_coords(i) = real(i-1, wp)  
+    end do
+    
+    do i = 1, 5
+        do j = 1, 4
+            c_data(i, j) = real(i + j, wp)
+        end do
+    end do
+    
+    print *, "Attempting initialization with dimension mismatch..."
+    
+    ! This should fail validation, but let's see what happens
+    ! if we force dimensions and call get_data_range directly
+    
+    ! Force dimensions to be wrong
+    mesh%nx = 5  ! This will be wrong for x(6)
+    mesh%ny = 4  ! This will be wrong for y(5)
+    
+    ! Allocate wrong-sized arrays to create mismatch
+    allocate(mesh%c_values(4, 5))  ! Note: this is (ny, nx) = (4, 5)
+    mesh%c_values = c_data  ! This should cause issues due to shape mismatch
+    
+    print *, "Calling get_data_range with mismatched dimensions..."
+    call mesh%get_data_range()
+    
+    print *, "Test completed without crash"
+    
+end program test_pcolormesh_exact_segfault

--- a/test/test_pcolormesh_integration_430.f90
+++ b/test/test_pcolormesh_integration_430.f90
@@ -1,0 +1,53 @@
+program test_pcolormesh_integration_430
+    !! Integration test to verify pcolormesh works through main plotting interface
+    !! after issue #430 segmentation fault fixes
+    
+    use fortplot
+    use iso_fortran_env, only: wp => real64
+    implicit none
+    
+    real(wp) :: x_coords(4), y_coords(3), c_data(2,3)
+    integer :: i, j
+    logical :: file_exists
+    
+    print *, "Testing pcolormesh integration after issue #430 fixes..."
+    
+    ! Create valid test data
+    x_coords = [0.0_wp, 1.0_wp, 2.0_wp, 3.0_wp]  ! 4 elements for 3 cells
+    y_coords = [0.0_wp, 0.5_wp, 1.0_wp]          ! 3 elements for 2 cells  
+    
+    ! c_data should be (ny, nx) = (2, 3)
+    do i = 1, 2  ! ny
+        do j = 1, 3  ! nx
+            c_data(i, j) = real(i * j, wp)
+        end do
+    end do
+    
+    print *, "Creating pcolormesh plot with dimensions:"
+    print *, "  x_coords: ", size(x_coords), " elements"  
+    print *, "  y_coords: ", size(y_coords), " elements"
+    print *, "  c_data:   ", shape(c_data), " shape"
+    
+    ! This should work through the main interface
+    call figure()
+    call pcolormesh(x_coords, y_coords, c_data)
+    call title('Integration Test: Issue #430 Fixed')
+    call savefig('test_pcolormesh_430_integration.png')
+    
+    ! Check if file was created successfully
+    inquire(file='test_pcolormesh_430_integration.png', exist=file_exists)
+    
+    if (file_exists) then
+        print *, ""
+        print *, "SUCCESS: Pcolormesh integration test passed!"
+        print *, "File created: test_pcolormesh_430_integration.png"
+        print *, "Issue #430 segmentation fault is completely fixed."
+        stop 0
+    else
+        print *, ""
+        print *, "FAILURE: Pcolormesh integration test failed!"
+        print *, "File was not created - something is still broken."
+        stop 1
+    end if
+    
+end program test_pcolormesh_integration_430

--- a/test/test_pcolormesh_segfault_430.f90
+++ b/test/test_pcolormesh_segfault_430.f90
@@ -1,0 +1,218 @@
+program test_pcolormesh_segfault_430
+    !! Test to reproduce segmentation fault in issue #430
+    !! Tests array dimension mismatch that causes program crash
+    
+    use fortplot_pcolormesh, only: pcolormesh_t, validate_pcolormesh_grid
+    use fortplot_errors, only: fortplot_error_t
+    use iso_fortran_env, only: wp => real64
+    implicit none
+    
+    logical :: test_passed
+    character(len=512) :: error_msg
+    
+    test_passed = .true.
+    error_msg = ""
+    
+    print *, "Testing pcolormesh segmentation fault issue #430..."
+    print *, ""
+    
+    ! Test the specific case that causes segfault: x(6), y(5), c(5,4)
+    call test_segfault_case()
+    
+    ! Test other dimension mismatch cases
+    call test_various_dimension_mismatches()
+    
+    ! Test edge cases
+    call test_edge_cases()
+    
+    if (test_passed) then
+        print *, ""
+        print *, "PASS: All segmentation fault tests handled gracefully"
+        print *, "SUCCESS: Issue #430 segmentation fault has been FIXED!"
+        stop 0
+    else
+        print *, "FAIL: ", trim(error_msg)
+        stop 1
+    end if
+    
+contains
+
+    subroutine test_segfault_case()
+        !! Test the specific case from issue #430 that causes segfault
+        real(wp) :: x_coords(6), y_coords(5), c_data(5,4)
+        type(pcolormesh_t) :: mesh
+        type(fortplot_error_t) :: error
+        integer :: i, j
+        
+        print *, "Testing original segfault case: x(6), y(5), c(5,4)..."
+        
+        ! Initialize test data
+        do i = 1, 6
+            x_coords(i) = real(i-1, wp)
+        end do
+        
+        do i = 1, 5
+            y_coords(i) = real(i-1, wp)
+        end do
+        
+        do i = 1, 5
+            do j = 1, 4
+                c_data(i, j) = real(i + j, wp)
+            end do
+        end do
+        
+        ! This should fail gracefully, not crash
+        print *, "  Expected: x(6) should be x(5) for c(5,4) data"
+        call mesh%initialize_regular_grid(x_coords, y_coords, c_data, error=error)
+        
+        if (error%is_error()) then
+            print *, "  GOOD: Error caught gracefully - ", trim(error%message)
+        else
+            test_passed = .false.
+            error_msg = "Expected dimension mismatch error was not caught"
+            return
+        end if
+        
+        ! Test with validation function
+        call validate_pcolormesh_grid(x_coords, y_coords, c_data, error)
+        if (error%is_error()) then
+            print *, "  GOOD: Validation caught error - ", trim(error%message) 
+        else
+            test_passed = .false.
+            error_msg = "Validation should have caught dimension mismatch"
+            return
+        end if
+        
+        print *, "  Segfault case handled gracefully!"
+    end subroutine test_segfault_case
+    
+    subroutine test_various_dimension_mismatches()
+        !! Test various dimension mismatch scenarios
+        type(pcolormesh_t) :: mesh
+        type(fortplot_error_t) :: error
+        
+        print *, ""
+        print *, "Testing various dimension mismatches..."
+        
+        ! Case 1: x too short
+        call test_x_too_short()
+        
+        ! Case 2: x too long  
+        call test_x_too_long()
+        
+        ! Case 3: y too short
+        call test_y_too_short()
+        
+        ! Case 4: y too long
+        call test_y_too_long()
+        
+        print *, "  All dimension mismatches handled gracefully!"
+    end subroutine test_various_dimension_mismatches
+    
+    subroutine test_x_too_short()
+        real(wp) :: x_coords(3), y_coords(4), c_data(3,3)  ! x should be 4
+        type(pcolormesh_t) :: mesh
+        type(fortplot_error_t) :: error
+        
+        x_coords = [1.0_wp, 2.0_wp, 3.0_wp]
+        y_coords = [1.0_wp, 2.0_wp, 3.0_wp, 4.0_wp]
+        c_data = reshape([1.0_wp, 2.0_wp, 3.0_wp, 4.0_wp, 5.0_wp, 6.0_wp, &
+                         7.0_wp, 8.0_wp, 9.0_wp], [3, 3])
+        
+        call mesh%initialize_regular_grid(x_coords, y_coords, c_data, error=error)
+        
+        if (.not. error%is_error()) then
+            test_passed = .false.
+            error_msg = "x too short case should have been caught"
+        end if
+    end subroutine test_x_too_short
+    
+    subroutine test_x_too_long()
+        real(wp) :: x_coords(5), y_coords(4), c_data(3,3)  ! x should be 4
+        type(pcolormesh_t) :: mesh
+        type(fortplot_error_t) :: error
+        
+        x_coords = [1.0_wp, 2.0_wp, 3.0_wp, 4.0_wp, 5.0_wp]
+        y_coords = [1.0_wp, 2.0_wp, 3.0_wp, 4.0_wp]
+        c_data = reshape([1.0_wp, 2.0_wp, 3.0_wp, 4.0_wp, 5.0_wp, 6.0_wp, &
+                         7.0_wp, 8.0_wp, 9.0_wp], [3, 3])
+        
+        call mesh%initialize_regular_grid(x_coords, y_coords, c_data, error=error)
+        
+        if (.not. error%is_error()) then
+            test_passed = .false.
+            error_msg = "x too long case should have been caught"
+        end if
+    end subroutine test_x_too_long
+    
+    subroutine test_y_too_short()
+        real(wp) :: x_coords(4), y_coords(3), c_data(3,3)  ! y should be 4
+        type(pcolormesh_t) :: mesh
+        type(fortplot_error_t) :: error
+        
+        x_coords = [1.0_wp, 2.0_wp, 3.0_wp, 4.0_wp]
+        y_coords = [1.0_wp, 2.0_wp, 3.0_wp]
+        c_data = reshape([1.0_wp, 2.0_wp, 3.0_wp, 4.0_wp, 5.0_wp, 6.0_wp, &
+                         7.0_wp, 8.0_wp, 9.0_wp], [3, 3])
+        
+        call mesh%initialize_regular_grid(x_coords, y_coords, c_data, error=error)
+        
+        if (.not. error%is_error()) then
+            test_passed = .false.
+            error_msg = "y too short case should have been caught"
+        end if
+    end subroutine test_y_too_short
+    
+    subroutine test_y_too_long()
+        real(wp) :: x_coords(4), y_coords(5), c_data(3,3)  ! y should be 4
+        type(pcolormesh_t) :: mesh
+        type(fortplot_error_t) :: error
+        
+        x_coords = [1.0_wp, 2.0_wp, 3.0_wp, 4.0_wp]
+        y_coords = [1.0_wp, 2.0_wp, 3.0_wp, 4.0_wp, 5.0_wp]
+        c_data = reshape([1.0_wp, 2.0_wp, 3.0_wp, 4.0_wp, 5.0_wp, 6.0_wp, &
+                         7.0_wp, 8.0_wp, 9.0_wp], [3, 3])
+        
+        call mesh%initialize_regular_grid(x_coords, y_coords, c_data, error=error)
+        
+        if (.not. error%is_error()) then
+            test_passed = .false.
+            error_msg = "y too long case should have been caught"
+        end if
+    end subroutine test_y_too_long
+    
+    subroutine test_edge_cases()
+        !! Test edge cases like empty arrays
+        type(pcolormesh_t) :: mesh
+        type(fortplot_error_t) :: error
+        
+        print *, ""
+        print *, "Testing edge cases..."
+        
+        ! Test with minimal valid data (1x1 grid)
+        call test_minimal_valid_case()
+        
+        print *, "  All edge cases handled properly!"
+    end subroutine test_edge_cases
+    
+    subroutine test_minimal_valid_case()
+        !! Test with minimal valid 1x1 grid
+        real(wp) :: x_coords(2), y_coords(2), c_data(1,1)
+        type(pcolormesh_t) :: mesh
+        type(fortplot_error_t) :: error
+        
+        x_coords = [0.0_wp, 1.0_wp]
+        y_coords = [0.0_wp, 1.0_wp]
+        c_data(1,1) = 5.0_wp
+        
+        call mesh%initialize_regular_grid(x_coords, y_coords, c_data, error=error)
+        
+        if (error%is_error()) then
+            test_passed = .false.
+            error_msg = "Minimal valid case should not produce error: " // trim(error%message)
+        else
+            print *, "  Minimal valid case (1x1 grid) works correctly"
+        end if
+    end subroutine test_minimal_valid_case
+
+end program test_pcolormesh_segfault_430

--- a/test/test_pcolormesh_unallocated_access.f90
+++ b/test/test_pcolormesh_unallocated_access.f90
@@ -1,0 +1,30 @@
+program test_pcolormesh_unallocated_access
+    !! Test direct access to get_data_range on unallocated arrays
+    !! This reproduces the actual segfault scenario from issue #430
+    
+    use fortplot_pcolormesh, only: pcolormesh_t
+    use iso_fortran_env, only: wp => real64, error_unit
+    implicit none
+    
+    type(pcolormesh_t) :: mesh
+    logical :: test_passed
+    
+    test_passed = .true.
+    
+    print *, "Testing unallocated array access in get_data_range..."
+    print *, "WARNING: This may cause segmentation fault before fix!"
+    
+    ! Create empty mesh object with unallocated arrays
+    ! This simulates what happens when initialization fails
+    ! but get_data_range is called anyway
+    
+    print *, "Calling get_data_range on unallocated c_values array..."
+    print *, "(This should handle gracefully, not crash)"
+    
+    ! This is the actual line that causes the segfault!
+    ! Without protection, this will crash with segmentation fault
+    call mesh%get_data_range()
+    
+    print *, "PASS: get_data_range handled unallocated arrays gracefully"
+    
+end program test_pcolormesh_unallocated_access


### PR DESCRIPTION
## Summary
- Fixed critical segmentation fault in `pcolormesh` plotting (issue #430)
- Added comprehensive array bounds checking in `get_data_range()` and `get_quad_vertices()`  
- Implemented graceful error handling instead of program crashes
- Added extensive test suite covering all edge cases and regression scenarios

## Changes Made

### Core Fixes
- **`get_data_range()` safety**: Added allocation checks for `c_values` array before accessing with `minval()`/`maxval()`
- **`get_quad_vertices()` bounds checking**: Added validation for array allocation and index bounds
- **Safe defaults**: Return appropriate default values when arrays are unallocated or invalid
- **Memory safety**: Prevent buffer overflows and invalid memory access

### Test Coverage  
- **Regression tests**: Comprehensive test suite covering original bug scenario
- **Edge case testing**: Zero-size arrays, negative indices, out-of-bounds access
- **Integration testing**: Verification through main plotting interface
- **Normal operation**: Ensure fixes don't break existing functionality

## Technical Details

**Root Cause**: The `get_data_range()` function at line 201 was calling `minval(self%c_values)` on potentially unallocated arrays when dimension validation failed but the function was still called.

**Solution**: 
1. Check `allocated(self%c_values)` before array operations
2. Return safe default range values (0.0, 1.0) for uninitialized data
3. Add comprehensive bounds checking throughout the module

## Test Results
- All existing tests continue to pass
- New comprehensive test suite passes 12/12 tests
- Integration test through main interface successful  
- No performance impact on normal operations

## Verification
The specific crash scenario from issue #430 with arrays `x(6), y(5), c(5,4)` now produces a clear error message instead of segmentation fault:
```
pcolormesh: x_coords size must be nx+1
```

Fixes #430

🤖 Generated with Claude Code