### PR TITLE
fix: reset figure state to prevent legend contamination between calls

### DIFF
--- a/src/fortplot_figure_core.f90
+++ b/src/fortplot_figure_core.f90
@@ -152,13 +152,27 @@ contains
             end if
         end if
         
-        ! Reset plot counter
+        ! Reset plot counter and state
         self%plot_count = 0
         self%rendered = .false.
+        self%show_legend = .false.
+        
+        ! Clear legend data to prevent state contamination between figure calls
+        call self%legend_data%clear()
+        
+        ! Reset axis limits and labels
+        self%xlim_set = .false.
+        self%ylim_set = .false.
+        if (allocated(self%title)) deallocate(self%title)
+        if (allocated(self%xlabel)) deallocate(self%xlabel)
+        if (allocated(self%ylabel)) deallocate(self%ylabel)
         
         ! Allocate plots array
         if (allocated(self%plots)) deallocate(self%plots)
         allocate(self%plots(self%max_plots))
+        
+        ! Clear streamlines data if allocated
+        if (allocated(self%streamlines)) deallocate(self%streamlines)
     end subroutine initialize
 
     subroutine add_plot(self, x, y, label, linestyle, color)

--- a/test/test_figure_state_isolation.f90
+++ b/test/test_figure_state_isolation.f90
@@ -1,0 +1,73 @@
+program test_figure_state_isolation
+    !! Test program to verify that figure() calls properly reset state
+    !! Reproduces Issue #434: Legend state contamination between figure calls
+    
+    use fortplot
+    use iso_fortran_env, only: wp => real64
+    implicit none
+    
+    real(wp) :: x1(5) = [1.0_wp, 2.0_wp, 3.0_wp, 4.0_wp, 5.0_wp]
+    real(wp) :: y1(5) = [1.0_wp, 4.0_wp, 2.0_wp, 8.0_wp, 3.0_wp]
+    real(wp) :: x2(5) = [1.0_wp, 2.0_wp, 3.0_wp, 4.0_wp, 5.0_wp]
+    real(wp) :: y2(5) = [2.0_wp, 3.0_wp, 1.0_wp, 5.0_wp, 4.0_wp]
+    type(figure_t), pointer :: fig_ptr
+    logical :: test_passed
+    
+    write(*,*) 'Testing figure state isolation...'
+    
+    ! Test 1: Create first figure with legend
+    call figure(figsize=[800.0d0, 600.0d0])
+    call plot(x1, y1, label='First Plot')
+    call legend()
+    
+    ! Get reference to global figure and check legend entries
+    fig_ptr => get_global_figure()
+    if (fig_ptr%legend_data%num_entries /= 1) then
+        write(*,*) 'FAIL: First figure should have 1 legend entry, got:', fig_ptr%legend_data%num_entries
+        stop 1
+    end if
+    write(*,*) 'PASS: First figure has correct legend entries (1)'
+    
+    ! Test 2: Create second figure - should have clean state
+    call figure(figsize=[800.0d0, 600.0d0])
+    call plot(x2, y2, label='Second Plot')
+    
+    ! Check that legend state is clean (no entries from previous figure)
+    fig_ptr => get_global_figure()
+    if (fig_ptr%legend_data%num_entries /= 0) then
+        write(*,*) 'FAIL: Second figure should have 0 legend entries before legend(), got:', fig_ptr%legend_data%num_entries
+        write(*,*) 'This indicates state contamination from first figure'
+        stop 1
+    end if
+    write(*,*) 'PASS: Second figure has clean legend state (0 entries)'
+    
+    ! Add legend to second figure  
+    call legend()
+    
+    ! Check that second figure now has only its own legend
+    if (fig_ptr%legend_data%num_entries /= 1) then
+        write(*,*) 'FAIL: Second figure should have 1 legend entry after legend(), got:', fig_ptr%legend_data%num_entries
+        stop 1
+    end if
+    write(*,*) 'PASS: Second figure has correct legend entries after legend() (1)'
+    
+    ! Test 3: Create third figure and verify complete isolation
+    call figure(figsize=[800.0d0, 600.0d0])
+    
+    ! Should have no legend entries and no plots
+    fig_ptr => get_global_figure()
+    if (fig_ptr%legend_data%num_entries /= 0) then
+        write(*,*) 'FAIL: Third figure should have 0 legend entries, got:', fig_ptr%legend_data%num_entries
+        stop 1
+    end if
+    
+    if (fig_ptr%plot_count /= 0) then
+        write(*,*) 'FAIL: Third figure should have 0 plots, got:', fig_ptr%plot_count
+        stop 1
+    end if
+    
+    write(*,*) 'PASS: Third figure has completely clean state'
+    
+    write(*,*) 'All tests passed! Figure state isolation is working correctly.'
+
+end program test_figure_state_isolation


### PR DESCRIPTION
## Summary

- Fixed critical state contamination bug where `figure()` calls did not reset legend data
- Each call to `figure()` now creates completely clean plotting state 
- Added comprehensive test to verify figure state isolation works correctly

## Technical Details

**Root Cause**: The `initialize()` method in `fortplot_figure_core.f90` was not clearing legend data, causing legend entries from previous figures to contaminate new figures.

**Solution**: Enhanced the `initialize()` method to properly reset all figure state including:
- Legend entries and metadata via `self%legend_data%clear()`
- Axis labels (title, xlabel, ylabel) 
- Axis limits and scaling flags
- Plot counter and rendering state
- Streamlines data arrays

**Test Coverage**: Added `test_figure_state_isolation.f90` that verifies:
- First figure legend works correctly
- Second figure starts with clean legend state (0 entries)
- Second figure can add its own legend independently 
- Third figure starts completely clean

## Test Results

```
Testing figure state isolation...
PASS: First figure has correct legend entries (1)
PASS: Second figure has clean legend state (0 entries)
PASS: Second figure has correct legend entries after legend() (1)  
PASS: Third figure has completely clean state
All tests passed! Figure state isolation is working correctly.
```

## Quality Verification

- ✅ All existing legend tests pass (`test_legend_comprehensive`)
- ✅ Basic plotting functionality preserved (`test_simple_validation`)
- ✅ No regressions in core features
- ✅ Fix follows QADS quality standards

Fixes #434

🤖 Generated with [Claude Code](https://claude.ai/code)