### PR TITLE
fix: replace error_stop stubs with graceful implementations

### DIFF
--- a/test/test_matplotlib_stubs.f90
+++ b/test/test_matplotlib_stubs.f90
@@ -1,0 +1,115 @@
+program test_matplotlib_stubs
+    !! Test that matplotlib stub implementations work correctly
+    use fortplot_matplotlib
+    use fortplot_logging, only: log_info
+    implicit none
+    
+    real(8) :: x(10), y(10), data(100)
+    integer :: i
+    logical :: test_passed
+    
+    ! Generate test data
+    do i = 1, 10
+        x(i) = real(i-1, 8)
+        y(i) = real((i-1)**2, 8)
+    end do
+    
+    do i = 1, 100
+        data(i) = real(i, 8) + 0.5d0 * sin(real(i, 8))
+    end do
+    
+    test_passed = .true.
+    call log_info("Testing matplotlib stub implementations...")
+    
+    ! Test scatter plot
+    call test_scatter()
+    
+    ! Test bar plot
+    call test_bar()
+    
+    ! Test horizontal bar plot
+    call test_barh()
+    
+    ! Test histogram
+    call test_hist()
+    
+    ! Test text annotation
+    call test_text()
+    
+    ! Test arrow annotation
+    call test_annotate()
+    
+    if (test_passed) then
+        call log_info("All tests passed!")
+    else
+        call log_info("Some tests failed")
+        stop 1
+    end if
+    
+contains
+
+    subroutine test_scatter()
+        call log_info("Testing scatter plot...")
+        call figure()
+        call scatter(x, y, label="Test scatter")
+        call title("Scatter Plot Test")
+        call xlabel("X values")
+        call ylabel("Y values")
+        call savefig("test_scatter.png")
+        call log_info("  scatter plot test complete")
+    end subroutine test_scatter
+    
+    subroutine test_bar()
+        call log_info("Testing bar plot...")
+        call figure()
+        call bar(x, y, label="Test bars")
+        call title("Bar Plot Test")
+        call xlabel("Categories")
+        call ylabel("Values")
+        call savefig("test_bar.png")
+        call log_info("  bar plot test complete")
+    end subroutine test_bar
+    
+    subroutine test_barh()
+        call log_info("Testing horizontal bar plot...")
+        call figure()
+        call barh(x, y, label="Test horizontal bars")
+        call title("Horizontal Bar Plot Test")
+        call xlabel("Values")
+        call ylabel("Categories")
+        call savefig("test_barh.png")
+        call log_info("  horizontal bar plot test complete")
+    end subroutine test_barh
+    
+    subroutine test_hist()
+        call log_info("Testing histogram...")
+        call figure()
+        call hist(data, bins=20, label="Test histogram")
+        call title("Histogram Test")
+        call xlabel("Values")
+        call ylabel("Frequency")
+        call savefig("test_hist.png")
+        call log_info("  histogram test complete")
+    end subroutine test_hist
+    
+    subroutine test_text()
+        call log_info("Testing text annotation...")
+        call figure()
+        call plot(x, y)
+        call text(5.0d0, 25.0d0, "Test annotation")
+        call title("Text Annotation Test")
+        call savefig("test_text.png")
+        call log_info("  text annotation test complete")
+    end subroutine test_text
+    
+    subroutine test_annotate()
+        call log_info("Testing arrow annotation...")
+        call figure()
+        call plot(x, y)
+        call annotate("Peak", [5.0d0, 25.0d0], [3.0d0, 30.0d0])
+        call title("Arrow Annotation Test")
+        call savefig("test_annotate.png")
+        call log_info("  arrow annotation test complete")
+    end subroutine test_annotate
+    
+end program test_matplotlib_stubs

--- a/test/test_no_error_stop.f90
+++ b/test/test_no_error_stop.f90
@@ -1,0 +1,63 @@
+program test_no_error_stop
+    !! Test that stub functions no longer call error_stop
+    use fortplot_matplotlib
+    implicit none
+    
+    real(8) :: x(5), y(5), data(20)
+    integer :: i
+    logical :: success
+    
+    ! Generate test data
+    do i = 1, 5
+        x(i) = real(i, 8)
+        y(i) = real(i*i, 8)
+    end do
+    
+    do i = 1, 20
+        data(i) = real(i, 8) + sin(real(i, 8))
+    end do
+    
+    success = .true.
+    
+    ! Test each function that previously had error_stop
+    print *, "Testing bar()..."
+    call bar(x, y)
+    print *, "  bar() passed (no error_stop)"
+    
+    print *, "Testing barh()..."  
+    call barh(x, y)
+    print *, "  barh() passed (no error_stop)"
+    
+    print *, "Testing hist()..."
+    call hist(data)
+    print *, "  hist() passed (no error_stop)"
+    
+    print *, "Testing histogram()..."
+    call histogram(data)
+    print *, "  histogram() passed (no error_stop)"
+    
+    print *, "Testing boxplot()..."
+    call boxplot(data)
+    print *, "  boxplot() passed (no error_stop)"
+    
+    print *, "Testing scatter()..."
+    call scatter(x, y)
+    print *, "  scatter() passed (no error_stop)"
+    
+    print *, "Testing text()..."
+    call text(2.5d0, 6.0d0, "Test")
+    print *, "  text() passed (no error_stop)"
+    
+    print *, "Testing annotate()..."
+    call annotate("Arrow", [3.0d0, 9.0d0], [2.0d0, 10.0d0])
+    print *, "  annotate() passed (no error_stop)"
+    
+    print *, "Testing errorbar()..."
+    call errorbar(x, y)
+    print *, "  errorbar() passed (no error_stop)"
+    
+    print *, ""
+    print *, "SUCCESS: All previously stubbed functions work without error_stop!"
+    print *, "Issue #444 is resolved - no more crashes from stub implementations."
+    
+end program test_no_error_stop


### PR DESCRIPTION
## Summary
- Fixes issue #444 by replacing 8 error_stop crashers in fortplot_matplotlib.f90 with graceful implementations
- All matplotlib stub methods now provide useful functionality or clear warnings instead of crashes
- Adds comprehensive test coverage to ensure no error_stop triggers

## Implementation Details

### Fully Functional (using existing figure_core methods):
- **hist()** - Delegates to figure_core's hist implementation
- **histogram()** - Alias that delegates to hist()
- **boxplot()** - Delegates to figure_core's boxplot implementation

### Graceful Approximations (with warnings):
- **bar()/barh()** - Use line plot approximation with warning message
- **scatter()** - Uses plot with markers as approximation
- **errorbar()** - Shows base plot without error bars (warns if error bars provided)

### Informative Placeholders (no crash):
- **text()** - Logs position and text content instead of crashing
- **annotate()** - Logs annotation details instead of crashing

## Test Coverage
- Added test_matplotlib_stubs.f90 - tests all implementations
- Added test_no_error_stop.f90 - verifies no error_stop triggers
- All functions tested and confirmed working without crashes

## Benefits
- Users can now call all matplotlib API functions without program termination
- Clear warnings indicate when features are partially implemented
- Smooth migration path as full implementations are added later

Fixes #444