### PR TITLE
fix: resolve critical PDF coordinate system issues

### DIFF
--- a/src/fortplot_pdf.f90
+++ b/src/fortplot_pdf.f90
@@ -86,7 +86,7 @@ contains
         call ctx%stream_writer%add_to_stream("1 w")
         call ctx%stream_writer%add_to_stream("1 J")
         call ctx%stream_writer%add_to_stream("1 j")
-        call ctx%stream_writer%add_to_stream("0 0 1 RG")
+        call ctx%stream_writer%add_to_stream("0 0 0 RG")
         
         ctx%margins = plot_margins_t()
         call calculate_plot_area(width, height, ctx%margins, ctx%plot_area)

--- a/src/fortplot_pdf_axes.f90
+++ b/src/fortplot_pdf_axes.f90
@@ -254,9 +254,9 @@ contains
         character(len=256) :: frame_cmd
         real(wp) :: x1, y1
         
-        ! Convert to PDF coordinates (Y=0 at bottom)
+        ! PDF coordinates: Y=0 at bottom (same as our data coordinates)
         x1 = plot_left
-        y1 = canvas_height - plot_bottom - plot_height  ! PDF Y coordinate conversion
+        y1 = plot_bottom  ! No conversion needed - PDF Y=0 is at bottom
         
         ! Draw rectangle frame
         write(frame_cmd, '(F0.3, 1X, F0.3, " ", F0.3, 1X, F0.3, " re S")') &
@@ -278,7 +278,7 @@ contains
         real(wp) :: tick_length, bottom_y
         
         tick_length = PDF_TICK_SIZE
-        bottom_y = canvas_height - plot_bottom  ! Convert to PDF coordinates
+        bottom_y = plot_bottom  ! PDF Y=0 is at bottom, no conversion needed
         
         ! Draw X-axis ticks (bottom of plot area)
         do i = 1, num_x
@@ -291,8 +291,8 @@ contains
         ! Draw Y-axis ticks (left side of plot area)
         do i = 1, num_y
             write(tick_cmd, '(F0.3, 1X, F0.3, " m ", F0.3, 1X, F0.3, " l S")') &
-                plot_left, canvas_height - y_positions(i), &
-                plot_left - tick_length, canvas_height - y_positions(i)
+                plot_left, y_positions(i), &
+                plot_left - tick_length, y_positions(i)
             ctx%stream_data = ctx%stream_data // trim(adjustl(tick_cmd)) // new_line('a')
         end do
     end subroutine draw_pdf_tick_marks_with_area
@@ -313,7 +313,7 @@ contains
         
         x_offset = 5.0_wp   ! Offset for X labels below ticks
         y_offset = 10.0_wp  ! Offset for Y labels left of ticks
-        bottom_y = canvas_height - plot_bottom  ! Convert to PDF coordinates
+        bottom_y = plot_bottom  ! PDF Y=0 is at bottom, no conversion needed
         
         ! Draw X-axis labels
         do i = 1, num_x
@@ -324,7 +324,7 @@ contains
         
         ! Draw Y-axis labels with overlap detection
         call draw_pdf_y_labels_with_overlap_detection(ctx, y_positions, y_labels, num_y, &
-                                                     plot_left - PDF_TICK_SIZE - y_offset, canvas_height)
+                                                     plot_left - PDF_TICK_SIZE - y_offset, 0.0_wp)
     end subroutine draw_pdf_tick_labels_with_area
 
     subroutine draw_pdf_title_and_labels(ctx, title, xlabel, ylabel, &
@@ -387,7 +387,7 @@ contains
         last_y_drawn = -1000.0_wp  ! Initialize to ensure first label is drawn
         
         do i = 1, num_y
-            label_y = canvas_height - y_positions(i) - 3.0_wp  ! Convert to PDF coordinates and vertically center
+            label_y = y_positions(i) - 3.0_wp  ! PDF Y=0 is at bottom, no conversion needed
             
             ! Only draw if sufficient spacing from last label
             if (abs(label_y - last_y_drawn) >= min_spacing) then

--- a/src/fortplot_pdf_coordinate.f90
+++ b/src/fortplot_pdf_coordinate.f90
@@ -79,8 +79,9 @@ contains
         pdf_x = (x - ctx%x_min) * common_scale + &
                 real(ctx%plot_area%left, wp) + x_offset
         
+        ! PDF coordinates: Y=0 at bottom, so transform data coordinates directly
         pdf_y = (y - ctx%y_min) * common_scale + &
-                real(ctx%height - ctx%plot_area%bottom - ctx%plot_area%height, wp) + y_offset
+                real(ctx%plot_area%bottom, wp) + y_offset
     end subroutine normalize_to_pdf_coords
 
     real(wp) function pdf_get_width_scale(ctx) result(scale)

--- a/test/test_pdf_coordinate_debug.f90
+++ b/test/test_pdf_coordinate_debug.f90
@@ -1,0 +1,63 @@
+program test_pdf_coordinate_debug
+    !! Diagnostic program to identify PDF coordinate system issues
+    !! Uses low-level PDF API to test coordinate transformations
+    
+    use fortplot_pdf
+    use fortplot_png  
+    use iso_fortran_env, only: wp => real64
+    implicit none
+    
+    type(pdf_context) :: pdf_ctx
+    type(png_context) :: png_ctx
+    real(wp), parameter :: x_data(5) = [1.0_wp, 2.0_wp, 3.0_wp, 4.0_wp, 5.0_wp]
+    real(wp), parameter :: y_data(5) = [2.0_wp, 4.0_wp, 1.0_wp, 5.0_wp, 3.0_wp]
+    integer :: i
+    
+    ! Create contexts
+    pdf_ctx = create_pdf_canvas(400, 300)
+    png_ctx = create_png_canvas(400, 300)
+    
+    ! Set coordinate system for both
+    call pdf_ctx%set_coordinates(0.0_wp, 6.0_wp, 0.0_wp, 6.0_wp)
+    png_ctx%x_min = 0.0_wp
+    png_ctx%x_max = 6.0_wp
+    png_ctx%y_min = 0.0_wp
+    png_ctx%y_max = 6.0_wp
+    
+    ! Draw coordinate system test - PDF
+    call pdf_ctx%color(0.0_wp, 0.0_wp, 0.0_wp)  ! Black
+    call pdf_ctx%set_line_width(1.0_wp)
+    
+    ! Draw data points as lines - PDF
+    call pdf_ctx%color(1.0_wp, 0.0_wp, 0.0_wp)  ! Red
+    call pdf_ctx%set_line_width(2.0_wp)
+    do i = 1, size(x_data) - 1
+        call pdf_ctx%line(x_data(i), y_data(i), x_data(i+1), y_data(i+1))
+    end do
+    
+    ! Add axes manually - PDF
+    call pdf_ctx%render_axes('PDF Debug Test', 'X Axis', 'Y Axis')
+    
+    ! Do the same for PNG
+    call png_ctx%color(0.0_wp, 0.0_wp, 0.0_wp)  ! Black
+    call png_ctx%set_line_width(1.0_wp)
+    
+    ! Draw data points as lines - PNG
+    call png_ctx%color(1.0_wp, 0.0_wp, 0.0_wp)  ! Red
+    call png_ctx%set_line_width(2.0_wp)
+    do i = 1, size(x_data) - 1
+        call png_ctx%line(x_data(i), y_data(i), x_data(i+1), y_data(i+1))
+    end do
+    
+    ! Save both files
+    call pdf_ctx%save('debug_coordinates_pdf.pdf')
+    call png_ctx%save('debug_coordinates_png.png')
+    
+    print *, 'Generated debug_coordinates_png.png and debug_coordinates_pdf.pdf'
+    print *, 'Compare both files to identify coordinate system issues:'
+    print *, '1. Check if X axis appears at bottom (correct) or top (incorrect)'
+    print *, '2. Check if axes are blue (incorrect) or black (correct)'
+    print *, '3. Check if plot appears within frame boundaries'
+    print *, '4. Verify data line positions match between formats'
+    
+end program test_pdf_coordinate_debug


### PR DESCRIPTION
## Summary
- Fixed critical PDF coordinate system issues where X axes appeared on top instead of bottom
- Corrected blue axes color to black as expected
- Resolved plot data appearing outside frame boundaries  
- Fixed Y-coordinate transformation throughout PDF rendering pipeline

## Technical Changes
- **Y-coordinate transformation**: Fixed `normalize_to_pdf_coords()` to properly handle PDF coordinate system (Y=0 at bottom)
- **Axes positioning**: Updated `draw_pdf_frame_with_area()` and related functions to remove incorrect coordinate inversions
- **Color initialization**: Changed initial PDF color from blue (`0 0 1 RG`) to black (`0 0 0 RG`)
- **Comprehensive coordinate fixes**: Updated all PDF axes drawing functions consistently

## Test Results
- ✅ X-axis labels now appear at bottom (correct)
- ✅ Y-axis labels properly positioned on left side
- ✅ Axes render in black instead of blue
- ✅ Plot data appears within frame boundaries
- ✅ Coordinate system properly oriented
- ✅ All existing PDF tests pass

## Files Changed
- `src/fortplot_pdf_coordinate.f90`: Core coordinate transformation fixes
- `src/fortplot_pdf_axes.f90`: Axes positioning and tick label fixes  
- `src/fortplot_pdf.f90`: Color initialization fix
- `test/test_pdf_coordinate_debug.f90`: New diagnostic test

Fixes #414

🤖 Generated with [Claude Code](https://claude.ai/code)