### PR TITLE
fix: correct PNG backend 100x dimension calculation error - fixes #577

### DIFF
--- a/src/fortplot_python_interface.f90
+++ b/src/fortplot_python_interface.f90
@@ -57,13 +57,16 @@ contains
         !! Python-accessible figure initialization
         !! 
         !! Arguments:
-        !!   width, height: Optional figure dimensions (default: 640x480)
+        !!   width, height: Optional figure dimensions in pixels (default: 640x480)
         integer, intent(in), optional :: width, height
         
         real(8), dimension(2) :: figsize
+        real(8), parameter :: DPI = 100.0d0
         
         if (present(width) .and. present(height)) then
-            figsize = [real(width, 8), real(height, 8)]
+            ! Convert pixel dimensions to inches for matplotlib compatibility
+            ! Python passes pixels, but mpl_figure expects inches
+            figsize = [real(width, 8) / DPI, real(height, 8) / DPI]
             call mpl_figure(figsize=figsize)
         else
             call mpl_figure()

--- a/test/test_figure_state_isolation.f90
+++ b/test/test_figure_state_isolation.f90
@@ -16,7 +16,7 @@ program test_figure_state_isolation
     write(*,*) 'Testing figure state isolation...'
     
     ! Test 1: Create first figure with legend
-    call figure(figsize=[800.0d0, 600.0d0])
+    call figure(figsize=[8.0d0, 6.0d0])
     call plot(x1, y1, label='First Plot')
     call legend()
     
@@ -29,7 +29,7 @@ program test_figure_state_isolation
     write(*,*) 'PASS: First figure has correct legend entries (1)'
     
     ! Test 2: Create second figure - should have clean state
-    call figure(figsize=[800.0d0, 600.0d0])
+    call figure(figsize=[8.0d0, 6.0d0])
     call plot(x2, y2, label='Second Plot')
     
     ! Check that legend state is clean (no entries from previous figure)
@@ -52,7 +52,7 @@ program test_figure_state_isolation
     write(*,*) 'PASS: Second figure has correct legend entries after legend() (1)'
     
     ! Test 3: Create third figure and verify complete isolation
-    call figure(figsize=[800.0d0, 600.0d0])
+    call figure(figsize=[8.0d0, 6.0d0])
     
     ! Should have no legend entries and no plots
     fig_ptr => get_global_figure()

--- a/test/test_legend_comprehensive.f90
+++ b/test/test_legend_comprehensive.f90
@@ -49,7 +49,7 @@ contains
         
         ! Enhanced error handling for Windows compatibility
         print *, "  Creating figure with size [640x480]..."
-        call figure(figsize=[640.0_wp, 480.0_wp])
+        call figure(figsize=[6.4_wp, 4.8_wp])
         
         print *, "  Setting title and labels..."
         call title("Basic Legend Test")
@@ -106,7 +106,7 @@ contains
         y = sin(x)
         
         do i = 1, 4
-            call figure(figsize=[640.0_wp, 480.0_wp])
+            call figure(figsize=[6.4_wp, 4.8_wp])
             call title("Legend: " // trim(positions(i)))
             call add_plot(x, y, label="sin(x)")
             call legend(position=trim(positions(i)))
@@ -139,7 +139,7 @@ contains
         y2 = sqrt(x)
         y3 = log(x+1)
         
-        call figure(figsize=[640.0_wp, 480.0_wp])
+        call figure(figsize=[6.4_wp, 4.8_wp])
         call title("Legend with Markers")
         call xlabel("X")
         call ylabel("Y")
@@ -181,7 +181,7 @@ contains
         y1 = cos(x)
         y2 = sin(x) * 0.5_wp
         
-        call figure(figsize=[640.0_wp, 480.0_wp])
+        call figure(figsize=[6.4_wp, 4.8_wp])
         call title("PDF Legend Test")
         call xlabel("X")
         call ylabel("Y")

--- a/test/test_scale_implementation.f90
+++ b/test/test_scale_implementation.f90
@@ -31,7 +31,7 @@ contains
         y = sin(x * 0.1_wp) * 100.0_wp
         
         ! Create plot with linear scale
-        call figure(figsize=[800.0d0, 600.0d0])
+        call figure(figsize=[8.0d0, 6.0d0])
         call set_xscale('linear')
         call set_yscale('linear')
         call plot(x, y, label='sin(x)')
@@ -59,7 +59,7 @@ contains
         y = x**2  ! Quadratic growth
         
         ! Create plot with log scales
-        call figure(figsize=[800.0d0, 600.0d0])
+        call figure(figsize=[8.0d0, 6.0d0])
         call set_xscale('log')
         call set_yscale('log')
         call plot(x, y, label='x^2')
@@ -88,7 +88,7 @@ contains
         y = x**3  ! Cubic function: negative to positive
         
         ! Create plot with symlog scales
-        call figure(figsize=[800.0d0, 600.0d0])
+        call figure(figsize=[8.0d0, 6.0d0])
         call set_xscale('symlog', threshold)
         call set_yscale('symlog', threshold)
         call plot(x, y, label='x^3')
@@ -119,7 +119,7 @@ contains
         where (x <= 0.0_wp) x = 0.001_wp
         
         ! Create plot with log scale on y-axis only
-        call figure(figsize=[800.0d0, 600.0d0])
+        call figure(figsize=[8.0d0, 6.0d0])
         call set_xscale('linear')
         call set_yscale('log')
         call plot(x, y, label='|sin(x)| + 0.1')
@@ -149,21 +149,21 @@ contains
         test_passed = .true.
         
         ! Test 1: Invalid scale type (should default to linear with warning)
-        call figure(figsize=[400.0d0, 300.0d0])
+        call figure(figsize=[4.0d0, 3.0d0])
         call set_xscale('invalid_scale')
         call set_yscale('invalid_scale')
         call plot(x, y)
         call savefig('test_invalid_scale.png')
         
         ! Test 2: Very small symlog threshold
-        call figure(figsize=[400.0d0, 300.0d0])
+        call figure(figsize=[4.0d0, 3.0d0])
         call set_xscale('symlog', 0.001_wp)
         call set_yscale('symlog', 0.001_wp)
         call plot(x, y)
         call savefig('test_small_threshold.png')
         
         ! Test 3: Switching scales after plotting
-        call figure(figsize=[400.0d0, 300.0d0])
+        call figure(figsize=[4.0d0, 3.0d0])
         call plot(x, y)
         call set_xscale('log')
         call set_yscale('log')

--- a/test/test_silent_output.f90
+++ b/test/test_silent_output.f90
@@ -19,7 +19,7 @@ program test_silent_output
     end do
     
     ! Create plot - should produce no console output
-    call figure(figsize=[400.0d0, 300.0d0])
+    call figure(figsize=[4.0d0, 3.0d0])
     call plot(x, y)
     call savefig(get_test_output_path('/tmp/silent_test.png'))
     


### PR DESCRIPTION
## Summary
- Fixed catastrophic PNG backend dimension calculation bug that was multiplying dimensions by 100
- PNG backend now correctly generates 640x480 images instead of 64000x48000
- Restored functionality to PNG output generation

## Problem
The PNG backend had a critical bug where dimensions were incorrectly calculated as 64000x48000 instead of 640x480 due to double multiplication by DPI=100:

1. Python wrapper passed pixel dimensions (640, 480) directly to Fortran's `mpl_figure` 
2. `mpl_figure` interpreted these as inches and multiplied by DPI=100 again
3. This resulted in 64000x48000 pixels, triggering dimension validation errors
4. PNG backend would fall back to PDF, making PNG output non-functional

## Solution
1. **Python interface fix**: Added proper pixel-to-inch conversion in `fortplot_python_interface.f90`
   - Added `DPI = 100.0d0` constant
   - Convert pixel dimensions to inches: `figsize = [real(width, 8) / DPI, real(height, 8) / DPI]`

2. **Test corrections**: Fixed test files using incorrect API
   - Changed `figsize=[800.0d0, 600.0d0]` to `figsize=[8.0d0, 6.0d0]` (inches, not pixels)
   - Tests now properly use inch values as expected by the API

## Testing
- Rebuilt and ran full test suite
- PNG dimension warnings eliminated for normal use cases
- Overflow test still properly triggers warnings as expected
- PNG backend now functional for standard dimensions

## Files Changed
- `src/fortplot_python_interface.f90` - Fixed pixel-to-inch conversion
- `test/test_scale_implementation.f90` - Corrected figsize values  
- `test/test_figure_state_isolation.f90` - Corrected figsize values
- `test/test_silent_output.f90` - Corrected figsize values
- `test/test_legend_comprehensive.f90` - Corrected figsize values

🤖 Generated with [Claude Code](https://claude.ai/code)