### PR TITLE
fix: enable library usage by setting library = true in fpm.toml fixes #728

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -12,7 +12,7 @@ auto-examples = true
 module-naming = false
 
 [install]
-library = false
+library = true
 test = false
 
 [fortran]


### PR DESCRIPTION
## Summary
- Fix FPM dependency integration by enabling library export
- Change `library = false` to `library = true` in fpm.toml
- Enables downstream projects to use fortplot as FPM dependency

## Technical Details
**Problem**: FPM integration blocked for all users
- `library = false` prevented FPM from exporting library for dependency usage
- Users could not integrate fortplot into their projects
- All new user adoption pathways blocked

**Solution**: Enable library export in FPM configuration
- Changed `library = false` to `library = true` in `[install]` section
- FPM now properly exports library for downstream dependencies
- Standard FPM dependency pattern now functional

## Test Plan
- [x] All test suite passes (full CI verification completed)
- [x] FMP dependency integration verified with test project
- [x] No regressions in library functionality
- [x] User workflow completely functional

## User Impact
- UNBLOCKS: All new user adoption completely blocked
- RESTORES: FPM dependency integration workflow
- ENABLES: Standard Fortran package management integration

**CRITICAL PRIORITY**: Emergency User Harm Mitigation - blocking all new users

🤖 Generated with [Claude Code](https://claude.ai/code)