### PR TITLE
fix(raster): align PNG tick labels with matplotlib spacing (fixes #1001)

### DIFF
--- a/src/backends/raster/fortplot_raster_axes.f90
+++ b/src/backends/raster/fortplot_raster_axes.f90
@@ -16,6 +16,12 @@ module fortplot_raster_axes
     public :: raster_draw_axes_and_labels, raster_render_ylabel
     public :: compute_title_position
 
+    ! Local spacing parameters for raster tick labels (pixels)
+    ! X tick labels are positioned X_TICK_LABEL_PAD pixels below the tick end
+    ! Y tick labels are right-aligned with a gap of Y_TICK_LABEL_RIGHT_PAD from the tick end
+    integer, parameter :: X_TICK_LABEL_PAD = 10
+    integer, parameter :: Y_TICK_LABEL_RIGHT_PAD = 14
+
 contains
 
     subroutine raster_draw_axes_and_labels(raster, width, height, plot_area, &
@@ -123,9 +129,9 @@ contains
             call process_latex_in_text(trim(tick_label), processed_text, processed_len)
             call escape_unicode_for_raster(processed_text(1:processed_len), escaped_text)
             text_width = calculate_text_width(trim(escaped_text))
-            ! Position x-tick label baseline 15 pixels below plot bottom (matplotlib-like)
+            ! Position x-tick label baseline TICK_MARK_LENGTH + X_TICK_LABEL_PAD below plot bottom (matplotlib-like)
             call render_text_to_image(raster%image_data, width, height, &
-                                    px - text_width/2, py + 15, trim(escaped_text), text_r, text_g, text_b)
+                                    px - text_width/2, py + tick_length + X_TICK_LABEL_PAD, trim(escaped_text), text_r, text_g, text_b)
         end do
     end subroutine raster_draw_x_axis_ticks
     
@@ -175,10 +181,10 @@ contains
             call escape_unicode_for_raster(processed_text(1:processed_len), escaped_text)
             text_width = calculate_text_width(trim(escaped_text))
             text_height = calculate_text_height(trim(escaped_text))
-            ! Right-align y-tick label so its right edge sits 19px left of plot area
-            ! With tick length 5px, set padding to 14px to achieve 19px total gap
+            ! Right-align y-tick label so its right edge sits (TICK_MARK_LENGTH + Y_TICK_LABEL_RIGHT_PAD)
+            ! pixels left of the plot area
             call render_text_to_image(raster%image_data, width, height, &
-                px - tick_length - text_width - 14, py - text_height/2, &
+                px - tick_length - text_width - Y_TICK_LABEL_RIGHT_PAD, py - text_height/2, &
                 trim(escaped_text), text_r, text_g, text_b)
         end do
     end subroutine raster_draw_y_axis_ticks

--- a/src/backends/raster/fortplot_raster_axes.f90
+++ b/src/backends/raster/fortplot_raster_axes.f90
@@ -131,7 +131,9 @@ contains
             text_width = calculate_text_width(trim(escaped_text))
             ! Position x-tick label baseline TICK_MARK_LENGTH + X_TICK_LABEL_PAD below plot bottom (matplotlib-like)
             call render_text_to_image(raster%image_data, width, height, &
-                                    px - text_width/2, py + tick_length + X_TICK_LABEL_PAD, trim(escaped_text), text_r, text_g, text_b)
+                                     px - text_width/2, &
+                                     py + tick_length + X_TICK_LABEL_PAD, &
+                                     trim(escaped_text), text_r, text_g, text_b)
         end do
     end subroutine raster_draw_x_axis_ticks
     
@@ -184,8 +186,9 @@ contains
             ! Right-align y-tick label so its right edge sits (TICK_MARK_LENGTH + Y_TICK_LABEL_RIGHT_PAD)
             ! pixels left of the plot area
             call render_text_to_image(raster%image_data, width, height, &
-                px - tick_length - text_width - Y_TICK_LABEL_RIGHT_PAD, py - text_height/2, &
-                trim(escaped_text), text_r, text_g, text_b)
+                                     px - tick_length - text_width - Y_TICK_LABEL_RIGHT_PAD, &
+                                     py - text_height/2, trim(escaped_text), &
+                                     text_r, text_g, text_b)
         end do
     end subroutine raster_draw_y_axis_ticks
     
@@ -271,8 +274,9 @@ contains
         y_pos = plot_area%bottom + plot_area%height / 2 - rotated_height / 2
         
         ! Composite the rotated text onto the main raster
-        call composite_bitmap_to_raster(raster%image_data, width, height, rotated_bitmap, &
-                                       rotated_width, rotated_height, x_pos, y_pos)
+        call composite_bitmap_to_raster(raster%image_data, width, height, &
+                                       rotated_bitmap, rotated_width, rotated_height, &
+                                       x_pos, y_pos)
         
         ! Clean up
         if (allocated(text_bitmap)) deallocate(text_bitmap)
@@ -297,7 +301,8 @@ contains
         ! Get current color and render title directly in pixel coordinates
         call raster%get_color_bytes(r, g, b)
         call render_text_to_image(raster%image_data, width, height, &
-                                 int(title_px), int(title_py), trim(escaped_text), r, g, b)
+                                 int(title_px), int(title_py), &
+                                 trim(escaped_text), r, g, b)
     end subroutine render_title_centered
 
     subroutine compute_title_position(plot_area, title_text, processed_text, processed_len, escaped_text, title_px, title_py)

--- a/src/backends/raster/fortplot_raster_axes.f90
+++ b/src/backends/raster/fortplot_raster_axes.f90
@@ -123,8 +123,9 @@ contains
             call process_latex_in_text(trim(tick_label), processed_text, processed_len)
             call escape_unicode_for_raster(processed_text(1:processed_len), escaped_text)
             text_width = calculate_text_width(trim(escaped_text))
+            ! Position x-tick label baseline 15 pixels below plot bottom (matplotlib-like)
             call render_text_to_image(raster%image_data, width, height, &
-                                    px - text_width/2, py + tick_length + 5, trim(escaped_text), text_r, text_g, text_b)
+                                    px - text_width/2, py + 15, trim(escaped_text), text_r, text_g, text_b)
         end do
     end subroutine raster_draw_x_axis_ticks
     
@@ -174,8 +175,10 @@ contains
             call escape_unicode_for_raster(processed_text(1:processed_len), escaped_text)
             text_width = calculate_text_width(trim(escaped_text))
             text_height = calculate_text_height(trim(escaped_text))
+            ! Right-align y-tick label so its right edge sits 19px left of plot area
+            ! With tick length 5px, set padding to 14px to achieve 19px total gap
             call render_text_to_image(raster%image_data, width, height, &
-                px - tick_length - text_width - 5, py - text_height/2, &
+                px - tick_length - text_width - 14, py - text_height/2, &
                 trim(escaped_text), text_r, text_g, text_b)
         end do
     end subroutine raster_draw_y_axis_ticks


### PR DESCRIPTION
### **User description**
Problem: PNG tick labels overlapped axes and were misaligned vs. matplotlib (issue #1001).\n\nSolution:\n- X-tick labels baseline moved to 15px below plot bottom (was tick_length+5=10).\n- Y-tick labels right-aligned to end exactly 19px left of plot area (padding 14px with 5px tick length).\n\nEvidence:\n- Local test suite: pytest (9 passed).\n- CI essential suite: make test-ci (passed).\n- Verifies against test/test_tick_vs_axis_labels.f90 expectations.\n\nScope: Raster (PNG) axis tick label positioning only. No API changes; minimal surgical edits in src/backends/raster/fortplot_raster_axes.f90.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix PNG tick label positioning alignment with matplotlib

- Adjust x-tick labels baseline to 15px below plot

- Right-align y-tick labels 19px left of plot area


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["X-tick labels"] --> B["Move baseline 15px below plot"]
  C["Y-tick labels"] --> D["Right-align 19px left of plot"]
  B --> E["Matplotlib-aligned spacing"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fortplot_raster_axes.f90</strong><dd><code>Adjust tick label positioning for matplotlib alignment</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backends/raster/fortplot_raster_axes.f90

<ul><li>Update x-tick label positioning from <code>py + tick_length + 5</code> to <code>py + 15</code><br> <li> Modify y-tick label padding from 5px to 14px for proper alignment<br> <li> Add explanatory comments for matplotlib-compatible spacing</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortplot/pull/1004/files#diff-a71133b874a2dddbd8478c749067d65e955638e0f428156487dff69dbe1fc3e1">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

