### PR TITLE
fix: Text not at all visible in PDFs (fixes #997)

### DIFF
--- a/scripts/test_pdf_text_visibility.py
+++ b/scripts/test_pdf_text_visibility.py
@@ -33,7 +33,9 @@ class TestPdfTextVisibility(unittest.TestCase):
             self.assertGreater(os.path.getsize(pdf_path), 200, "PDF file too small (likely empty)")
 
             # Check uncompressed content stream for text drawing operators
-            data = open(pdf_path, 'rb').read()
+            # Read file safely and search for uncompressed text operators
+            with open(pdf_path, 'rb') as f:
+                data = f.read()
             # PDF produced by fortplot is plain-text streams; search in bytes
             self.assertIn(b" Tj", data, "No text show (Tj) operator found in PDF")
             self.assertIn(b" Tm", data, "No text matrix (Tm) operator found in PDF")

--- a/scripts/test_pdf_text_visibility.py
+++ b/scripts/test_pdf_text_visibility.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+import os
+import sys
+import tempfile
+import unittest
+
+# Ensure local python package path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'python'))
+
+try:
+    import fortplot
+    FORTPLOT_AVAILABLE = True
+except Exception:
+    FORTPLOT_AVAILABLE = False
+
+
+@unittest.skipUnless(FORTPLOT_AVAILABLE, "fortplot not available")
+class TestPdfTextVisibility(unittest.TestCase):
+    def test_pdf_contains_text_commands(self):
+        # Create simple figure with visible text elements
+        fortplot.figure([6.4, 4.8])
+        fortplot.plot([0, 1], [0, 1], label="line")
+        fortplot.title("PDF Text Visibility Test")
+        fortplot.xlabel("X Label")
+        fortplot.ylabel("Y Label")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            pdf_path = os.path.join(tmp, "visibility_test.pdf")
+            fortplot.savefig(pdf_path)
+
+            # Sanity: file exists and is non-trivial size
+            self.assertTrue(os.path.exists(pdf_path), "PDF file was not created")
+            self.assertGreater(os.path.getsize(pdf_path), 200, "PDF file too small (likely empty)")
+
+            # Check uncompressed content stream for text drawing operators
+            data = open(pdf_path, 'rb').read()
+            # PDF produced by fortplot is plain-text streams; search in bytes
+            self.assertIn(b" Tj", data, "No text show (Tj) operator found in PDF")
+            self.assertIn(b" Tm", data, "No text matrix (Tm) operator found in PDF")
+            # Presence of Tj/Tm in stream indicates text is emitted and positioned
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/backends/vector/fortplot_pdf.f90
+++ b/src/backends/vector/fortplot_pdf.f90
@@ -87,6 +87,7 @@ contains
         call ctx%stream_writer%add_to_stream("1 J")
         call ctx%stream_writer%add_to_stream("1 j")
         call ctx%stream_writer%add_to_stream("0 0 0 RG")
+        call ctx%stream_writer%add_to_stream("0 0 0 rg")
         
         ctx%margins = plot_margins_t()
         call calculate_pdf_plot_area(width, height, ctx%margins, ctx%plot_area)
@@ -168,7 +169,13 @@ contains
         ! This provides better UX for low-level PDF API users
         call this%render_axes()
         
-        this%core_ctx%stream_data = this%stream_writer%content_stream
+        ! Combine vector (stream_writer) and text (core_ctx) streams
+        ! Draw vector content first, then text so labels appear on top
+        if (len_trim(this%core_ctx%stream_data) > 0) then
+            this%core_ctx%stream_data = trim(this%stream_writer%content_stream)//new_line('a')//trim(this%core_ctx%stream_data)
+        else
+            this%core_ctx%stream_data = this%stream_writer%content_stream
+        end if
         call write_pdf_file(this%core_ctx, filename, file_success)
         
         ! If file creation failed, continue without ERROR STOP

--- a/src/backends/vector/fortplot_pdf_text.f90
+++ b/src/backends/vector/fortplot_pdf_text.f90
@@ -65,8 +65,9 @@ contains
             this%fonts%get_helvetica_obj(), PDF_FONT_SIZE
         this%stream_data = this%stream_data // trim(adjustl(text_cmd)) // new_line('a')
         
-        ! Position text
-        write(text_cmd, '(F0.3, 1X, F0.3, " Td")') x, y
+        ! Position text using absolute positioning matrix
+        ! Use identity transform with translation (x,y)
+        write(text_cmd, '("1 0 0 1 ", F0.3, 1X, F0.3, " Tm")') x, y
         this%stream_data = this%stream_data // trim(adjustl(text_cmd)) // new_line('a')
         
         ! Show text
@@ -94,8 +95,13 @@ contains
         ! Begin text object
         this%stream_data = this%stream_data // "BT" // new_line('a')
         
-        ! Set initial position
-        write(text_cmd, '(F0.3, 1X, F0.3, " Td")') x, y
+        ! Select default font (Helvetica) for label-sized text
+        write(text_cmd, '("/F", I0, 1X, F0.1, " Tf")') &
+            this%fonts%get_helvetica_obj(), PDF_LABEL_SIZE
+        this%stream_data = this%stream_data // trim(adjustl(text_cmd)) // new_line('a')
+
+        ! Set initial absolute position
+        write(text_cmd, '("1 0 0 1 ", F0.3, 1X, F0.3, " Tm")') x, y
         this%stream_data = this%stream_data // trim(adjustl(text_cmd)) // new_line('a')
         
         ! Process text character by character
@@ -110,10 +116,16 @@ contains
         class(pdf_context_core), intent(inout) :: this
         real(wp), intent(in) :: x, y
         character(len=*), intent(in) :: text
+        character(len=256) :: font_cmd
         
         ! Begin text object
         this%stream_data = this%stream_data // "BT" // new_line('a')
         
+        ! Select default font (Helvetica) for label-sized text
+        write(font_cmd, '("/F", I0, 1X, F0.1, " Tf")') &
+            this%fonts%get_helvetica_obj(), PDF_LABEL_SIZE
+        this%stream_data = this%stream_data // trim(adjustl(font_cmd)) // new_line('a')
+
         ! Set up rotation matrix
         call setup_rotated_text_matrix(this, x, y)
         
@@ -216,8 +228,8 @@ contains
             this%fonts%get_helvetica_obj(), PDF_FONT_SIZE
         this%stream_data = this%stream_data // trim(adjustl(text_cmd)) // new_line('a')
         
-        ! Position and show text
-        write(text_cmd, '(F0.3, 1X, F0.3, " Td")') x, y
+        ! Position and show text using absolute positioning
+        write(text_cmd, '("1 0 0 1 ", F0.3, 1X, F0.3, " Tm")') x, y
         this%stream_data = this%stream_data // trim(adjustl(text_cmd)) // new_line('a')
         this%stream_data = this%stream_data // "(" // text // ") Tj" // new_line('a')
         
@@ -244,8 +256,8 @@ contains
             this%fonts%get_helvetica_obj(), PDF_TITLE_SIZE
         this%stream_data = this%stream_data // trim(adjustl(text_cmd)) // new_line('a')
         
-        ! Position and show text
-        write(text_cmd, '(F0.3, 1X, F0.3, " Td")') x, y
+        ! Position and show text using absolute positioning
+        write(text_cmd, '("1 0 0 1 ", F0.3, 1X, F0.3, " Tm")') x, y
         this%stream_data = this%stream_data // trim(adjustl(text_cmd)) // new_line('a')
         this%stream_data = this%stream_data // "(" // text // ") Tj" // new_line('a')
         


### PR DESCRIPTION
### **User description**
Summary: <brief summary>

Evidence: <logs/outputs/links>

Verification: <tests run>


___

### **PR Type**
Bug fix


___

### **Description**
- Fix PDF text visibility by adding fill color and merging streams

- Replace relative text positioning with absolute positioning

- Add comprehensive PDF text visibility test


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PDF Canvas"] --> B["Add Fill Color"]
  B --> C["Stream Merger"]
  C --> D["Absolute Positioning"]
  D --> E["Visible Text"]
  F["Test Suite"] --> G["Visibility Validation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fortplot_pdf.f90</strong><dd><code>Add fill color and stream merging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backends/vector/fortplot_pdf.f90

<ul><li>Add fill color command (<code>0 0 0 rg</code>) to PDF canvas initialization<br> <li> Implement stream merging to combine vector and text content<br> <li> Ensure text appears on top of vector graphics</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortplot/pull/1005/files#diff-b6808bf1e748bba7bf8e9d2e3508fbc62435a6cbc3eec4b2354c3f31bc319e2a">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>fortplot_pdf_text.f90</strong><dd><code>Fix text positioning and font selection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backends/vector/fortplot_pdf_text.f90

<ul><li>Replace relative positioning (<code>Td</code>) with absolute positioning (<code>Tm</code>)<br> <li> Add explicit font selection for mixed font text functions<br> <li> Fix text matrix positioning for all text drawing functions</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortplot/pull/1005/files#diff-5dc5350803725030be14248c6ca77228bec963801bd9e7a5cedd19462d86992e">+21/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_pdf_text_visibility.py</strong><dd><code>Add PDF text visibility test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/test_pdf_text_visibility.py

<ul><li>Create comprehensive test for PDF text visibility<br> <li> Verify presence of text operators (<code>Tj</code>, <code>Tm</code>) in PDF output<br> <li> Test with multiple text elements (title, labels, legend)</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortplot/pull/1005/files#diff-e4ceeaf7e5eb53f25ceeb6886ee8a97f2a06232e493f1a3b0fbf5a6e61378dd6">+46/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

