### PR TITLE
test: validate PNG zlib integrity; fixes #983

### DIFF
--- a/test/test_png_zlib_integrity_983.f90
+++ b/test/test_png_zlib_integrity_983.f90
@@ -1,12 +1,13 @@
 program test_png_zlib_integrity_983
-    use fortplot, only: figure, plot, savefig, wp
+    use fortplot, only: plot, savefig, wp
+    use iso_fortran_env, only: int64
     use fortplot_png_validation, only: validate_png_file
     implicit none
 
     character(len=*), parameter :: fn = 'test/output/png_zlib_integrity_983.png'
     logical :: exists
     integer :: unit
-    integer(8) :: fsize
+    integer(int64) :: fsize
 
     call plot([0.0_wp, 1.0_wp, 2.0_wp, 3.0_wp], [0.0_wp, 1.0_wp, 0.0_wp, 1.0_wp])
     call savefig(fn)
@@ -24,7 +25,7 @@ program test_png_zlib_integrity_983
     close(unit)
 
     print *, 'PNG size (bytes):', fsize
-    if (fsize > 200000_8) then
+    if (fsize > 200000_int64) then
         print *, 'ERROR: PNG too large for simple plot (possible compression failure)'
         error stop 2
     end if

--- a/test/test_png_zlib_integrity_983.f90
+++ b/test/test_png_zlib_integrity_983.f90
@@ -1,0 +1,33 @@
+program test_png_zlib_integrity_983
+    use fortplot, only: figure, plot, savefig, wp
+    use fortplot_png_validation, only: validate_png_file
+    implicit none
+
+    character(len=*), parameter :: fn = 'test/output/png_zlib_integrity_983.png'
+    logical :: exists
+    integer :: unit
+    integer(8) :: fsize
+
+    call plot([0.0_wp, 1.0_wp, 2.0_wp, 3.0_wp], [0.0_wp, 1.0_wp, 0.0_wp, 1.0_wp])
+    call savefig(fn)
+
+    call validate_png_file(fn, 'Issue #983: PNG zlib integrity')
+
+    inquire(file=fn, exist=exists)
+    if (.not. exists) then
+        print *, 'ERROR: PNG not created: ', fn
+        error stop 1
+    end if
+
+    open(newunit=unit, file=fn, access='stream', form='unformatted', status='old')
+    inquire(unit=unit, size=fsize)
+    close(unit)
+
+    print *, 'PNG size (bytes):', fsize
+    if (fsize > 200000_8) then
+        print *, 'ERROR: PNG too large for simple plot (possible compression failure)'
+        error stop 2
+    end if
+
+    print *, 'SUCCESS: PNG compression integrity validated (Issue #983)'
+end program test_png_zlib_integrity_983


### PR DESCRIPTION
### **User description**
Adds targeted regression test to verify PNG zlib stream integrity and guard against inflate errors (Issue #983).\n\nChanges:\n- New test: test_png_zlib_integrity_983.f90, which:\n  - Generates a simple PNG via public API\n  - Validates with pngcheck (when available)\n  - Enforces reasonable file size (<200 KB) to catch compression failures\n\nEvidence (local):\n- CI-fast suite: make test-ci -> PASSED\n- pytest (11 tests): PASSED\n- New test output:\n  - ✓ PNG validation passed: test/output/png_zlib_integrity_983.png\n  - PNG size (bytes): 24841\n  - SUCCESS: PNG compression integrity validated (Issue #983)\n\nThis confirms that current zlib compression produces valid, compact PNGs. The test prevents regressions that lead to 1.4MB files and FFmpeg "inflate returned error -3" failures.,--base,main,--head,fix/issue-983-critical-png-compression-completely-brok],


___

### **PR Type**
Tests


___

### **Description**
- Add regression test for PNG zlib compression integrity

- Validate PNG file creation and compression quality

- Prevent future PNG compression failures and oversized files

- Guard against zlib inflate errors in generated PNGs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Generate PNG plot"] --> B["Validate PNG file"]
  B --> C["Check file size"]
  C --> D["Verify compression integrity"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_png_zlib_integrity_983.f90</strong><dd><code>PNG zlib integrity regression test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/test_png_zlib_integrity_983.f90

<ul><li>Creates new regression test program for PNG zlib integrity<br> <li> Generates simple plot and saves as PNG file<br> <li> Validates PNG file using external validation module<br> <li> Checks file size to detect compression failures (max 200KB)</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortplot/pull/1007/files#diff-cca21b7ce06d0746b9559e4d55d41b174d4e39881e5205f31e708c45407941a1">+33/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

