### PR TITLE
fix(security): sanitize sensitive logs in file ops & zlib (fixes #961)

### DIFF
--- a/src/external/fortplot_zlib_huffman.f90
+++ b/src/external/fortplot_zlib_huffman.f90
@@ -2,6 +2,7 @@ module fortplot_zlib_huffman
     !! Huffman encoding and deflate compression functionality
     !! Split from fortplot_zlib.f90 for file size compliance (Issue #884)
     use, intrinsic :: iso_fortran_env, only: int8, int32
+    use fortplot_logging, only: log_error
     implicit none
     
     private
@@ -155,7 +156,7 @@ contains
         do i = 0, num_bits - 1
             ! Bounds check to prevent buffer overrun
             if (byte_pos > buffer_size) then
-                print *, "ERROR: Buffer overrun in write_bits - byte_pos:", byte_pos, "buffer_size:", buffer_size
+                call log_error('Compression error: buffer overrun in write_bits')
                 return
             end if
             

--- a/src/system/fortplot_file_operations.f90
+++ b/src/system/fortplot_file_operations.f90
@@ -5,6 +5,7 @@ module fortplot_file_operations
     !! restrictions to prevent unauthorized filesystem access.
 
     use fortplot_os_detection, only: is_debug_enabled, is_windows
+    use fortplot_logging,      only: log_warning
     use fortplot_path_operations, only: parse_path_segments
 
     implicit none
@@ -43,7 +44,7 @@ contains
         ! SECURITY LAYER 1: Basic path safety validation
         if (.not. is_basic_safe_path(normalized_path)) then
             if (debug_enabled) then
-                write(*,'(A,A)') 'SECURITY: Unsafe path blocked by security validation: ', trim(path)
+                call log_warning('Security: Unsafe path blocked by validation')
             end if
             success = .false.
             return
@@ -53,7 +54,7 @@ contains
         call check_allowed_path(normalized_path, is_allowed_path)
         if (.not. is_allowed_path) then
             if (debug_enabled) then
-                write(*,'(A,A)') 'SECURITY: Directory creation not allowed for path: ', trim(path)
+                call log_warning('Security: Directory creation not allowed for requested path')
             end if
             success = .false.
             return
@@ -63,8 +64,7 @@ contains
         call create_directory_recursive(path, success)
         
         if (.not. success .and. debug_enabled) then
-            write(*,'(A,A)') 'WARNING: Could not create directory: ', trim(path)
-            write(*,'(A)') '  Check filesystem permissions and parent directory existence'
+            call log_warning('Directory creation failed (check permissions and parent existence)')
         end if
     end subroutine create_directory_runtime
 

--- a/src/system/fortplot_file_operations.f90
+++ b/src/system/fortplot_file_operations.f90
@@ -6,7 +6,6 @@ module fortplot_file_operations
 
     use fortplot_os_detection, only: is_debug_enabled, is_windows
     use fortplot_logging,      only: log_warning
-    use fortplot_path_operations, only: parse_path_segments
 
     implicit none
     private


### PR DESCRIPTION
### **User description**
Replace raw prints with fortplot_logging and remove sensitive details from messages in file operations and zlib huffman. All tests pass locally.


___

### **PR Type**
Bug fix


___

### **Description**
- Replace raw print statements with controlled logging

- Sanitize sensitive path information from error messages

- Add fortplot_logging module imports for security compliance

- Remove detailed path exposure in security validation messages


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Raw print statements"] --> B["fortplot_logging calls"]
  C["Sensitive path details"] --> D["Generic security messages"]
  B --> E["Secure logging system"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fortplot_zlib_huffman.f90</strong><dd><code>Replace raw prints with secure logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/external/fortplot_zlib_huffman.f90

<ul><li>Add fortplot_logging module import<br> <li> Replace raw print with log_error call for buffer overrun<br> <li> Remove sensitive buffer details from error message</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortplot/pull/1008/files#diff-56e2fa52d60b95d18879254c3c4388421e0c49669aba04a6ba837a39df7f9109">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>fortplot_file_operations.f90</strong><dd><code>Sanitize sensitive path information in logs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/system/fortplot_file_operations.f90

<ul><li>Add fortplot_logging module import<br> <li> Replace write statements with log_warning calls<br> <li> Remove sensitive path information from security messages<br> <li> Sanitize directory creation failure messages</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortplot/pull/1008/files#diff-5022ab71925192248c02d0edbb020bbf059e4d321a4e407760837f5ab59383ea">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

