### PR TITLE
fix: harden Python bridge stdin processing (fixes #956)

### DIFF
--- a/app/fortplot_python_bridge.f90
+++ b/app/fortplot_python_bridge.f90
@@ -3,9 +3,17 @@ program fortplot_python_bridge
     !! This reads commands from stdin and executes fortplot functions
     use fortplot_matplotlib
     use iso_fortran_env, only: wp => real64
+    use fortplot_logging, only: log_error, log_warning
+    use fortplot_parameter_validation, only: validate_numeric_parameters, &
+         is_finite_safe, parameter_validation_result_t
+    use fortplot_validation_core, only: validate_file_path
     implicit none
     
-    character(len=256) :: command
+    integer, parameter :: MAX_CMD_LEN = 64
+    integer, parameter :: MAX_STR_LEN = 256
+    integer, parameter :: MAX_INPUT_ARRAY = 1000000
+    
+    character(len=MAX_STR_LEN) :: command
     real(wp), allocatable :: x(:), y(:), data(:)
     integer :: ios
     
@@ -14,8 +22,7 @@ program fortplot_python_bridge
     
     ! Main command processing loop
     do
-        read(*, '(A)', iostat=ios) command
-        if (ios /= 0) exit
+        if (.not. safe_read_line(MAX_CMD_LEN, command)) exit
         
         command = adjustl(trim(command))
         if (len_trim(command) == 0) cycle
@@ -68,11 +75,16 @@ contains
     
     subroutine process_plot_command(x_arr, y_arr)
         real(wp), allocatable, intent(inout) :: x_arr(:), y_arr(:)
-        character(len=256) :: label_str
-        integer :: n, i, ios
+        character(len=MAX_STR_LEN) :: label_str
+        integer :: n, ios
+        type(parameter_validation_result_t) :: v
         
         read(*, *, iostat=ios) n
         if (ios /= 0) return
+        if (n <= 0 .or. n > MAX_INPUT_ARRAY) then
+            call log_error('Invalid or excessive array size for PLOT')
+            return
+        end if
         
         if (allocated(x_arr)) deallocate(x_arr)
         if (allocated(y_arr)) deallocate(y_arr)
@@ -80,8 +92,13 @@ contains
         
         call read_xy_data(x_arr, y_arr, n)
         
-        read(*, '(A)', iostat=ios) label_str
-        if (ios == 0 .and. len_trim(label_str) > 0) then
+        ! Validate numeric inputs (NaN/infinity handling)
+        v = validate_numeric_parameters(x_arr, 'x', 'python_bridge_plot')
+        if (.not. v%is_valid) return
+        v = validate_numeric_parameters(y_arr, 'y', 'python_bridge_plot')
+        if (.not. v%is_valid) return
+        
+        if (safe_read_line(MAX_STR_LEN, label_str) .and. len_trim(label_str) > 0) then
             call plot(x_arr, y_arr, label=trim(label_str))
         else
             call plot(x_arr, y_arr)
@@ -90,11 +107,16 @@ contains
     
     subroutine process_scatter_command(x_arr, y_arr)
         real(wp), allocatable, intent(inout) :: x_arr(:), y_arr(:)
-        character(len=256) :: label_str
+        character(len=MAX_STR_LEN) :: label_str
         integer :: n, ios
+        type(parameter_validation_result_t) :: v
         
         read(*, *, iostat=ios) n
         if (ios /= 0) return
+        if (n <= 0 .or. n > MAX_INPUT_ARRAY) then
+            call log_error('Invalid or excessive array size for SCATTER')
+            return
+        end if
         
         if (allocated(x_arr)) deallocate(x_arr)
         if (allocated(y_arr)) deallocate(y_arr)
@@ -102,8 +124,13 @@ contains
         
         call read_xy_data(x_arr, y_arr, n)
         
-        read(*, '(A)', iostat=ios) label_str
-        if (ios == 0 .and. len_trim(label_str) > 0) then
+        ! Validate numeric inputs (NaN/infinity handling)
+        v = validate_numeric_parameters(x_arr, 'x', 'python_bridge_scatter')
+        if (.not. v%is_valid) return
+        v = validate_numeric_parameters(y_arr, 'y', 'python_bridge_scatter')
+        if (.not. v%is_valid) return
+        
+        if (safe_read_line(MAX_STR_LEN, label_str) .and. len_trim(label_str) > 0) then
             call scatter(x_arr, y_arr, label=trim(label_str))
         else
             call scatter(x_arr, y_arr)
@@ -112,11 +139,16 @@ contains
     
     subroutine process_histogram_command(data_arr)
         real(wp), allocatable, intent(inout) :: data_arr(:)
-        character(len=256) :: label_str
+        character(len=MAX_STR_LEN) :: label_str
         integer :: n, i, ios
+        type(parameter_validation_result_t) :: v
         
         read(*, *, iostat=ios) n
         if (ios /= 0) return
+        if (n <= 0 .or. n > MAX_INPUT_ARRAY) then
+            call log_error('Invalid or excessive array size for HISTOGRAM')
+            return
+        end if
         
         if (allocated(data_arr)) deallocate(data_arr)
         allocate(data_arr(n))
@@ -126,8 +158,10 @@ contains
             if (ios /= 0) exit
         end do
         
-        read(*, '(A)', iostat=ios) label_str
-        if (ios == 0 .and. len_trim(label_str) > 0) then
+        v = validate_numeric_parameters(data_arr, 'data', 'python_bridge_hist')
+        if (.not. v%is_valid) return
+        
+        if (safe_read_line(MAX_STR_LEN, label_str) .and. len_trim(label_str) > 0) then
             call hist(data_arr, label=trim(label_str))
         else
             call hist(data_arr)
@@ -151,36 +185,39 @@ contains
     end subroutine
     
     subroutine process_title_command()
-        character(len=256) :: title_str
-        integer :: ios
-        read(*, '(A)', iostat=ios) title_str
-        if (ios == 0) call title(trim(title_str))
+        character(len=MAX_STR_LEN) :: title_str
+        if (safe_read_line(MAX_STR_LEN, title_str)) call title(trim(title_str))
     end subroutine
     
     subroutine process_xlabel_command()
-        character(len=256) :: xlabel_str
-        integer :: ios
-        read(*, '(A)', iostat=ios) xlabel_str
-        if (ios == 0) call xlabel(trim(xlabel_str))
+        character(len=MAX_STR_LEN) :: xlabel_str
+        if (safe_read_line(MAX_STR_LEN, xlabel_str)) call xlabel(trim(xlabel_str))
     end subroutine
     
     subroutine process_ylabel_command()
-        character(len=256) :: ylabel_str
-        integer :: ios
-        read(*, '(A)', iostat=ios) ylabel_str
-        if (ios == 0) call ylabel(trim(ylabel_str))
+        character(len=MAX_STR_LEN) :: ylabel_str
+        if (safe_read_line(MAX_STR_LEN, ylabel_str)) call ylabel(trim(ylabel_str))
     end subroutine
     
     subroutine process_savefig_command()
-        character(len=256) :: filename_str
-        integer :: ios
-        read(*, '(A)', iostat=ios) filename_str
-        if (ios == 0) call savefig(trim(filename_str))
+        character(len=MAX_STR_LEN) :: filename_str
+        type(parameter_validation_result_t) :: path_validation
+        
+        if (.not. safe_read_line(MAX_STR_LEN, filename_str)) return
+        
+        path_validation = validate_file_path(trim(filename_str), check_parent=.true., context='python_bridge_savefig')
+        if (.not. path_validation%is_valid) then
+            call log_error('Invalid file path in SAVEFIG')
+            return
+        end if
+        
+        call savefig(trim(filename_str))
     end subroutine
     
     subroutine process_show_command()
         logical :: blocking_flag
         integer :: ios
+        blocking_flag = .true.
         read(*, *, iostat=ios) blocking_flag
         call show(blocking=blocking_flag)
     end subroutine
@@ -189,14 +226,42 @@ contains
         real(wp) :: xmin_val, xmax_val
         integer :: ios
         read(*, *, iostat=ios) xmin_val, xmax_val
-        if (ios == 0) call xlim(xmin_val, xmax_val)
+        if (ios /= 0) return
+        if (.not. is_finite_safe(xmin_val) .or. .not. is_finite_safe(xmax_val)) then
+            call log_error('Invalid numeric range in XLIM')
+            return
+        end if
+        call xlim(xmin_val, xmax_val)
     end subroutine
     
     subroutine process_ylim_command()
         real(wp) :: ymin_val, ymax_val
         integer :: ios
         read(*, *, iostat=ios) ymin_val, ymax_val
-        if (ios == 0) call ylim(ymin_val, ymax_val)
+        if (ios /= 0) return
+        if (.not. is_finite_safe(ymin_val) .or. .not. is_finite_safe(ymax_val)) then
+            call log_error('Invalid numeric range in YLIM')
+            return
+        end if
+        call ylim(ymin_val, ymax_val)
     end subroutine
+    
+    logical function safe_read_line(max_len, out)
+        !! Safely read a line from stdin, enforcing maximum length
+        integer, intent(in) :: max_len
+        character(len=*), intent(inout) :: out
+        character(len=4096) :: buf
+        integer :: ios
+        
+        safe_read_line = .false.
+        read(*, '(A)', iostat=ios) buf
+        if (ios /= 0) return
+        if (len_trim(buf) > max_len) then
+            call log_error('Input line exceeds maximum allowed length')
+            return
+        end if
+        out = buf(1:min(len(out), len_trim(buf)))
+        safe_read_line = .true.
+    end function safe_read_line
     
 end program fortplot_python_bridge


### PR DESCRIPTION
PROBLEM: Python bridge read() lacked input bounds; array sizes unbounded; filenames unsanitized.\nEVIDENCE: Reproduced via fpm run with >64-char command and huge array size; prior code accepted inputs.\nSOLUTION: \n- Added safe_read_line(max_len) with 4K temp buffer + max enforcement.\n- Capped array sizes (MAX_INPUT_ARRAY=1_000_000) with error logging.\n- Validated numeric inputs using validate_numeric_parameters.\n- Validated save paths with validate_file_path(check_parent=.true.).\n- Guarded xlim/ylim with is_finite_safe.\n\nTests run:\n- make test-ci: all essential tests passed, app compiled.\n- Manual runs: long command rejected; huge n rejected; SAVEFIG path validated.\nLogs:\n- Long cmd: '[ERROR] Input line exceeds maximum allowed length'\n- Huge n: '[ERROR] Invalid or excessive array size for PLOT'\n- SAVEFIG: warnings for parent dir + file I/O error as expected when path missing.\n