### PR TITLE
fix(python): accept matplotlib-like kwargs in scatter() (fixes #944)

### DIFF
--- a/python/fortplot/data.py
+++ b/python/fortplot/data.py
@@ -14,7 +14,23 @@ def _ensure_array(obj):
         return np.array(obj)
     return obj
 
-def scatter(x, y, c=None, s=None, label=""):
+def scatter(
+    x,
+    y,
+    c=None,
+    s=None,
+    label="",
+    marker=None,
+    alpha=None,
+    edgecolors=None,
+    linewidths=None,
+    markersize=None,
+    color=None,
+    colormap=None,
+    vmin=None,
+    vmax=None,
+    show_colorbar=None,
+):
     """Create a scatter plot.
     
     Parameters
@@ -23,11 +39,29 @@ def scatter(x, y, c=None, s=None, label=""):
         The horizontal and vertical coordinates of the data points.
         x and y must be the same size.
     c : array-like, optional
-        The color specification (currently not implemented).
-    s : array-like, optional  
-        The marker sizes (currently not implemented).
+        Color values per-point (accepted for API compatibility).
+    s : array-like, optional
+        Marker sizes per-point (accepted for API compatibility).
     label : str, optional
         Label for the plot, used in legend. Default is empty string.
+    marker : str, optional
+        Matplotlib-style marker specification (accepted for API compatibility).
+    alpha : float, optional
+        Global marker opacity in [0,1] (accepted for API compatibility).
+    edgecolors : str or tuple, optional
+        Edge color for markers (accepted for API compatibility).
+    linewidths : float or array-like, optional
+        Line width of marker edges (accepted for API compatibility).
+    markersize : float, optional
+        Marker size when using a uniform size (accepted for API compatibility).
+    color : tuple, optional
+        RGB triple in [0,1] for uniform color (accepted for API compatibility).
+    colormap : str, optional
+        Name of colormap when using scalar array `c` (accepted for API compatibility).
+    vmin, vmax : float, optional
+        Color scaling bounds (accepted for API compatibility).
+    show_colorbar : bool, optional
+        Whether to display a colorbar for scalar `c` (accepted for API compatibility).
         
     Examples
     --------
@@ -45,6 +79,9 @@ def scatter(x, y, c=None, s=None, label=""):
     """
     x = _ensure_array(x)
     y = _ensure_array(y)
+    # Forward to the Fortran bridge. The current bridge supports label;
+    # additional matplotlib-compatible kwargs are accepted here for API
+    # compatibility but may be ignored by the backend until fully mapped.
     _fortplot.fortplot.scatter(x, y, label)
 
 def histogram(data, bins=None, density=False, label=""):

--- a/scripts/test_python_scatter_kwargs.py
+++ b/scripts/test_python_scatter_kwargs.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'python'))
+
+import numpy as np
+import pytest
+
+
+def test_scatter_accepts_matplotlib_kwargs(tmp_path):
+    import fortplot
+
+    x = np.linspace(0, 1, 10)
+    y = np.linspace(1, 0, 10)
+
+    # Should not raise for common matplotlib kwargs
+    fortplot.figure()
+    fortplot.scatter(
+        x,
+        y,
+        marker='o',
+        alpha=0.5,
+        edgecolors='k',
+        linewidths=2.0,
+        label='pts',
+    )
+
+    out = tmp_path / "scatter_kwargs.png"
+    fortplot.savefig(str(out))
+    assert out.exists() and out.stat().st_size > 0
+


### PR DESCRIPTION
- Problem: Python scatter() rejected standard matplotlib kwargs (marker, alpha, edgecolors, linewidths) causing 'unexpected keyword' errors.\n- Solution: Updated python/fortplot/data.py scatter() signature to accept these kwargs (no-op pass-through for now to maintain compatibility without altering backend protocol). Added pytest scripts/test_python_scatter_kwargs.py to verify file save after calling scatter with these kwargs.\n- Tests: Ran CI-optimized suite (make test-ci) and full pytest; all passed locally.\n- Scope: Minimal Python-side API completeness; no Fortran changes.\n