### PR TITLE
refactor(pdf): reduce fortplot_pdf.f90 to <500 lines (fixes #941)

### DIFF
--- a/src/backends/vector/fortplot_pdf_coordinate.f90
+++ b/src/backends/vector/fortplot_pdf_coordinate.f90
@@ -10,7 +10,7 @@ module fortplot_pdf_coordinate
                                    draw_pdf_x_marker
     use fortplot_plot_data, only: plot_data_t
     use fortplot_legend, only: legend_entry_t
-    use fortplot_margins, only: plot_area_t
+    use fortplot_margins, only: plot_area_t, plot_margins_t
     implicit none
     
     private
@@ -31,6 +31,7 @@ module fortplot_pdf_coordinate
     public :: pdf_set_legend_border_width, pdf_calculate_legend_position
     public :: pdf_extract_rgb_data, pdf_get_png_data
     public :: pdf_prepare_3d_data, pdf_render_ylabel
+    public :: calculate_pdf_plot_area
     
 contains
 
@@ -267,5 +268,18 @@ contains
             pdf_y = (y - y_min) * y_scale + plot_bottom
         end if
     end subroutine safe_coordinate_transform
-    
+
+    subroutine calculate_pdf_plot_area(canvas_width, canvas_height, margins, plot_area)
+        !! Calculate plot area for PDF backend (mathematical coordinates: Y=0 at bottom)
+        integer, intent(in) :: canvas_width, canvas_height
+        type(plot_margins_t), intent(in) :: margins
+        type(plot_area_t), intent(out) :: plot_area
+        ! Calculate positions for mathematical coordinate system (Y=0 at bottom)
+        plot_area%left = int(margins%left * real(canvas_width, wp))
+        plot_area%width = int(margins%right * real(canvas_width, wp)) - plot_area%left
+        ! For PDF mathematical coordinates (Y=0 at bottom), use direct calculation
+        plot_area%bottom = int(margins%bottom * real(canvas_height, wp))
+        plot_area%height = int(margins%top * real(canvas_height, wp)) - plot_area%bottom
+    end subroutine calculate_pdf_plot_area
+
 end module fortplot_pdf_coordinate

--- a/test/test_pdf_plot_area_calculation.f90
+++ b/test/test_pdf_plot_area_calculation.f90
@@ -1,0 +1,43 @@
+program test_pdf_plot_area_calculation
+    !! Verifies calculate_pdf_plot_area() after refactor to coordinate module.
+    !! Ensures mathematical Y-up coordinates are handled correctly.
+
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    use fortplot_margins, only: plot_margins_t, plot_area_t
+    use fortplot_pdf_coordinate, only: calculate_pdf_plot_area
+    implicit none
+
+    integer :: cw, ch
+    type(plot_margins_t) :: m
+    type(plot_area_t) :: a
+
+    cw = 640
+    ch = 480
+
+    m%left = 0.10_wp
+    m%right = 0.90_wp
+    m%bottom = 0.10_wp
+    m%top = 0.90_wp
+
+    call calculate_pdf_plot_area(cw, ch, m, a)
+
+    call assert_equal_int(a%left, 64, 'left')
+    call assert_equal_int(a%width, 512, 'width')
+    call assert_equal_int(a%bottom, 48, 'bottom')
+    call assert_equal_int(a%height, 384, 'height')
+
+    print *, 'PASS: calculate_pdf_plot_area returns expected plot area'
+
+contains
+
+    subroutine assert_equal_int(got, expect, label)
+        integer, intent(in) :: got, expect
+        character(len=*), intent(in) :: label
+        if (got /= expect) then
+            print *, 'FAIL: ', trim(label), ' got=', got, ' expect=', expect
+            stop 1
+        end if
+    end subroutine assert_equal_int
+
+end program test_pdf_plot_area_calculation
+


### PR DESCRIPTION
### **User description**
Problem: src/backends/vector/fortplot_pdf.f90 exceeded the 500-line module guideline (516 lines), hurting maintainability.\n\nSolution:\n- Moved calculate_pdf_plot_area() into fortplot_pdf_coordinate to keep layout/coordinate logic together.\n- Trimmed redundant comments and tightened whitespace in fortplot_pdf.f90.\n- No functional changes; preserved public API and behavior.\n\nEvidence:\n- CI-fast test suite passes locally (make test-ci).\n- New line count for fortplot_pdf.f90: 486 (<500).\n\nNotes on dedup/simplification:\n- Reused existing fortplot_pdf_coordinate module rather than adding new helpers.\n- Kept surface area minimal—no new public APIs introduced.\n


___

### **PR Type**
Enhancement


___

### **Description**
- Moved `calculate_pdf_plot_area()` from main module to coordinate module

- Reduced fortplot_pdf.f90 from 516 to 486 lines (<500 limit)

- Cleaned up redundant comments and whitespace

- Maintained all public APIs and functionality


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["fortplot_pdf.f90"] -- "move function" --> B["fortplot_pdf_coordinate.f90"]
  A -- "remove comments" --> C["Reduced line count"]
  C -- "meets guideline" --> D["<500 lines"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fortplot_pdf.f90</strong><dd><code>Remove function and clean up comments</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backends/vector/fortplot_pdf.f90

<ul><li>Removed <code>calculate_pdf_plot_area()</code> function (moved to coordinate <br>module)<br> <li> Trimmed redundant comments throughout the file<br> <li> Simplified code formatting and whitespace<br> <li> Reduced total lines from 516 to 486</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortplot/pull/1015/files#diff-b6808bf1e748bba7bf8e9d2e3508fbc62435a6cbc3eec4b2354c3f31bc319e2a">+2/-43</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>fortplot_pdf_coordinate.f90</strong><dd><code>Add plot area calculation function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backends/vector/fortplot_pdf_coordinate.f90

<ul><li>Added <code>calculate_pdf_plot_area()</code> function from main PDF module<br> <li> Added <code>plot_margins_t</code> import for the moved function<br> <li> Exported the new function in public interface</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortplot/pull/1015/files#diff-985c0f2c57917997c690c3d591e9299abd1fd79506593c8c14a50bc54c6e521f">+16/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

