### PR TITLE
fix: CRITICAL: Python bridge executable hangs indefinitely on ex

### DIFF
--- a/app/fortplot_python_bridge.f90
+++ b/app/fortplot_python_bridge.f90
@@ -8,7 +8,6 @@ program fortplot_python_bridge
          is_finite_safe, parameter_validation_result_t
     use fortplot_validation_core, only: validate_file_path
     implicit none
-    
     integer, parameter :: MAX_CMD_LEN = 64
     integer, parameter :: MAX_STR_LEN = 256
     integer, parameter :: MAX_INPUT_ARRAY = 1000000
@@ -16,6 +15,32 @@ program fortplot_python_bridge
     character(len=MAX_STR_LEN) :: command
     real(wp), allocatable :: x(:), y(:), data(:)
     integer :: ios
+    ! Command-line handling
+    integer :: argc, i
+    character(len=64) :: arg
+
+    argc = command_argument_count()
+    if (argc > 0) then
+        do i = 1, argc
+            call get_command_argument(i, arg)
+            if (trim(adjustl(arg)) == '--help' .or. trim(adjustl(arg)) == '-h') then
+                write(*, '(A)') 'fortplot_python_bridge - stdin-driven plotting bridge'
+                write(*, '(A)') 'Usage:'
+                write(*, '(A)') '  - Run without arguments and communicate via stdin.'
+                write(*, '(A)') '  - Example sequence:'
+                write(*, '(A)') '      FIGURE'
+                write(*, '(A)') '      640 480'
+                write(*, '(A)') '      PLOT'
+                write(*, '(A)') '      <n> then n lines of x, then n lines of y'
+                write(*, '(A)') '      TITLE'
+                write(*, '(A)') '      <text>'
+                write(*, '(A)') '      SAVEFIG'
+                write(*, '(A)') '      <filename>'
+                write(*, '(A)') '      QUIT'
+                stop
+            end if
+        end do
+    end if
     
     ! Initialize figure
     call figure()

--- a/scripts/test_python_bridge_security.py
+++ b/scripts/test_python_bridge_security.py
@@ -6,6 +6,7 @@ Covers:
 - Command length limit enforcement
 - Excessive array size rejection for PLOT
 - SAVEFIG empty path validation
+- `--help`/`-h` argument prints usage and exits
 
 Intended to be fast and run in CI-fast set.
 """
@@ -29,6 +30,20 @@ def run_bridge():
         bufsize=1,
     )
     return proc
+
+def test_help_argument_exits_quickly():
+    exe = FortplotModule()._find_bridge_executable()
+    result = subprocess.run(
+        [exe, "--help"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, timeout=5
+    )
+    out = result.stdout or ""
+    err = result.stderr or ""
+    combined = out + err
+    assert result.returncode == 0, f"--help should exit 0, got {result.returncode}. Output:\n{combined}"
+    assert "fortplot_python_bridge" in combined and "Usage:" in combined, (
+        "Help output missing expected markers. Output was:\n" + combined
+    )
+    print('✓ --help prints usage and exits')
 
 
 def test_long_command_rejected():
@@ -100,6 +115,7 @@ def test_savefig_empty_path_rejected():
 
 
 def main():
+    test_help_argument_exits_quickly()
     test_long_command_rejected()
     test_plot_excessive_array_size_rejected()
     test_savefig_empty_path_rejected()
@@ -108,4 +124,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-


### PR DESCRIPTION
### **PR Type**
Bug fix, Tests


___

### **Description**
- Add `--help` argument handling to prevent indefinite hanging

- Include usage information display for command-line help

- Add test coverage for help argument behavior

- Fix critical issue where bridge executable would hang on exit


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Command line args"] --> B["Check for --help/-h"]
  B --> C["Print usage info"]
  C --> D["Exit cleanly"]
  B --> E["Continue normal stdin processing"]
  F["Add test coverage"] --> G["Verify help behavior"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fortplot_python_bridge.f90</strong><dd><code>Add help argument handling and usage display</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/fortplot_python_bridge.f90

<ul><li>Add command-line argument parsing for <code>--help</code> and <code>-h</code> flags<br> <li> Display comprehensive usage information when help is requested<br> <li> Exit cleanly after showing help to prevent hanging</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortplot/pull/1016/files#diff-cbe0c6fb949f95d1cb9eb21d9ec1f479aa63ff061d8e95b6e391f7ddd1f3d5d0">+26/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_python_bridge_security.py</strong><dd><code>Add test coverage for help argument behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/test_python_bridge_security.py

<ul><li>Add <code>test_help_argument_exits_quickly()</code> function to verify help <br>behavior<br> <li> Update test documentation to include help argument coverage<br> <li> Integrate help test into main test execution flow</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortplot/pull/1016/files#diff-bb99e91985539c6f79b36b091df0f509ffe0bf8e4616cc563263666285082c30">+16/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

