### PR TITLE
fix: CODE QUALITY: Unused deprecated warning mode functions create ma (fixes #911)

### DIFF
--- a/src/utilities/validation/fortplot_parameter_validation.f90
+++ b/src/utilities/validation/fortplot_parameter_validation.f90
@@ -18,7 +18,7 @@ module fortplot_parameter_validation
     ! Re-export context system for backward compatibility  
     use fortplot_validation_context, only: validation_warning, validation_error, &
                                           validation_warning_with_context, validation_error_with_context, &
-                                          default_validation_context, set_warning_mode, &
+                                          default_validation_context, &
                                           validation_context_t, parameter_validation_result_t, &
                                           WARNING_MODE_ALL, WARNING_MODE_ERRORS, WARNING_MODE_SILENT
     implicit none
@@ -40,7 +40,6 @@ module fortplot_parameter_validation
     public :: validation_warning_with_context
     public :: validation_error_with_context
     public :: default_validation_context
-    public :: set_warning_mode
     public :: validation_context_t
     public :: parameter_validation_result_t
     public :: WARNING_MODE_ALL, WARNING_MODE_ERRORS, WARNING_MODE_SILENT

--- a/src/utilities/validation/fortplot_validation_context.f90
+++ b/src/utilities/validation/fortplot_validation_context.f90
@@ -38,7 +38,6 @@ module fortplot_validation_context
     public :: validation_warning_with_context
     public :: validation_error_with_context
     public :: default_validation_context
-    public :: set_warning_mode
     public :: validation_context_t
     public :: parameter_validation_result_t
     public :: WARNING_MODE_ALL, WARNING_MODE_ERRORS, WARNING_MODE_SILENT
@@ -53,23 +52,7 @@ module fortplot_validation_context
     
 contains
     
-    ! Set warning output mode for advanced users
-    ! DEPRECATED: Use validation_context_t instead for thread-safe operation
-    subroutine set_warning_mode(mode)
-        integer, intent(in) :: mode
-        
-        ! Issue #871: Global state deprecated for thread safety
-        print *, "[DEPRECATED] set_warning_mode: Global warning state violates thread safety."
-        print *, "             Use validation_context_t parameter in new validation functions."
-        print *, "             This function will be removed in v2.0."
-        
-        if (mode >= WARNING_MODE_ALL .and. mode <= WARNING_MODE_SILENT) then
-            current_warning_mode = mode
-        else
-            call validation_warning("Invalid warning mode, using default (all warnings)", &
-                                   "set_warning_mode")
-        end if
-    end subroutine set_warning_mode
+    ! DEPRECATED: validation_warning is legacy; prefer validation_warning_with_context
     
     ! Output warning message with context (with spam prevention)
     subroutine validation_warning(message, context)
@@ -112,6 +95,7 @@ contains
         end if
     end subroutine validation_warning
     
+    ! DEPRECATED: validation_error is legacy; prefer validation_error_with_context
     ! Output error message with context
     subroutine validation_error(message, context)
         character(len=*), intent(in) :: message

--- a/test/test_issue_871_global_state_fix.f90
+++ b/test/test_issue_871_global_state_fix.f90
@@ -42,8 +42,7 @@ program test_issue_871_global_state_fix
     
     ! Test 2: Legacy compatibility (still uses global state but with deprecation warning)
     write(output_unit, '(A)') ""
-    write(output_unit, '(A)') "Test 2: Legacy global state compatibility (with deprecation warning)"
-    call set_warning_mode(WARNING_MODE_ERRORS)
+    write(output_unit, '(A)') "Test 2: Legacy global state compatibility (without global mode)"
     result = validate_plot_dimensions(8.0_wp, 6.0_wp)
     if (result%is_valid .and. .not. result%has_warning) then
         write(output_unit, '(A)') "  ✓ PASS: Legacy function still works"


### PR DESCRIPTION
- Summary: Remove unused deprecated `set_warning_mode`; mark legacy `validation_warning`/`validation_error` as deprecated; update one test to stop calling removed API.
- Tests: Ran `make test-ci` (300s cap) before/after; all passed locally.
- Scope: Only validation modules and one test updated; no behavior change for non-deprecated APIs.
- Evidence: CI-fast output shows full pass; grep shows no remaining call sites to `set_warning_mode`.