### PR TITLE
fix: pcolormesh linear gradient cut in docs (fixes #1032)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ ARGS ?=
 
 # FPM flags for different build targets
 FPM_FLAGS_LIB = --flag -fPIC
-FPM_FLAGS_TEST = 
+FPM_FLAGS_TEST =
 FPM_FLAGS_DEFAULT = $(FPM_FLAGS_LIB)
 
 .PHONY: all build example debug test clean help matplotlib example_python example_matplotlib doc coverage create_build_dirs create_test_dirs validate-output test-docs verify-functionality verify-setup verify-size-compliance issue-branch issue-open-pr pr-merge pr-cleanup issue-loop issue-loop-dry
@@ -27,7 +27,7 @@ example: create_build_dirs
 debug:
 	fpm run $(FPM_FLAGS_TEST) $(ARGS)
 
-# Run tests  
+# Run tests
 test: create_test_dirs
 	fpm test $(FPM_FLAGS_TEST) $(ARGS)
 

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,8 @@ test-ci:
 	@python3 scripts/test_pdf_axes_color_black.py || exit 1
 	@# Security regression tests for Python bridge stdin handling (PR #1010)
 	@python3 scripts/test_python_bridge_security.py || exit 1
+	@# Regression for filled-quad edge coverage (prevents 1px cuts on borders)
+	@fpm test $(FPM_FLAGS_TEST) --target test_quad_fill_edges || exit 1
 	@# Guard against redundant pcolormesh tests (Issue #897)
 	@./scripts/test_pcolormesh_guard.sh || exit 1
 	@echo "CI essential test suite completed successfully"

--- a/Makefile
+++ b/Makefile
@@ -99,8 +99,10 @@ run-release:
 
 # Build documentation with FORD
 doc:
-	# Ensure critical example media exist for docs (fixes #858)
+	# Ensure critical example media exist for docs (fixes #858, #1032)
+	# Generate streamplot and pcolormesh demos so images are available in docs
 	$(MAKE) example ARGS="streamplot_demo" >/dev/null
+	$(MAKE) example ARGS="pcolormesh_demo" >/dev/null
 	# Run FORD to generate documentation structure
 	ford doc.md
 	# Copy example media files to doc build directory AFTER running FORD

--- a/test/test_quad_fill_edges.f90
+++ b/test/test_quad_fill_edges.f90
@@ -1,0 +1,39 @@
+program test_quad_fill_edges
+    !! Regression test: ensure filled quads reach image borders (no 1px cut)
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    use fortplot_raster_primitives, only: draw_filled_quad_raster, color_to_byte
+    implicit none
+
+    integer, parameter :: width = 128, height = 96
+    integer(1), allocatable :: image_data(:)
+    real(wp) :: xq(4), yq(4)
+    integer :: idx_center_right, idx_top_center
+    logical :: pass
+
+    allocate(image_data(width*height*3))
+    image_data = 0_1
+
+    ! Full-coverage quad: corners at the raster bounds
+    xq = [1.0_wp, real(width, wp), real(width, wp), 1.0_wp]
+    yq = [1.0_wp, 1.0_wp, real(height, wp), real(height, wp)]
+
+    call draw_filled_quad_raster(image_data, width, height, xq, yq, 1.0_wp, 0.0_wp, 0.0_wp)
+
+    ! Sample a pixel on the right edge midpoint (should be filled red)
+    idx_center_right = 3 * ((height/2 - 1) * width + (width - 1)) + 1
+    ! Sample a pixel on the top edge midpoint (should be filled red)
+    idx_top_center = 3 * ((0) * width + (width/2 - 1)) + 1
+
+    pass = (image_data(idx_center_right) == color_to_byte(1.0_wp)) .and. &
+           (image_data(idx_center_right+1) == 0_1) .and. &
+           (image_data(idx_center_right+2) == 0_1) .and. &
+           (image_data(idx_top_center) == color_to_byte(1.0_wp))
+
+    if (pass) then
+        print *, 'PASS: Filled quad reaches image borders (no 1px cut)'
+    else
+        print *, 'FAIL: Filled quad does not reach image borders'
+        stop 1
+    end if
+end program test_quad_fill_edges
+

--- a/test/test_quad_fill_edges.f90
+++ b/test/test_quad_fill_edges.f90
@@ -36,4 +36,3 @@ program test_quad_fill_edges
         stop 1
     end if
 end program test_quad_fill_edges
-


### PR DESCRIPTION
This fixes the example page image issue by generating pcolormesh demo media during docs build. Also adds a regression test to ensure filled quads reach image borders (guards against 1px edge cuts).