### PR TITLE
fix: ARCHITECTURAL CRISIS: 768-line ASCII backend violates 500-line limit (fixes #747)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,10 @@ jobs:
         mkdir -p output/example/fortran/legend_demo
         mkdir -p output/example/fortran/marker_demo
 
+    - name: Verify file size compliance (limits)
+      if: matrix.os == 'ubuntu-latest'
+      run: make verify-size-compliance
+
     - name: Build project
       shell: bash
       run: |


### PR DESCRIPTION
Enforce file size compliance in CI via Makefile target to guard against regressions.\n\n- Adds a CI step on Ubuntu to run `make verify-size-compliance` which verifies Fortran file lengths against target/hard limits.\n- Current state is compliant for ASCII backend: `src/backends/ascii/fortplot_ascii.f90` is 499 lines (<=500).\n- This ensures future changes cannot reintroduce the oversized-file regression without CI catching it.\n\nTests: \n- Baseline `make test` and `fpm test` pass locally within 120s.\n- `make verify-size-compliance` reports no critical violations and only advisory warnings outside ASCII backend.\n\nThis change is minimal and scoped only to CI, aligning with the issue intent to keep ASCII backend under limits.