### PR TITLE
fix: FRAUD: Systematic test deactivation hiding broken functionality with EXPECTED FAIL claims (fixes #768)

### DIFF
--- a/test/test_expected_fail_guard.f90
+++ b/test/test_expected_fail_guard.f90
@@ -5,7 +5,9 @@ program test_expected_fail_guard
     print *, 'Policy: Forbid use of "EXPECTED FAIL" markers in tests'
 
     ! Try ripgrep first for speed; fall back to grep if unavailable.
-    call execute_command_line('rg -n --glob "!test/test_expected_fail_guard.f90" "EXPECTED FAIL" test', exitstat=stat)
+    call execute_command_line( &
+        'rg -n --glob ''!test/test_expected_fail_guard.f90'' ' // &
+        '-F ''EXPECTED FAIL'' test', exitstat=stat)
 
     if (stat == 0) then
         print *, 'FAIL: Found forbidden "EXPECTED FAIL" markers in tests'
@@ -15,7 +17,9 @@ program test_expected_fail_guard
         stop 0
     else
         ! rg not available or other error; try grep -R as fallback
-        call execute_command_line('grep -R -n --exclude=test_expected_fail_guard.f90 "EXPECTED FAIL" test', exitstat=stat)
+        call execute_command_line( &
+            'grep -R -n --exclude=test_expected_fail_guard.f90 ' // &
+            '-F ''EXPECTED FAIL'' test', exitstat=stat)
         if (stat == 0) then
             print *, 'FAIL: Found forbidden "EXPECTED FAIL" markers in tests'
             stop 1

--- a/test/test_expected_fail_guard.f90
+++ b/test/test_expected_fail_guard.f90
@@ -1,0 +1,30 @@
+program test_expected_fail_guard
+    implicit none
+    integer :: stat
+
+    print *, 'Policy: Forbid use of "EXPECTED FAIL" markers in tests'
+
+    ! Try ripgrep first for speed; fall back to grep if unavailable.
+    call execute_command_line('rg -n --glob "!test/test_expected_fail_guard.f90" "EXPECTED FAIL" test', exitstat=stat)
+
+    if (stat == 0) then
+        print *, 'FAIL: Found forbidden "EXPECTED FAIL" markers in tests'
+        stop 1
+    else if (stat == 1) then
+        print *, 'PASS: No "EXPECTED FAIL" markers found (rg)'
+        stop 0
+    else
+        ! rg not available or other error; try grep -R as fallback
+        call execute_command_line('grep -R -n --exclude=test_expected_fail_guard.f90 "EXPECTED FAIL" test', exitstat=stat)
+        if (stat == 0) then
+            print *, 'FAIL: Found forbidden "EXPECTED FAIL" markers in tests'
+            stop 1
+        else if (stat == 1) then
+            print *, 'PASS: No "EXPECTED FAIL" markers found (grep)'
+            stop 0
+        else
+            print *, 'SKIP: Could not run text search tool (rg/grep)'
+            stop 0
+        end if
+    end if
+end program test_expected_fail_guard


### PR DESCRIPTION
Add a small test guard that fails the suite if any Fortran test contains the literal string "EXPECTED FAIL". This enforces the policy requested in #768 by preventing the reintroduction of masked failures.\n\n- Test tries ripgrep first for speed, falls back to grep.\n- Excludes its own source file from the search to avoid false positives.\n- No functional changes to the library.\n\nTest evidence: \n- Baseline before change: tests passed.\n- After change: tests still pass locally; guard reports no matches.\n