### PR TITLE
fix: enable histogram tests; guard invalid inputs (fixes #285)

### DIFF
--- a/src/figures/plot_types/fortplot_figure_histogram.f90
+++ b/src/figures/plot_types/fortplot_figure_histogram.f90
@@ -117,11 +117,19 @@ contains
         ! Set defaults
         n_bins = 10
         if (present(bins)) n_bins = bins
-        
+
+        ! Guard against invalid inputs (graceful no-op)
+        if (size(data) == 0) then
+            return
+        end if
+        if (n_bins <= 0) then
+            return
+        end if
+
         normalize_density = .false.
         if (present(density)) normalize_density = density
-        
-        ! Calculate histogram
+
+        ! Calculate histogram (validated inputs)
         call calculate_histogram_bins(data, n_bins, normalize_density, bin_edges, bin_counts)
         
         ! Create line data for visualization

--- a/test/test_histogram_functionality.f90
+++ b/test/test_histogram_functionality.f90
@@ -164,6 +164,9 @@ contains
         ! This should not crash with segmentation fault
         call fig%hist(data, bins=0)
         
+        ! Verify no plot was added
+        call assert_equal(real(fig%plot_count, wp), 0.0_wp, "Zero bins adds no plots")
+        
         print *, '  PASS: Zero bins handled without segmentation fault'
         call end_test()
     end subroutine test_histogram_zero_bins
@@ -179,6 +182,9 @@ contains
         
         ! This should not crash with segmentation fault
         call fig%hist(data, bins=-5)
+        
+        ! Verify no plot was added
+        call assert_equal(real(fig%plot_count, wp), 0.0_wp, "Negative bins adds no plots")
         
         print *, '  PASS: Negative bins handled without segmentation fault'
         call end_test()

--- a/test/test_histogram_functionality.f90
+++ b/test/test_histogram_functionality.f90
@@ -20,7 +20,7 @@ program test_histogram_functionality
     integer :: test_count = 0
     integer :: pass_count = 0
     logical :: on_windows
-    logical, parameter :: HIST_ENABLED = .false.  ! hist() disabled pending issue #285
+    logical, parameter :: HIST_ENABLED = .true.   ! hist() implemented; enable tests (fixes #285)
 
     print *, "=== HISTOGRAM FUNCTIONALITY TESTS ==="
     


### PR DESCRIPTION
Summary
- Enable histogram tests and add guards for empty data and invalid bins.

Scope
- test/test_histogram_functionality.f90
- src/figures/plot_types/fortplot_figure_histogram.f90

Verification
- Ran full suite with 120s timeout: all tests pass locally. Histogram suite passes (12/12).

Rationale
- Issue #285 cited unimplemented hist/bar; histogram is implemented. This aligns tests with implementation and avoids crashes for empty data or nonpositive bins.