### PR TITLE
fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, windows-2025]
+        os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -198,6 +198,41 @@ jobs:
         else
           echo "ImageMagick not found - skipping graphics quality tests"
         fi
+
+  test-coverage:
+    name: test-coverage
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-coverage-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gfortran make
+          python3 -m pip install --upgrade pip
+          pip3 install gcovr
+
+      - name: Setup Fortran Package Manager (Ubuntu)
+        run: |
+          wget --timeout=30 --tries=2 https://github.com/fortran-lang/fpm/releases/download/v0.12.0/fpm-0.12.0-linux-x86_64-gcc-12
+          chmod +x fpm-0.12.0-linux-x86_64-gcc-12
+          sudo mv fpm-0.12.0-linux-x86_64-gcc-12 /usr/local/bin/fpm
+          fpm --version
+
+      - name: Run coverage
+        env:
+          TEST_TIMEOUT: 120s
+        run: |
+          make coverage
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-txt
+          path: coverage.txt
 
     - name: Test FPM and CMake examples (Ubuntu)
       if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,12 @@ jobs:
           echo "ImageMagick not found - skipping graphics quality tests"
         fi
 
+    - name: Test FPM and CMake examples (Ubuntu)
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        timeout 2m fpm test --target test_system_fpm_example || echo "FPM example test skipped due to timeout"
+        timeout 2m fpm test --target test_system_cmake_example || echo "CMake example test skipped due to timeout"
+
   test-coverage:
     name: test-coverage
     runs-on: ubuntu-latest
@@ -233,9 +239,3 @@ jobs:
         with:
           name: coverage-txt
           path: coverage.txt
-
-    - name: Test FPM and CMake examples (Ubuntu)
-      if: matrix.os == 'ubuntu-latest'
-      run: |
-        timeout 2m fpm test --target test_system_fpm_example || echo "FPM example test skipped due to timeout"
-        timeout 2m fpm test --target test_system_cmake_example || echo "CMake example test skipped due to timeout"


### PR DESCRIPTION
Summary
- Fix workflow: use valid Windows runner and add coverage job to satisfy pending checks.

Scope
- Modified `.github/workflows/ci.yml` only.

Verification
- Local test suites pass: ran `make test` and `make test-ci` successfully.
- Workflow YAML validated by repository conventions; coverage job mirrors `make coverage`.

Rationale
- Addresses CI jobs stuck in pending: invalid `windows-2025` label and missing `test-coverage` job.
