### PR TITLE
fix: REPOSITORY CRISIS: 200+ branches causing navigation chaos and me (fixes #913)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -295,7 +295,7 @@ help:
 
 # Prune remote-tracking branches and delete local merged branches (dry-run by default)
 git-prune:
-	@echo "Running safe git prune (dry-run). Use -- FORCE=1 to apply."
+	@echo "Running safe git prune (dry-run). Use FORCE=1 to apply."
 	@if [ "$(FORCE)" = "1" ]; then \
 		./scripts/git_prune.sh --force; \
 	else \

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ FPM_FLAGS_LIB = --flag -fPIC
 FPM_FLAGS_TEST =
 FPM_FLAGS_DEFAULT = $(FPM_FLAGS_LIB)
 
-.PHONY: all build example debug test clean help matplotlib example_python example_matplotlib doc create_build_dirs create_test_dirs validate-output test-docs verify-functionality verify-setup verify-size-compliance issue-branch issue-open-pr pr-merge pr-cleanup issue-loop issue-loop-dry test-python-bridge-example
+.PHONY: all build example debug test clean help matplotlib example_python example_matplotlib doc create_build_dirs create_test_dirs validate-output test-docs verify-functionality verify-setup verify-size-compliance issue-branch issue-open-pr pr-merge pr-cleanup issue-loop issue-loop-dry test-python-bridge-example git-prune
 
 # Default target
 all: build
@@ -282,6 +282,7 @@ help:
 	@echo "  release     - Build with optimizations"
 	@echo "  run-release - Run optimized build"
 	@echo "  help        - Show this help message"
+	@echo "  git-prune   - Safely prune remote-tracking and old merged local branches"
 	@echo ""
 	@echo "Pass additional fmp arguments using ARGS variable:"
 	@echo "  make example ARGS=\"basic_plots\""
@@ -291,3 +292,12 @@ help:
 	@echo "This project uses STB TrueType and STB Image Write for text and PNG compression."
 	@echo "All dependencies are included as header-only libraries."
 	@echo "No external packages required."
+
+# Prune remote-tracking branches and delete local merged branches (dry-run by default)
+git-prune:
+	@echo "Running safe git prune (dry-run). Use -- FORCE=1 to apply."
+	@if [ "$(FORCE)" = "1" ]; then \
+		./scripts/git_prune.sh --force; \
+	else \
+		./scripts/git_prune.sh; \
+	fi

--- a/README.md
+++ b/README.md
@@ -423,6 +423,25 @@ The documentation is generated in `build/doc/index.html` and includes:
 
 **Browse documentation**: Open `file:///path/to/fortplot/build/doc/index.html`
 
+## Branch Naming & Lifecycle
+
+- Naming: use `fix/<topic>`, `feat/<topic>`, `docs/<topic>`, `refactor/<topic>`.
+- Scope: keep branches focused; one unit of change per branch.
+- Lifecycle: delete branches after merge; avoid long-lived topic branches.
+- Hygiene: regularly prune remote-tracking branches and local branches fully merged into `main`.
+
+Pruning helper:
+
+```bash
+# Dry-run: see what would be pruned
+make git-prune
+
+# Apply pruning (removes merged local branches older than 30 days)
+make git-prune FORCE=1
+```
+
+This keeps the repository navigable and avoids metadata bloat.
+
 ## Why though?
 
 Mostly for the lulz and to help make Fortran great again. In addition,

--- a/scripts/git_prune.sh
+++ b/scripts/git_prune.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Safe Git branch pruning utility
+# - Prunes remote-tracking branches that have been removed from origin
+# - Optionally deletes local branches fully merged into main (older than N days)
+#
+# Usage:
+#   scripts/git_prune.sh            # dry-run (prints planned actions)
+#   scripts/git_prune.sh --force    # apply actions
+#   scripts/git_prune.sh --days 30 --force
+#
+# Notes:
+# - Never touches current branch, 'main', or 'master'
+# - Remote deletion is NOT performed by this tool
+
+DAYS=30
+FORCE=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --force)
+      FORCE=1
+      shift
+      ;;
+    --days)
+      DAYS=${2:-30}
+      shift 2
+      ;;
+    -h|--help)
+      sed -n '1,80p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  echo "ERROR: Not a git repository" >&2
+  exit 2
+fi
+
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+DEFAULT_MAIN="main"
+if git show-ref --verify --quiet refs/heads/$DEFAULT_MAIN; then
+  MAIN=$DEFAULT_MAIN
+elif git show-ref --verify --quiet refs/heads/master; then
+  MAIN="master"
+else
+  MAIN=$DEFAULT_MAIN
+fi
+
+echo "== Git Prune (dry-run: $((1-FORCE))) =="
+echo "Current branch: $CURRENT_BRANCH"
+echo "Main branch:    $MAIN"
+echo "Threshold:      ${DAYS} days"
+
+echo "-- Step 1: Prune remote-tracking branches (origin) --"
+if [[ $FORCE -eq 1 ]]; then
+  git remote prune origin || true
+else
+  echo "DRY-RUN: would run 'git remote prune origin'"
+fi
+
+echo "-- Step 2: Delete local branches fully merged into $MAIN and older than ${DAYS} days --"
+merged_branches=$(git for-each-ref --format='%(refname:short) %(committerdate:iso8601)' refs/heads | \
+  while read -r name date; do
+    [[ "$name" == "$MAIN" || "$name" == "master" || "$name" == "$CURRENT_BRANCH" ]] && continue
+    if git merge-base --is-ancestor "$name" "$MAIN" 2>/dev/null; then
+      # Compute age in days
+      ts_branch=$(date -d "$date" +%s 2>/dev/null || gdate -d "$date" +%s)
+      ts_now=$(date +%s)
+      age_days=$(( (ts_now - ts_branch) / 86400 ))
+      if [[ $age_days -ge $DAYS ]]; then
+        echo "$name"
+      fi
+    fi
+  done)
+
+if [[ -z "$merged_branches" ]]; then
+  echo "No eligible local merged branches older than ${DAYS} days."
+else
+  echo "Eligible branches:"
+  printf '  - %s\n' $merged_branches
+  if [[ $FORCE -eq 1 ]]; then
+    for b in $merged_branches; do
+      git branch -D "$b" || true
+    done
+  else
+    echo "DRY-RUN: would delete the above local branches"
+  fi
+fi
+
+echo "Done."
+


### PR DESCRIPTION
Summary
- Add safe pruning script and Makefile target; document branch naming/lifecycle.

Scope
- Files touched: scripts/git_prune.sh, Makefile, README.md. No code behavior changes.

Verification
- Ran `make test-ci` (120s timeout): all tests passed locally.
- Dry-run `make git-prune` prints planned actions; FORCE=1 applies safely.

Rationale
- Addresses repository hygiene from #913 by documenting policy and providing tooling for automated pruning without destructive operations.
