### PR TITLE
fix: Makefile: test-docs uses non-existent target test_documentation_examples (fixes #1064)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,12 +155,15 @@ validate-output: create_build_dirs
 	fpm test $(FPM_FLAGS_TEST) --target test_output_validation
 	@echo "Functional output validation completed successfully"
 
-# Test documentation examples
+# Test documentation-related targets (run existing doc tests)
 test-docs: create_build_dirs
-	@echo "Running documentation example validation..."
+	$(call _timeout_notice)
+	@echo "Running documentation tests$(if $(TIMEOUT_PREFIX), with timeout $(TEST_TIMEOUT),)..."
 	@mkdir -p output/test
-	fpm test $(FPM_FLAGS_TEST) --target test_documentation_examples
-	@echo "Documentation example validation completed successfully"
+	@$(TIMEOUT_PREFIX) fpm test $(FPM_FLAGS_TEST) --target test_doc_core || exit 1
+	@$(TIMEOUT_PREFIX) fpm test $(FPM_FLAGS_TEST) --target test_doc_processing_output || exit 1
+	@$(TIMEOUT_PREFIX) fpm test $(FPM_FLAGS_TEST) --target test_docs_index_pages || exit 1
+	@echo "Documentation tests completed successfully"
 
 # Run comprehensive functional tests
 test-functional: test validate-output test-docs


### PR DESCRIPTION
Summary
- Update `test-docs` to run existing documentation tests instead of a non-existent target.

Scope
- Edit `Makefile` only: replace `test_documentation_examples` with `test_doc_core`, `test_doc_processing_output`, and `test_docs_index_pages` under the timeout wrapper.

Verification
- Ran `make test-ci` (passed).
- Ran `make test-docs` locally: all three doc-related tests passed under timeout.

Rationale
- `test-docs` should validate documentation-related functionality. The previous target did not exist, making the target ineffective. This aligns the Makefile with the actual test programs present in `test/`.
