### PR TITLE
fix: Invalid example in fortplot.f90: figure_legend(fig, ) (fixes #1068)

### DIFF
--- a/src/core/fortplot.f90
+++ b/src/core/fortplot.f90
@@ -46,7 +46,7 @@ module fortplot
     !!   call fig%initialize(800, 600)
     !!   call figure_add_plot(fig, x, y, label="data", linestyle='b-o')
     !!   call figure_add_contour(fig, x_grid, y_grid, z_field)
-    !!   call figure_legend(fig, )
+    !!   call figure_legend(fig)
     !!   call figure_savefig(fig, 'results.pdf')
     !!
     !! Author: fortplot contributors


### PR DESCRIPTION
Summary
- Fix invalid Quick Start example call in `src/core/fortplot.f90`.

Scope
- Update comment example: `call figure_legend(fig, )` -> `call figure_legend(fig)`.
- No code behavior changes.

Verification
- Ran `make test-ci` locally: all tests passed.
- Change is in comments only; build unaffected.

Rationale
- Prevent copy/paste syntax errors for new users following the Quick Start.
