### PR TITLE
fix: Docs: use Ninja generator in CMake instructions to match project (fixes #1072)

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ target_link_libraries(your_target fortplot::fortplot)
 
 ```bash
 # Build with trampoline detection enabled
-cmake -B build && cmake --build build
+cmake -S . -B build -G Ninja && cmake --build build -j
 # Library builds successfully = trampoline-free core code
 
 # Verify no executable stack segments
@@ -325,7 +325,7 @@ fpm build --flag "-Werror=trampolines" 2>/dev/null || echo "Trampoline detection
 fpm build --flag "-Wtrampolines -Werror=trampolines"
 
 # CMake: Automatic security flags (see CMakeLists.txt lines 36-47)
-cmake -B build && cmake --build build
+cmake -S . -B build -G Ninja && cmake --build build -j
 
 # Standard development (FPM default)
 make build  # Uses fpm.toml configuration


### PR DESCRIPTION
Summary
- Update README CMake instructions to use Ninja generator per project guidelines.

Scope
- README.md only; no code behavior changes.

Verification
- Ran `make test` (fpm test) locally; all tests passed unchanged.

Rationale
- Aligns docs with established build guidance for consistent CMake usage.
