### PR TITLE
fix: Boolean env parsing inconsistent; unify across modules (fixes #1074)

### DIFF
--- a/src/external/fortplot_logging.f90
+++ b/src/external/fortplot_logging.f90
@@ -7,7 +7,7 @@ module fortplot_logging
     !! - Automatic CI detection: GITHUB_ACTIONS, CI, CONTINUOUS_INTEGRATION
     !! - FORTPLOT_FORCE_WARNINGS: Force warnings even in CI environments
     
-    use fortplot_string_utils, only: to_lowercase, parse_boolean_env
+    use fortplot_string_utils, only: parse_boolean_env
     implicit none
     private
     

--- a/src/external/fortplot_logging.f90
+++ b/src/external/fortplot_logging.f90
@@ -7,6 +7,7 @@ module fortplot_logging
     !! - Automatic CI detection: GITHUB_ACTIONS, CI, CONTINUOUS_INTEGRATION
     !! - FORTPLOT_FORCE_WARNINGS: Force warnings even in CI environments
     
+    use fortplot_string_utils, only: to_lowercase, parse_boolean_env
     implicit none
     private
     
@@ -183,41 +184,6 @@ contains
         end if
     end function detect_ci_environment
     
-    logical function parse_boolean_env(env_value)
-        !! Parse environment variable as boolean value
-        !! Supports: '1', 'true', 'yes', 'on' (case-insensitive) = .true.
-        !! All other values = .false.
-        character(len=*), intent(in) :: env_value
-        character(len=256) :: lower_value
-        
-        parse_boolean_env = .false.
-        
-        ! Convert to lowercase for comparison
-        lower_value = to_lowercase(trim(env_value))
-        
-        if (lower_value == '1' .or. &
-            lower_value == 'true' .or. &
-            lower_value == 'yes' .or. &
-            lower_value == 'on') then
-            parse_boolean_env = .true.
-        end if
-    end function parse_boolean_env
-    
-    function to_lowercase(input_string) result(output_string)
-        !! Convert string to lowercase
-        character(len=*), intent(in) :: input_string
-        character(len=len(input_string)) :: output_string
-        integer :: i, ascii_val
-        integer, parameter :: ASCII_A = 65, ASCII_Z = 90, CASE_OFFSET = 32
-        
-        output_string = input_string
-        do i = 1, len(input_string)
-            ascii_val = iachar(input_string(i:i))
-            if (ascii_val >= ASCII_A .and. ascii_val <= ASCII_Z) then
-                output_string(i:i) = achar(ascii_val + CASE_OFFSET)
-            end if
-        end do
-    end function to_lowercase
     
     logical function is_warnings_suppressed()
         !! Check if warnings are currently suppressed

--- a/src/system/fortplot_windows_performance.f90
+++ b/src/system/fortplot_windows_performance.f90
@@ -8,6 +8,7 @@ module fortplot_windows_performance
     
     use iso_fortran_env, only: int32, real64
     use iso_c_binding, only: c_char, c_int, c_null_char
+    use fortplot_string_utils, only: parse_boolean_env
     implicit none
     private
     
@@ -85,18 +86,18 @@ contains
         
         ! Check for performance override flags
         call get_environment_variable("FORTPLOT_USE_MEMORY_BACKEND", env_value, status=stat)
-        if (stat == 0 .and. (trim(env_value) == "1" .or. trim(env_value) == "true")) then
-            global_config%use_memory_backend = .true.
+        if (stat == 0 .and. len_trim(env_value) > 0) then
+            if (parse_boolean_env(env_value)) global_config%use_memory_backend = .true.
         end if
         
         call get_environment_variable("FORTPLOT_BATCH_IO", env_value, status=stat)
-        if (stat == 0 .and. (trim(env_value) == "1" .or. trim(env_value) == "true")) then
-            global_config%batch_file_operations = .true.
+        if (stat == 0 .and. len_trim(env_value) > 0) then
+            if (parse_boolean_env(env_value)) global_config%batch_file_operations = .true.
         end if
         
         call get_environment_variable("FORTPLOT_MINIMIZE_IO", env_value, status=stat)
-        if (stat == 0 .and. (trim(env_value) == "1" .or. trim(env_value) == "true")) then
-            global_config%minimize_io = .true.
+        if (stat == 0 .and. len_trim(env_value) > 0) then
+            if (parse_boolean_env(env_value)) global_config%minimize_io = .true.
         end if
         
         ! Set optimal temp directory
@@ -113,7 +114,7 @@ contains
         
         ! Log configuration if in debug mode
         call get_environment_variable("FORTPLOT_DEBUG", env_value, status=stat)
-        if (stat == 0 .and. (trim(env_value) == "1" .or. trim(env_value) == "true")) then
+        if (stat == 0 .and. len_trim(env_value) > 0 .and. parse_boolean_env(env_value)) then
             print *, "Windows Performance Configuration:"
             print *, "  Memory backend: ", global_config%use_memory_backend
             print *, "  Batch I/O: ", global_config%batch_file_operations

--- a/src/utilities/core/fortplot_string_utils.f90
+++ b/src/utilities/core/fortplot_string_utils.f90
@@ -1,0 +1,39 @@
+module fortplot_string_utils
+    !! Core string utilities with minimal dependencies
+    implicit none
+    private
+    public :: to_lowercase, parse_boolean_env
+
+contains
+
+    function to_lowercase(input) result(output)
+        !! Convert string to lowercase (ASCII A-Z)
+        character(len=*), intent(in) :: input
+        character(len=len(input)) :: output
+        integer :: i, c
+        do i = 1, len(input)
+            c = iachar(input(i:i))
+            if (c >= 65 .and. c <= 90) then
+                output(i:i) = achar(c + 32)
+            else
+                output(i:i) = input(i:i)
+            end if
+        end do
+    end function to_lowercase
+
+    logical function parse_boolean_env(env_value) result(val)
+        !! Case-insensitive parse for common boolean-ish strings.
+        character(len=*), intent(in) :: env_value
+        character(len=len_trim(env_value)) :: lower
+        val = .false.
+        if (len_trim(env_value) == 0) return
+        lower = to_lowercase(trim(env_value))
+        if (lower == '1' .or. lower == 'true' .or. lower == 'yes' .or. lower == 'on') then
+            val = .true.
+        else if (lower == '0' .or. lower == 'false' .or. lower == 'no' .or. lower == 'off') then
+            val = .false.
+        end if
+    end function parse_boolean_env
+
+end module fortplot_string_utils
+

--- a/src/utilities/fortplot_utils.f90
+++ b/src/utilities/fortplot_utils.f90
@@ -107,6 +107,8 @@ contains
         end do
     end function to_lowercase
 
+    ! Note: boolean env parsing is provided by src/utilities/core/fortplot_string_utils.f90
+
     subroutine ensure_directory_exists(filepath)
         !! Ensure output directory exists for a given filepath
         !! Extracts the parent directory and creates it securely using

--- a/src/utilities/fortplot_utils.f90
+++ b/src/utilities/fortplot_utils.f90
@@ -6,6 +6,7 @@ module fortplot_utils
     !! by grouping related utility functions together.
     
     use fortplot_context, only: plot_context
+    use fortplot_string_utils, only: to_lowercase
     use fortplot_png, only: create_png_canvas
     use fortplot_pdf, only: create_pdf_canvas
     use fortplot_ascii, only: create_ascii_canvas
@@ -14,7 +15,7 @@ module fortplot_utils
     
     private
     public :: get_backend_from_filename, initialize_backend
-    public :: to_lowercase, ensure_directory_exists
+    public :: ensure_directory_exists
     
 contains
 
@@ -86,28 +87,8 @@ contains
         end select
     end subroutine initialize_backend
 
-    function to_lowercase(input) result(output)
-        !! Convert string to lowercase
-        !! 
-        !! @param input: Input string
-        !! @return output: Lowercase string
-        
-        character(len=*), intent(in) :: input
-        character(len=len(input)) :: output
-        integer :: i, char_code
-        
-        do i = 1, len(input)
-            char_code = iachar(input(i:i))
-            if (char_code >= 65 .and. char_code <= 90) then
-                ! Convert uppercase A-Z to lowercase a-z
-                output(i:i) = achar(char_code + 32)
-            else
-                output(i:i) = input(i:i)
-            end if
-        end do
-    end function to_lowercase
-
-    ! Note: boolean env parsing is provided by src/utilities/core/fortplot_string_utils.f90
+    ! Note: to_lowercase and boolean env parsing are provided by
+    ! src/utilities/core/fortplot_string_utils.f90
 
     subroutine ensure_directory_exists(filepath)
         !! Ensure output directory exists for a given filepath

--- a/test/test_boolean_env_parsing.f90
+++ b/test/test_boolean_env_parsing.f90
@@ -1,0 +1,34 @@
+program test_boolean_env_parsing
+    !! Focused test for parse_boolean_env utility
+    use fortplot_string_utils, only: parse_boolean_env
+    implicit none
+
+    call ensure(parse_boolean_env('1'), '1 => true')
+    call ensure(parse_boolean_env('true'), 'true => true')
+    call ensure(parse_boolean_env('TRUE'), 'TRUE => true')
+    call ensure(parse_boolean_env('Yes'), 'Yes => true')
+    call ensure(parse_boolean_env('on'), 'on => true')
+
+    call ensure(.not. parse_boolean_env('0'), '0 => false')
+    call ensure(.not. parse_boolean_env('false'), 'false => false')
+    call ensure(.not. parse_boolean_env('FALSE'), 'FALSE => false')
+    call ensure(.not. parse_boolean_env('No'), 'No => false')
+    call ensure(.not. parse_boolean_env('off'), 'off => false')
+
+    call ensure(.not. parse_boolean_env('random'), 'random => false')
+    call ensure(.not. parse_boolean_env(''), 'empty => false')
+
+contains
+
+    subroutine ensure(cond, msg)
+        logical, intent(in) :: cond
+        character(len=*), intent(in) :: msg
+        if (.not. cond) then
+            print *, 'FAIL: ', trim(msg)
+            stop 1
+        else
+            print *, 'PASS: ', trim(msg)
+        end if
+    end subroutine ensure
+
+end program test_boolean_env_parsing


### PR DESCRIPTION
Summary
- Centralizes boolean environment parsing and applies it to Windows performance config and logging, ensuring case-insensitive behavior.

Scope
- Added src/utilities/core/fortplot_string_utils.f90 with to_lowercase/parse_boolean_env.
- Refactored src/external/fortplot_logging.f90 and src/system/fortplot_windows_performance.f90 to use shared parser.
- Added test/test_boolean_env_parsing.f90 to validate parsing coverage.

Verification
- Ran `make test-ci` and `make test ARGS="--target test_boolean_env_parsing"`; all tests pass locally within timeout.

Rationale
- Fixes inconsistent, case-sensitive env handling on Windows and deduplicates logic for maintainability.
