### PR TITLE
docs(examples): compact ASCII previews; link to full text

### DIFF
--- a/doc/examples/basic_plots.md
+++ b/doc/examples/basic_plots.md
@@ -34,22 +34,10 @@ make example ARGS="basic_plots"
 ![simple_plot.png](../../media/examples/basic_plots/simple_plot.png)
 
 ASCII output preview:
+
 ```
-                                Simple Sine Wave
-+--------------------------------------------------------------------------------+
-|1.0     *                                      *                               |
-|      *   *                                  *   *                             |
-|0.5  *     *                                *     *                            |
-|     *       *                            *       *                           |
-|0.0---------*----*----------------------------*----*-----------                |
-|             *  *                              *  *                            |
-|-0.5          **                                **                             |
-|                                                                               |
-|-1.0+--------+----------+----------+----------+----------+--------+           |
-      0        2          4          6          8         10                   |
-+--------------------------------------------------------------------------------+
-                                       x
-sin(x)
+[Preview truncated for readability]
+See full ASCII output via the download link below.
 ```
 
 > **Full ASCII Output**: [Download simple_plot.txt](../../media/examples/basic_plots/simple_plot.txt) | [ASCII Format Guide](../ascii_output_format.md)
@@ -61,22 +49,10 @@ sin(x)
 ![multi_line.png](../../media/examples/basic_plots/multi_line.png)
 
 ASCII output preview:
+
 ```
-                           Sine and Cosine Functions
-+--------------------------------------------------------------------------------+
-|1.0     *                                      *                - sin(x)       |
-|      *   *                                  *   *            - cos(x)         |
-|0.5  *     *    o                          *     *    o                        |
-|     *       *o   o                      *       *o   o                       |
-|0.0---------*----o---o----------------------------o----*-----------            |
-|             *  *     o                              o  *                      |
-|-0.5          **       o                              o  **                    |
-|                        o                            o                         |
-|-1.0+--------+----------o----------+----------+------o----+--------+           |
-      0        2          4          6          8         10                   |
-+--------------------------------------------------------------------------------+
-                                       x
-y
+[Preview truncated for readability]
+See full ASCII output via the download link below.
 ```
 
 > **Full ASCII Output**: [Download multi_line.txt](../../media/examples/basic_plots/multi_line.txt) | [ASCII Format Guide](../ascii_output_format.md)

--- a/doc/examples/colored_contours.md
+++ b/doc/examples/colored_contours.md
@@ -44,52 +44,10 @@ make example ARGS="colored_contours"
 ![gaussian_default.png](../../media/examples/colored_contours/gaussian_default.png)
 
 ASCII output preview:
-```
-                 2D Gaussian - Default Colorblind-Safe Colormap
-+--------------------------------------------------------------------------------+
-|3.00                                                                            |
-|2.00                                                                            |
-|1.00                                                                            |
-|0.                                                                              |
 
-                 2D Gaussian - Default Colorblind-Safe Colormap
-+--------------------------------------------------------------------------------+
-|3.00                                                                            |
-| *                                                                              |
-|                                                                                |
-| *                                                                              |
-|2*00                                                                            |
-| *                                                                              |
-| *                                                                              |
-| *                                                                              |
-| *                                                                              |
-|1*00                            :  :  : :  :  :                                 |
-| *                          : :    @  @ @  @    : :                             |
-| *                       :::   @@@ #  # #  # @@@   :::                          |
-| *                      :   @@@ # ##  # #  ## # @@@   :                         |
-| *                     :   @  # # #   # #   # # #  @   :                        |
-|0*                    :   @  #  #  #       #  #  #  @   :                       |
-|                      :  @  #  # #    o o    # #  #  @  :                       |
-| *                    :   @  #  #  #       #  #  #  @   :                       |
-| *                     :   @  # # #   # #   # # #  @   :                        |
-| *                      :   @@@ # ##  # #  ## # @@@   :                         |
-|-1.00                    :::   @@@ #  # #  # @@@   :::                          |
-| *                          : :    @  @ @  @    : :                             |
-| *                              :  :  : :  :  :                                 |
-| *                                                                              |
-| *                                                                              |
-|-2.00                                                                           |
-| *                                                                              |
-| *                                                                              |
-| *                                                                              |
-| *  *  *  *  *  *  *  *  *  *  *  *  *   *  *  *  *  *  *  *  *  *  *  *  *   * |
-|-3.00       -2.00         -1.00        0            1.00          2.00     3.00 |
-+--------------------------------------------------------------------------------+
-                                       x
-y
-+--------------------------------------------------------------------------------+
-                                       x
-y
+```
+[Preview truncated for readability]
+See full ASCII output via the download link below.
 ```
 
 > **Full ASCII Output**: [Download gaussian_default.txt](../../media/examples/colored_contours/gaussian_default.txt) | [ASCII Format Guide](../ascii_output_format.md)
@@ -101,47 +59,10 @@ y
 ![saddle_plasma.png](../../media/examples/colored_contours/saddle_plasma.png)
 
 ASCII output preview:
-```
-Saddle Function - Plasma Colormap
-+--------------------------------------------------------------------------------+
-| ... [representative sample showing colormap pattern] ...                      |
 
-                       Saddle Function - Plasma Colormap
-+--------------------------------------------------------------------------------+
-|                                                                                |
-| *  o  o        o              o               o              o        o  o     |
-|2.00 o    o      o  o            o  o  o  o  o            o  o      o    o      |
-| %#    o o o o        oo  o                         o  oo        o o o o    # # |
-| % ###    oo   o oo          oo  o  o  o  o  o  oo          oo o   oo    ###  # |
-| * ## ##     o o o  o                                     o  o o o     ## ##    |
-|     #   ##        oo  o oo                         oo o  oo        ##   #      |
-| %     ##   #          o     o   oo o  o  o oo   o     o          #   ##     ## |
-|1*00     ##  ##          oo o                     o oo          ##  ##     #    |
-| *  #       #    #           o   o oo     oo o   o           #    #       #     |
-| *    #      ##   ##                   o                   ##   ##      #       |
-|                    #                                     #                     |
-| %     #       #     #                                   #     #       #      @ |
-| @      #       ##    #                                 #    ##       #      @  |
-|0@      #        #     #                               #     #        #      @  |
-| @      #        #      #                             #      #        #      @  |
-| @      #        #     #                               #     #        #      @  |
-| @      #       ##    #                                 #    ##       #      @  |
-| %     #       #     #                                   #     #       #      @ |
-| *    #       #    ##                                     ##    #       #       |
-|-1.00        #    #                    o                    #    #              |
-| *  #       #    #           o   o oo     oo o   o           #    #       #     |
-| * #     ##  ##          oo o                     o oo          ##  ##     #    |
-| %     ##   #          o     o   oo o  o  o oo   o     o          #   ##     ## |
-|     #   ##        oo  o oo                         oo o  oo        ##   #      |
-| * ## ##     o o o  o                                     o  o o o     ## ##    |
-|-2.00#    oo   o oo          oo  o  o  o  o  o  oo          oo o   oo    ###  # |
-| %#    o o o o        oo  o                         o  oo        o o o o    # # |
-| *  *o o* o *  *oo *o  *  *   *o o* o* o *o  * o*   *   * o* oo*   *o *o o*   * |
-|       -2.00           -1.00           0               1.00            2.00     |
-+--------------------------------------------------------------------------------+
-                                       x
-y
-+--------------------------------------------------------------------------------+
+```
+[Preview truncated for readability]
+See full ASCII output via the download link below.
 ```
 
 > **Full ASCII Output**: [Download saddle_plasma.txt](../../media/examples/colored_contours/saddle_plasma.txt) | [ASCII Format Guide](../ascii_output_format.md)
@@ -153,47 +74,10 @@ y
 ![ripple_jet.png](../../media/examples/colored_contours/ripple_jet.png)
 
 ASCII output preview:
-```
-Ripple Function - Jet Colormap
-+--------------------------------------------------------------------------------+
-| ... [representative sample showing colormap pattern] ...                      |
 
-                         Ripple Function - Jet Colormap
-+--------------------------------------------------------------------------------+
-|2.00                                                                            |
-| %            #        @           @       @           @        #            #  |
-| #           #       @   @   @   @           @   @   @   @       #            # |
-|1*50     #     @ @   @       oo  o   o   o   o  oo       @   @ @     #          |
-|     # #  @  @ @ @  oo   o                           o   oo  @ @ @  @  # #      |
-| *   #   @   @   o                                           o   @   @   #      |
-| %#    @   @   o                                               o   @   @    # # |
-|1.00@@ @ @ o o               oo  o   o   o   o  oo               o o @ @ @@     |
-| *       o               o   @   @   @   @   @   @   o               o          |
-| @   @  o              o @  @@   @   #   #   @   @@  @ o              o  @   @@ |
-|.500  o             oo @  @  ##  %  %%   %%  %  ##  @  @ oo             o  @    |
-| *@  o           o  @@ @ @ # %                   % # @ @ @@  o           o  @   |
-|     o           o       #                           #       o           o      |
-| @  o           o @  @ #  %                         %  # @  @ o           o  @  |
-|0%  o          o  @ @ #  %         % %   % %         %  # @ @  o          o   @ |
-|                                                                                |
-| %  o          o  @ @ #  %         % %   % %         %  # @ @  o          o   @ |
-| @  o           o @  @ #  %                         %  # @  @ o           o  @  |
-|-.500o           o       #                           #       o           o      |
-| *@  o           o  @@ @ @ # %                   % # @ @ @@  o           o  @   |
-|   @  o             oo @  @  ##  %  %%   %%  %  ##  @  @ oo             o  @    |
-| @   @  o              o @  @@   @   #   #   @   @@  @ o              o  @   @@ |
-|-1.00    o               o   @   @   @   @   @   @   o               o          |
-|    @@ @ @ o o               oo  o   o   o   o  oo               o o @ @ @@     |
-| %#    @   @   o                                               o   @   @    # # |
-|-1.50#   @   @   o                                           o   @   @   #      |
-|     # #  @  @ @ @  oo   o                           o   oo  @ @ @  @  # #      |
-| *       #     @ @   @       oo  o   o   o   o  oo       @   @ @     #          |
-| %   *    *  #%    * @ % @  *@  *@ @ *   * @ @*  @*  @ % @ *    %#  *    *   #% |
-|-2.00    -1.50     -1.00     -.500     0         .500      1.00      1.50  2.00 |
-+--------------------------------------------------------------------------------+
-                                       x
-y
-+--------------------------------------------------------------------------------+
+```
+[Preview truncated for readability]
+See full ASCII output via the download link below.
 ```
 
 > **Full ASCII Output**: [Download ripple_jet.txt](../../media/examples/colored_contours/ripple_jet.txt) | [ASCII Format Guide](../ascii_output_format.md)
@@ -205,47 +89,10 @@ y
 ![ripple_coolwarm.png](../../media/examples/colored_contours/ripple_coolwarm.png)
 
 ASCII output preview:
-```
-Ripple Function - Coolwarm Colormap
-+--------------------------------------------------------------------------------+
-| ... [representative sample showing colormap pattern] ...                      |
 
-                      Ripple Function - Coolwarm Colormap
-+--------------------------------------------------------------------------------+
-|2.00                                                                            |
-| %            #        @           *       *           @        #            #  |
-| #           #       @   *   *   *           *   *   *   @       #            # |
-|1*50     #     @ @   *       **  *   *   *   *  **       *   @ @     #          |
-|     # #  @  @ * *  **   *                           *   **  * * @  @  # #      |
-| *   #   @   *   *                                           *   *   @   #      |
-| %#    @   *   *                                               *   *   @    # # |
-|1.00@@ * * * *               **  *   *   *   *  **               * * * * @@     |
-| *       *               *   *   *   @   @   *   *   *               *          |
-| @   *  *              * *  *@   @   #   #   @   @*  * *              *  *   @@ |
-|.500  *             ** *  @  ##  o  oo   oo  o  ##  @  * **             *  *    |
-| **  *           *  ** @ @ # o                   o # @ @ **  *           *  *   |
-|     *           *       #                           #       *           *      |
-| *  *           * *  @ #  o                         o  # @  * *           *  *  |
-|0*  *          *  * @ #  o         o o   o o         o  # @ *  *          *   * |
-|                                                                                |
-| *  *          *  * @ #  o         o o   o o         o  # @ *  *          *   * |
-| *  *           * *  @ #  o                         o  # @  * *           *  *  |
-|-.500*           *       #                           #       *           *      |
-| **  *           *  ** @ @ # o                   o # @ @ **  *           *  *   |
-|   *  *             ** *  @  ##  o  oo   oo  o  ##  @  * **             *  *    |
-| @   *  *              * *  *@   @   #   #   @   @*  * *              *  *   @@ |
-|-1.00    *               *   *   *   @   @   *   *   *               *          |
-|    @@ * * * *               **  *   *   *   *  **               * * * * @@     |
-| %#    @   *   *                                               *   *   @    # # |
-|-1.50#   @   *   *                                           *   *   @   #      |
-|     # #  @  @ * *  **   *                           *   **  * * @  @  # #      |
-| *       #     @ @   *       **  *   *   *   *  **       *   @ @     #          |
-| %   *    *  #%    * @ % *  **  ** * *   * * **  **  * % @ *    %#  *    *   #% |
-|-2.00    -1.50     -1.00     -.500     0         .500      1.00      1.50  2.00 |
-+--------------------------------------------------------------------------------+
-                                       x
-y
-+--------------------------------------------------------------------------------+
+```
+[Preview truncated for readability]
+See full ASCII output via the download link below.
 ```
 
 > **Full ASCII Output**: [Download ripple_coolwarm.txt](../../media/examples/colored_contours/ripple_coolwarm.txt) | [ASCII Format Guide](../ascii_output_format.md)
@@ -257,47 +104,10 @@ y
 ![ripple_inferno.png](../../media/examples/colored_contours/ripple_inferno.png)
 
 ASCII output preview:
-```
-Ripple Function - Inferno Colormap
-+--------------------------------------------------------------------------------+
-| ... [representative sample showing colormap pattern] ...                      |
 
-                       Ripple Function - Inferno Colormap
-+--------------------------------------------------------------------------------+
-|2.00                                                                            |
-| %            #        +           +       +           +        #            #  |
-| #           #       +   +   +   +           +   +   +   +       #            # |
-|1*50     #     + +   +       ..  .   .   .   .  ..       +   + +     #          |
-|     # #  +  + + +  ..   .                           .   ..  + + +  +  # #      |
-| *   #   +   +   .                                           .   +   +   #      |
-| %#    +   +   .                                               .   +   +    # # |
-|1.00++ + + . .               ..  .   .   .   .  ..               . . + + ++     |
-| *       .               .   +   +   +   +   +   +   .               .          |
-| *   +  .              . +  ++   #   #   #   #   ++  + .              .  +   ++ |
-|.500  .             .. +  +  ##  #  ##   ##  #  ##  +  + ..             .  +    |
-| *+  .           .  ++ + # # #                   # # # + ++  .           .  +   |
-|     .           .       #                           #       .           .      |
-| *  .           . +  + #  #                         #  # +  + .           .  +  |
-|0*  .          .  + + #  #         # #   # #         #  # + +  .          .   + |
-|                                                                                |
-| *  .          .  + + #  #         # #   # #         #  # + +  .          .   + |
-| *  .           . +  + #  #                         #  # +  + .           .  +  |
-|-.500.           .       #                           #       .           .      |
-| *+  .           .  ++ + # # #                   # # # + ++  .           .  +   |
-|   +  .             .. +  +  ##  #  ##   ##  #  ##  +  + ..             .  +    |
-| *   +  .              . +  ++   #   #   #   #   ++  + .              .  +   ++ |
-|-1.00    .               .   +   +   +   +   +   +   .               .          |
-|    ++ + + . .               ..  .   .   .   .  ..               . . + + ++     |
-| %#    +   +   .                                               .   +   +    # # |
-|-1.50#   +   +   .                                           .   +   +   #      |
-|     # #  +  + + +  ..   .                           .   ..  + + +  +  # #      |
-| *       #     + +   +       ..  .   .   .   .  ..       +   + +     #          |
-| %   *    *  #%    * + * +  *+  *+ + *   * + +*  +*  + * + *    %#  *    *   #% |
-|-2.00    -1.50     -1.00     -.500     0         .500      1.00      1.50  2.00 |
-+--------------------------------------------------------------------------------+
-                                       x
-y
-+--------------------------------------------------------------------------------+
+```
+[Preview truncated for readability]
+See full ASCII output via the download link below.
 ```
 
 > **Full ASCII Output**: [Download ripple_inferno.txt](../../media/examples/colored_contours/ripple_inferno.txt) | [ASCII Format Guide](../ascii_output_format.md)

--- a/doc/examples/contour_demo.md
+++ b/doc/examples/contour_demo.md
@@ -33,22 +33,10 @@ make example ARGS="contour_demo"
 ![contour_gaussian.png](../../media/examples/contour_demo/contour_gaussian.png)
 
 ASCII output preview:
+
 ```
-                              2D Gaussian Function
-+--------------------------------------------------------------------------------+
-|2.0                              .  .  . .  .  .                                |
-|                           . ..    .  . .  .    .. .                           |
-|1.5                     ..  . ...  . .. .. .  ... .  ..                        |
-|                    .  .  ... ....... . . ....... ...  .  .                    |
-|1.0                .   ... .. .... .... .... .... .. ...   .                   |
-|                  .  .. .... ..... ##### ##### ..... ....  ..                  |
-|0.5              .   ... .... ##### ##### ##### ##### .... ...                 |
-|                .   . ... ### ##### @@@@@ @@@@@ ##### ### ... .                |
-|0.0+--------+----------+----------+----------+----------+--------+             |
-   -2.0    -1.0        0.0        1.0        2.0        3.0                    |
-+--------------------------------------------------------------------------------+
-                                       x
-y
+[Preview truncated for readability]
+See full ASCII output via the download link below.
 ```
 
 > **Full ASCII Output**: [Download contour_gaussian.txt](../../media/examples/contour_demo/contour_gaussian.txt) | [ASCII Format Guide](../ascii_output_format.md)
@@ -60,22 +48,10 @@ y
 ![mixed_plot.png](../../media/examples/contour_demo/mixed_plot.png)
 
 ASCII output preview:
+
 ```
-                           Mixed Plot: Contour + Line
-+--------------------------------------------------------------------------------+
-|1.0        .     .         ..     #*  * *  *#     ..         .     .           |
-|           .      .          *#*             *#*          .      .             |
-|0.5         .      .     #*#   . .         . .   #*#     .      .              |
-|   * *  * *  * *  * .                . .                . *  * * * *  * *  *   |
-|0.0 ..   ..   . .    . ..         .  .  . .  .  .         .. .    . .   ..  ..|
-|             ..      ..         .. .. ... .. ..         ..      ..             |
-|-0.5          .        .       .   ... ### ###   .       .        .            |
-|                               .   .  .###.  .   .                             |
-|-1.0+--------+----------+----------+----------+----------+--------+            |
-    -2.0    -1.0        0.0        1.0        2.0        3.0                   |
-+--------------------------------------------------------------------------------+
-                                       x
-y
+[Preview truncated for readability]
+See full ASCII output via the download link below.
 ```
 
 > **Full ASCII Output**: [Download mixed_plot.txt](../../media/examples/contour_demo/mixed_plot.txt) | [ASCII Format Guide](../ascii_output_format.md)

--- a/doc/examples/line_styles.md
+++ b/doc/examples/line_styles.md
@@ -39,22 +39,10 @@ make example ARGS="line_styles"
 ![line_styles.png](../../media/examples/line_styles/line_styles.png)
 
 ASCII output preview:
+
 ```
-                         Complete Line Style Reference
-+--------------------------------------------------------------------------------+
-|3.0  ________________                              -- Solid (-)                  |
-|                                                                                |
-|2.0  ---- ---- ---- ---- ----                     -- Dashed (--)               |
-|                                                                                |
-|1.0  .... .... .... .... ....                     -- Dotted (:)               |
-|                                                                                |
-|0.0  _._ _._ _._ _._ _._ _._                        -- Dash-dot (-.)             |
-|                                                                                |
-|-1.0+--------+----------+----------+----------+----------+--------+            |
-     0        2          4          6          8         10                     |
-+--------------------------------------------------------------------------------+
-                                       x
-Line Styles
+[Preview truncated for readability]
+See full ASCII output via the download link below.
 ```
 
 > **Full ASCII Output**: [Download line_styles.txt](../../media/examples/line_styles/line_styles.txt) | [ASCII Format Guide](../ascii_output_format.md)

--- a/doc/examples/pcolormesh_demo.md
+++ b/doc/examples/pcolormesh_demo.md
@@ -49,22 +49,10 @@ make example ARGS="pcolormesh_demo"
 ![pcolormesh_basic.png](../../media/examples/pcolormesh_demo/pcolormesh_basic.png)
 
 ASCII output preview:
+
 ```
-                       Basic Pcolormesh - Linear Gradient
-+--------------------------------------------------------------------------------+
-|1.20                                                                            |
-|        +               *              #              %               @         |
-|0.90    -               =              +              *               #         |
-|        .               :              -              =               +         |
-|0.60    .               .               :              -               =         |
-|        .               .               .              :               -         |
-|0.30    .               .               .              .               :         |
-|        .               .               .              .               .         |
-|0.00+--------+----------+----------+----------+----------+--------+            |
-     0.0     0.4        0.8        1.2        1.6        2.0                   |
-+--------------------------------------------------------------------------------+
-                                  X coordinate
-Y coordinate
+[Preview truncated for readability]
+See full ASCII output via the download link below.
 ```
 
 > **Full ASCII Output**: [Download pcolormesh_basic.txt](../../media/examples/pcolormesh_demo/pcolormesh_basic.txt) | [ASCII Format Guide](../ascii_output_format.md)
@@ -76,22 +64,10 @@ Y coordinate
 ![pcolormesh_sinusoidal.png](../../media/examples/pcolormesh_demo/pcolormesh_sinusoidal.png)
 
 ASCII output preview:
+
 ```
-                        Pcolormesh - Sinusoidal Pattern
-+--------------------------------------------------------------------------------+
-|1.20    =       =       =      =       =       =       =      =                |
-|        +       +       +      +       +       +       +      +                |
-|0.90    *       *       *      *       *       *       *      *                |
-|        #       #       #      #       #       #       #      #                |
-|0.60    %       %       %      %       %       %       %      %                |
-|        @       @       @      @       @       @       @      @                |
-|0.30    .       .       .      .       .       .       .      .                |
-|        :       :       :      :       :       :       :      :                |
-|0.00+--------+----------+----------+----------+----------+--------+            |
-     0.0     0.4        0.8        1.2        1.6        2.0                   |
-+--------------------------------------------------------------------------------+
-                                  X coordinate
-Y coordinate
+[Preview truncated for readability]
+See full ASCII output via the download link below.
 ```
 
 > **Full ASCII Output**: [Download pcolormesh_sinusoidal.txt](../../media/examples/pcolormesh_demo/pcolormesh_sinusoidal.txt) | [ASCII Format Guide](../ascii_output_format.md)
@@ -103,22 +79,10 @@ Y coordinate
 ![pcolormesh_plasma.png](../../media/examples/pcolormesh_demo/pcolormesh_plasma.png)
 
 ASCII output preview:
+
 ```
-                      Pcolormesh - Radial Pattern (Plasma)
-+--------------------------------------------------------------------------------+
-|1.20    = -     =     + =      = #     =     # =       =+     =                |
-|        + *     +     * +      + %     +     % +       +*     +                |
-|0.80    # @     #     @ #      # =     #     = #       #@     #                |
-|        % .     %     . %      % :     %     : %       %.     %                |
-|0.60    @ :     @     : @      @ .     @     . @       @:     @                |
-|        = -     =     - =      = +     =     + =       =-     =                |
-|0.30    : +     :     + :      : *     :     * :       :+     :                |
-|        . #     .     # .      . %     .     % .       .#     .                |
-|0.00+--------+----------+----------+----------+----------+--------+            |
-     0.0     0.4        0.8        1.2        1.6        2.0                   |
-+--------------------------------------------------------------------------------+
-                                  X coordinate
-Y coordinate
+[Preview truncated for readability]
+See full ASCII output via the download link below.
 ```
 
 > **Full ASCII Output**: [Download pcolormesh_plasma.txt](../../media/examples/pcolormesh_demo/pcolormesh_plasma.txt) | [ASCII Format Guide](../ascii_output_format.md)

--- a/doc/examples/scale_examples.md
+++ b/doc/examples/scale_examples.md
@@ -33,22 +33,10 @@ make example ARGS="scale_examples"
 ![log_scale.png](../../media/examples/scale_examples/log_scale.png)
 
 ASCII output preview:
+
 ```
-Log Scale Example
-+--------------------------------------------------------------------------------+
-|10000   *                                                                       |
-|                                                                               |
-|1000      *                                                                     |
-|                                                                               |
-|100         *                                                                   |
-|                                                                               |
-|10            *                                                                 |
-|                                                                               |
-|1+--------+----------+----------+----------+----------+--------+              |
-  0        2          4          6          8         10                       |
-+--------------------------------------------------------------------------------+
-                                       x
-log(y)
+[Preview truncated for readability]
+See full ASCII output via the download link below.
 ```
 
 > **Full ASCII Output**: [Download log_scale.txt](../../media/examples/scale_examples/log_scale.txt) | [ASCII Format Guide](../ascii_output_format.md)
@@ -60,25 +48,10 @@ log(y)
 ![symlog_scale.png](../../media/examples/scale_examples/symlog_scale.png)
 
 ASCII output preview:
+
 ```
-Symlog Scale Example
-+--------------------------------------------------------------------------------+
-|100                                                                   *         |
-|                                                                                |
-|10                                                             *                |
-|                                                                                |
-|1                                                      *                        |
-|0     *     *     *                            *                               |
-|-1                         *            *                                      |
-|                                                                               |
-|-10                   *                                                        |
-|                                                                               |
-|-100              *                                                            |
-+--------+----------+----------+----------+----------+--------+                 |
--10     -5         0          5          10        15                          |
-+--------------------------------------------------------------------------------+
-                                       x
-symlog(y)
+[Preview truncated for readability]
+See full ASCII output via the download link below.
 ```
 
 > **Full ASCII Output**: [Download symlog_scale.txt](../../media/examples/scale_examples/symlog_scale.txt) | [ASCII Format Guide](../ascii_output_format.md)

--- a/doc/examples/unicode_demo.md
+++ b/doc/examples/unicode_demo.md
@@ -47,23 +47,10 @@ make example ARGS="unicode_demo"
 ![unicode_demo.png](../../media/examples/unicode_demo/unicode_demo.png)
 
 ASCII output preview:
+
 ```
-             Wave Functions: ψ(ω t) = A e^{-λ t} sin(ω t + φ)
-+--------------------------------------------------------------------------------+
-|1.0                                                                             |
-|     *                     -- α damped: sin                                    |
-|   *   *                   -- β damped: cos                                    |
-|0.5 *     *                -- γ oscillation                                   |
-|   *       *   ****                                                            |
-|0.0*--------*-------****---*----*--***-*-------*-*------***---*----------     |
-|             * *     *  *      *      *     * *         *   * *               |
-|-0.5           *       *                * *               *                    |
-|                                                                               |
-|-1.0+--------+----------+----------+----------+----------+--------+           |
-     0        2          4          6          8         10                    |
-+--------------------------------------------------------------------------------+
-                                  ωt (radians)
-Amplitude
+[Preview truncated for readability]
+See full ASCII output via the download link below.
 ```
 
 > **Full ASCII Output**: [Download unicode_demo.txt](../../media/examples/unicode_demo/unicode_demo.txt) | [ASCII Format Guide](../ascii_output_format.md)


### PR DESCRIPTION
Summary
- Remove large ASCII art blocks embedded in example pages and replace with a compact preview placeholder plus link to full .txt. The generated ASCII files remain unchanged and linked.

Scope
- Update 7 example docs that had inline ASCII art code blocks.

Verification
- Markdown now shows a short placeholder block instead of wide ASCII that rendered poorly. Links to `../../media/examples/.../*.txt` remain and serve the full output.
- No code changes; CI unaffected.

Rationale
- The inline ASCII didn’t render correctly in docs due to layout/width issues, while the actual ASCII outputs are fine. This change keeps pages clean and consistent and still provides a clearly labeled link to the full ASCII output.
