### PR TITLE
fix: Pdf simple plot examples shows "sin() Tj (x) Tj ()" in y label - (fixes #1083)

### DIFF
--- a/src/backends/vector/fortplot_pdf_text.f90
+++ b/src/backends/vector/fortplot_pdf_text.f90
@@ -155,6 +155,8 @@ contains
         integer :: i, codepoint
         character(len=4) :: utf_char
         character(len=8) :: symbol_char
+        character(len=8) :: escaped_char
+        integer :: esc_len
         
         do i = 1, len_trim(text)
             ! Get Unicode codepoint for character
@@ -177,8 +179,11 @@ contains
                     call switch_to_helvetica_font(this)
                     in_symbol_font = .false.
                 end if
-                ! Output regular character
-                this%stream_data = this%stream_data // "(" // text(i:i) // ") Tj" // new_line('a')
+                ! Output regular character with PDF escaping for (, ), and \
+                escaped_char = ''
+                esc_len = 0
+                call escape_pdf_string(text(i:i), escaped_char, esc_len)
+                this%stream_data = this%stream_data // "(" // escaped_char(1:esc_len) // ") Tj" // new_line('a')
             end if
         end do
     end subroutine process_text_segments

--- a/test/test_pdf_text_escaping.f90
+++ b/test/test_pdf_text_escaping.f90
@@ -1,0 +1,66 @@
+! Test: PDF text escaping for parentheses in mixed-font rendering
+program test_pdf_text_escaping
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    use fortplot, only: figure, ylabel, savefig
+    implicit none
+
+    character(len=*), parameter :: out_pdf = 'build/test/output/pdf_label_parens.pdf'
+    integer(kind=8) :: fsize
+    character, allocatable :: data(:)
+    integer :: unit, ios, i
+    logical :: found_open, found_close
+
+    call figure(figsize=[6.4_wp, 4.8_wp])
+    call ylabel('sin(x)')
+    call savefig(out_pdf)
+
+    found_open = .false.
+    found_close = .false.
+
+    open(newunit=unit, file=out_pdf, access='stream', form='unformatted', status='old', iostat=ios)
+    if (ios /= 0) then
+        print *, 'FAIL: cannot open ', trim(out_pdf)
+        stop 1
+    end if
+
+    inquire(unit=unit, size=fsize)
+    if (fsize <= 0) then
+        print *, 'FAIL: zero-size PDF'
+        close(unit)
+        stop 1
+    end if
+
+    allocate(character(len=1) :: data(fsize))
+    read(unit, iostat=ios) data
+    close(unit)
+    if (ios /= 0) then
+        print *, 'FAIL: cannot read PDF data'
+        stop 1
+    end if
+
+    ! Scan contiguous data for patterns
+    do i = 1, fsize-4
+        if (.not. found_open) then
+            if (data(i) == '(' .and. data(i+1) == '\' .and. data(i+2) == '(' .and. data(i+3) == ')' .and. data(i+4) == ' ') then
+                found_open = .true.
+            end if
+        end if
+        if (.not. found_close) then
+            if (data(i) == '(' .and. data(i+1) == '\' .and. data(i+2) == ')' .and. data(i+3) == ')' .and. data(i+4) == ' ') then
+                found_close = .true.
+            end if
+        end if
+        if (found_open .and. found_close) exit
+    end do
+
+    if (.not. found_open) then
+        print *, 'FAIL: missing escaped open parenthesis sequence (\() Tj in PDF stream'
+        stop 1
+    end if
+    if (.not. found_close) then
+        print *, 'FAIL: missing escaped close parenthesis sequence (\)) Tj in PDF stream'
+        stop 1
+    end if
+
+    print *, 'PASS: PDF parentheses escaped in mixed-font text'
+end program test_pdf_text_escaping


### PR DESCRIPTION
Summary
- Escape parentheses in PDF mixed-font text rendering to prevent raw "Tj" artifacts in labels.

Scope
- src/backends/vector/fortplot_pdf_text.f90
- test/test_pdf_text_escaping.f90

Verification
- Ran full test suite: all passed.
- New test asserts escaped sequences for '(' and ')' in generated PDF stream.

Rationale
- Fixes malformed PDF strings causing "sin() Tj (x) Tj ()" to appear in y-labels.
