### PR TITLE
fix: Streamplot too colorful (fixes #1089)

### DIFF
--- a/src/interfaces/fortplot_matplotlib_advanced.f90
+++ b/src/interfaces/fortplot_matplotlib_advanced.f90
@@ -335,6 +335,7 @@ contains
         real(8), intent(in), optional :: density, linewidth_scale, arrow_scale
         character(len=*), intent(in), optional :: colormap, label
         real(8) :: density_local
+        real(wp) :: line_color(3)
         real, allocatable :: trajectories(:,:,:)
         integer, allocatable :: traj_lengths(:)
         integer :: n_traj, i, j
@@ -353,6 +354,9 @@ contains
         end if
         density_local = 1.0d0
         if (present(density)) density_local = density
+        ! Use a single default color for all streamlines (matplotlib-style)
+        line_color = [0.0_wp, 0.447_wp, 0.698_wp]
+
         ! Generate trajectories using matplotlib-compatible algorithm
         call streamplot_matplotlib(x, y, u, v, density_local, trajectories, n_traj, traj_lengths)
 
@@ -364,7 +368,7 @@ contains
                 traj_x(j) = x(1) + real(trajectories(i, j, 1), wp) * (x(size(x)) - x(1)) / real(size(x) - 1, wp)
                 traj_y(j) = y(1) + real(trajectories(i, j, 2), wp) * (y(size(y)) - y(1)) / real(size(y) - 1, wp)
             end do
-            call fig%add_plot(traj_x, traj_y)
+            call fig%add_plot(traj_x, traj_y, color=line_color)
             deallocate(traj_x, traj_y)
         end do
     end subroutine streamplot

--- a/test/test_streamplot_interface_color.f90
+++ b/test/test_streamplot_interface_color.f90
@@ -1,0 +1,62 @@
+program test_streamplot_interface_color
+    use, intrinsic :: iso_fortran_env, only: real64
+    use fortplot_matplotlib_advanced, only: streamplot, get_global_figure, ensure_global_figure_initialized
+    use fortplot_figure_core, only: figure_t
+    use fortplot_plot_data, only: plot_data_t
+    implicit none
+
+    real(real64), dimension(5) :: x
+    real(real64), dimension(5) :: y
+    real(real64), dimension(5,5) :: u, v
+    class(figure_t), pointer :: fig
+    type(plot_data_t), pointer :: plots(:)
+    integer :: i, j, n
+    real(real64), dimension(3) :: ref_color
+    logical :: all_same
+
+    ! Setup a simple vector field
+    do i = 1, 5
+        x(i) = real(i-1, real64)
+        y(i) = real(i-1, real64)
+    end do
+    do j = 1, 5
+        do i = 1, 5
+            u(i,j) = 1.0_real64
+            v(i,j) = 0.0_real64
+        end do
+    end do
+
+    call ensure_global_figure_initialized()
+    call streamplot(x, y, u, v)
+
+    fig => get_global_figure()
+    n = fig%get_plot_count()
+    if (n <= 0) then
+        print *, "ERROR: streamplot produced no plots"
+        stop 1
+    end if
+
+    plots => fig%get_plots()
+    ref_color = plots(1)%color
+    all_same = .true.
+    do i = 2, n
+        if (any(abs(plots(i)%color - ref_color) > 1.0e-12_real64)) then
+            all_same = .false.
+            exit
+        end if
+    end do
+
+    if (.not. all_same) then
+        print *, "ERROR: Streamplot interface assigned varying colors across streamlines"
+        stop 1
+    end if
+
+    ! Optional: check equals default blue
+    if (any(abs(ref_color - [0.0_real64, 0.447_real64, 0.698_real64]) > 1.0e-12_real64)) then
+        print *, "ERROR: Streamplot default color not blue as expected"
+        stop 1
+    end if
+
+    print *, "Streamplot interface color test passed"
+end program test_streamplot_interface_color
+


### PR DESCRIPTION
Summary
- Make streamplot interface use a single default color for all streamlines.

Scope
- Updated src/interfaces/fortplot_matplotlib_advanced.f90 streamplot to pass a fixed color.
- Added test/test_streamplot_interface_color.f90 to verify uniform colors.

Verification
- Ran make test-ci and make test with TEST_TIMEOUT=120s; all tests passed locally.
- New test confirms every streamline shares the same RGB color and matches the default blue.

Rationale
- Issue #1089 reported streamplot cycling colors per streamline when using the matplotlib-compatible interface. The core streamplot already used a single color; the interface path added lines via add_plot without a color, triggering color cycling. Passing an explicit color aligns defaults with user expectation and docs.
