### PR TITLE
fix(example): use global figure for animation to avoid segfault

### DIFF
--- a/example/fortran/animation/save_animation_demo.f90
+++ b/example/fortran/animation/save_animation_demo.f90
@@ -5,7 +5,7 @@ program save_animation_demo
 
     integer, parameter :: NFRAMES = 60
     
-    type(figure_t), target :: fig
+    type(figure_t), pointer :: pfig
     type(animation_t) :: anim
     real(wp), dimension(100) :: x, y
     integer :: i
@@ -18,17 +18,18 @@ program save_animation_demo
     ! Initial y data
     y = sin(x)
     
-    ! Initialize local figure object and add content directly
-    call fig%initialize()
-    call fig%add_plot(x, y, label='animated wave')
-    call fig%set_title('Animation Save Demo')
-    call fig%set_xlabel('x')
-    call fig%set_ylabel('y')
-    call fig%set_xlim(0.0_wp, 2.0_wp * 3.14159_wp)
-    call fig%set_ylim(-1.5_wp, 1.5_wp)
+    ! Use pyplot-style global figure to avoid initialization differences across environments
+    call figure(figsize=[8.0_wp, 6.0_wp])
+    call add_plot(x, y, label='animated wave')
+    call title('Animation Save Demo')
+    call xlabel('x')
+    call ylabel('y')
+    call xlim(0.0_wp, 2.0_wp * 3.14159_wp)
+    call ylim(-1.5_wp, 1.5_wp)
     
-    ! Create animation with figure reference
-    anim = FuncAnimation(update_wave, frames=NFRAMES, interval=50, fig=fig)
+    ! Create animation with the same global figure reference
+    pfig => get_global_figure()
+    anim = FuncAnimation(update_wave, frames=NFRAMES, interval=50, fig=pfig)
     
     ! Save as MP4 video with 24 fps to GitHub Pages structure
     print *, "Saving animation as MP4..."
@@ -47,8 +48,8 @@ contains
         ! Update y data with animated wave
         y = sin(x + phase) * cos(phase * 0.5_wp)
         
-        ! Update plot data on the same figure used by the animation
-        call fig%set_ydata(1, y)
+        ! Update plot data via pyplot API (targets global figure)
+        call set_ydata(y)
     end subroutine update_wave
     
     subroutine save_animation_with_error_handling(anim, filename, fps)


### PR DESCRIPTION
Summary
- Prevent intermittent segfault in CI when initializing a local figure by using the pyplot global figure and passing it to FuncAnimation, while still ensuring the animation updates the same plotted series.

Scope
- example/fortran/animation/save_animation_demo.f90
  - Switch back to pyplot `figure()/add_plot()` setup.
  - Obtain `pfig => get_global_figure()` and pass to `FuncAnimation`.
  - Use `set_ydata(y)` for frame updates.

Verification
- Local: `make example ARGS="save_animation_demo"` → MP4 ~53 KiB at 800x600, 60 frames, shows line content.
- Special examples script now runs save_animation_demo without crash.

Rationale
- CI runner (GCC 13, ffmpeg 6.1.1) hit a segfault inside `figure_initialize` when using a local `figure_t`. Using the established pyplot code path (which CI already exercises for other examples) removes the crash while maintaining the fix that the animation operates on the same figure context.
