### PR TITLE
fix(example): ensure animated line is visibly rendered each frame

### DIFF
--- a/example/fortran/animation/save_animation_demo.f90
+++ b/example/fortran/animation/save_animation_demo.f90
@@ -21,6 +21,7 @@ program save_animation_demo
     ! Use pyplot-style global figure to avoid initialization differences across environments
     call figure(figsize=[8.0_wp, 6.0_wp])
     call add_plot(x, y, label='animated wave')
+    call set_line_width(2.0_wp)
     call title('Animation Save Demo')
     call xlabel('x')
     call ylabel('y')
@@ -48,8 +49,9 @@ contains
         ! Update y data with animated wave
         y = sin(x + phase) * cos(phase * 0.5_wp)
         
-        ! Update plot data via pyplot API (targets global figure)
-        call set_ydata(y)
+        ! Update plot data on the same figure and force re-render
+        call pfig%set_ydata(1, y)
+        call pfig%set_rendered(.false.)
     end subroutine update_wave
     
     subroutine save_animation_with_error_handling(anim, filename, fps)


### PR DESCRIPTION
Summary
- Ensure the animated line is clearly visible by increasing line width and forcing a re-render on each frame update.

Scope
- example/fortran/animation/save_animation_demo.f90
  - call set_line_width(2.0)
  - in update_wave(): use pfig%set_ydata(1, y) and pfig%set_rendered(.false.)
  - keep using pyplot global figure (avoids CI segfault) and pass it into FuncAnimation

Verification
- Local: `make example ARGS="save_animation_demo"` produces MP4 800x600, 60 frames, ~53 KiB.
- Used ffprobe to confirm stream and frame count.
- Special examples script runs through animation without crash.

Rationale
- Previously, frames could reuse a rendered buffer and the thin default line could be visually lost in compression. Explicitly resetting rendered state per frame and using a slightly thicker line makes the line reliably visible in the encoded video across environments.
