### PR TITLE
fix: In https://lazy-fortran.github.io/fortplot/page/examples/marker_ (fixes #1110)

### DIFF
--- a/doc/examples/marker_demo.md
+++ b/doc/examples/marker_demo.md
@@ -54,4 +54,8 @@ make example ARGS="marker_demo"
 
 ![marker_colors.png](../../media/examples/marker_demo/marker_colors.png)
 
-[Download PDFs](../../media/examples/)
+Download PDFs:
+
+- [scatter_plot.pdf](../../media/examples/marker_demo/scatter_plot.pdf)
+- [all_marker_types.pdf](../../media/examples/marker_demo/all_marker_types.pdf)
+- [marker_colors.pdf](../../media/examples/marker_demo/marker_colors.pdf)


### PR DESCRIPTION
Summary
- Replace generic "Download PDFs" link with explicit example PDF links.

Scope
- doc/examples/marker_demo.md only; no code behavior changes.

Verification
- Built and ran full test suite locally: all tests passed.
- Links resolve to expected media paths for marker_demo outputs.

Rationale
- Improves UX by providing direct PDF downloads per example as requested.
