### PR TITLE
fix: Problems in pcolormesh (fixes #1111)

### DIFF
--- a/src/backends/vector/fortplot_pdf_core.f90
+++ b/src/backends/vector/fortplot_pdf_core.f90
@@ -89,9 +89,12 @@ contains
         safe_g = max(0.0_wp, min(1.0_wp, safe_g))
         safe_b = max(0.0_wp, min(1.0_wp, safe_b))
         
+        ! Set both stroking (RG) and non-stroking (rg) colors.
         write(color_cmd, '(F0.3, 1X, F0.3, 1X, F0.3, " RG")') safe_r, safe_g, safe_b
         this%stream_data = this%stream_data // trim(adjustl(color_cmd)) // new_line('a')
-    end subroutine set_pdf_color
+        write(color_cmd, '(F0.3, 1X, F0.3, 1X, F0.3, " rg")') safe_r, safe_g, safe_b
+        this%stream_data = this%stream_data // trim(adjustl(color_cmd)) // new_line('a')
+        end subroutine set_pdf_color
 
     subroutine set_pdf_line_width(this, width)
         class(pdf_context_core), intent(inout) :: this

--- a/src/backends/vector/fortplot_pdf_drawing.f90
+++ b/src/backends/vector/fortplot_pdf_drawing.f90
@@ -210,10 +210,14 @@ contains
             call log_debug(trim(debug_msg))
         end if
         
-        ! Write validated color values
+        ! Write validated color values for strokes AND fills
+        ! Keep stroke and fill colors in sync to ensure filled shapes
+        ! (e.g., pcolormesh quads) render with the intended color.
         write(cmd, '(F0.3,1X,F0.3,1X,F0.3," RG")') r_safe, g_safe, b_safe
         call this%add_to_stream(trim(cmd))
-    end subroutine pdf_write_color
+        write(cmd, '(F0.3,1X,F0.3,1X,F0.3," rg")') r_safe, g_safe, b_safe
+        call this%add_to_stream(trim(cmd))
+        end subroutine pdf_write_color
 
     subroutine pdf_write_line_width(this, width)
         !! Write PDF line width command with robust validation

--- a/test/test_pdf_pcolormesh_colors.f90
+++ b/test/test_pdf_pcolormesh_colors.f90
@@ -1,0 +1,55 @@
+program test_pdf_pcolormesh_colors
+    use fortplot
+    use iso_fortran_env, only: wp => real64
+    use fortplot_system_runtime, only: create_directory_runtime
+    implicit none
+
+    character(len=*), parameter :: out_pdf = 'test/output/test_pcolormesh_colors.pdf'
+    real(wp) :: x(4), y(3), c(2,3)
+    logical :: ok
+
+    integer :: unit, ios
+    character(len=65536) :: buf
+    integer :: read_len
+    logical :: has_nonblack_fill
+
+    call create_directory_runtime('test/output', ok)
+
+    x = [0.0_wp, 1.0_wp, 2.0_wp, 3.0_wp]
+    y = [0.0_wp, 0.5_wp, 1.0_wp]
+    c = reshape([0.1_wp, 0.4_wp, 0.6_wp, &
+                 0.2_wp, 0.8_wp, 0.9_wp], [2,3])
+
+    call figure()
+    call pcolormesh(x, y, c)
+    call title('PDF pcolormesh color test')
+    call savefig(out_pdf)
+
+    ! Read the generated PDF and verify that at least one non-black
+    ! non-stroking color ("rg") command appears in the stream.
+    open(newunit=unit, file=out_pdf, status='old', action='read', iostat=ios)
+    if (ios /= 0) then
+        write(*,'(A)') 'FAIL: could not open '//trim(out_pdf)
+        error stop 1
+    end if
+    buf = ''
+    read_len = 0
+    do
+        read(unit, '(A)', iostat=ios) buf(read_len+1:)
+        if (ios /= 0) exit
+        read_len = len_trim(buf)
+        if (read_len > len(buf) - 256) exit
+    end do
+    close(unit)
+
+    ! Check for any ' rg' occurrence that is not the initial '0 0 0 rg'
+    has_nonblack_fill = index(buf, ' rg') > 0 .and. index(buf, '0.000 0.000 0.000 rg') == 0
+    if (has_nonblack_fill) then
+        write(*,'(A)') 'PASS: PDF contains non-black fill color commands (rg)'
+        stop 0
+    else
+        write(*,'(A)') 'FAIL: Missing non-black fill color (rg) in PDF stream'
+        error stop 2
+    end if
+end program test_pdf_pcolormesh_colors
+


### PR DESCRIPTION
Summary
- Fix PDF pcolormesh fills by setting non-stroking color.

Scope
- Update PDF color setters to write both RG and rg.
- Add test ensuring non-black fill color appears in PDF stream.

Verification
- Ran CI-fast tests locally: all passed.
- New test: test_pdf_pcolormesh_colors ensures 'rg' with non-black values.

Rationale
- Issue #1111 reports empty pcolormesh in PDF; root cause was not setting non-stroking color used by 'f'.
