### PR TITLE
fix: The "all marker types" plot is empty (fixes #1109)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,8 @@ doc:
 	# Generate streamplot and pcolormesh demos so images are available in docs
 	$(MAKE) example ARGS="streamplot_demo" >/dev/null
 	$(MAKE) example ARGS="pcolormesh_demo" >/dev/null
+	# Generate marker demo so marker images (including all_marker_types.png) are present (fixes #1109)
+	$(MAKE) example ARGS="marker_demo" >/dev/null
 	# Generate animation demo so MP4 is available for docs (fixes #1085)
 	$(MAKE) example ARGS="save_animation_demo" >/dev/null
 	# Run FORD to generate documentation structure


### PR DESCRIPTION
Summary
- Ensure marker_demo images (including all_marker_types.png) are generated during `make doc`.

Scope
- Makefile: add `make example ARGS="marker_demo"` in `doc` target.

Verification
- Ran `make example ARGS="marker_demo"` and confirmed output file exists and is non-empty: `output/example/fortran/marker_demo/all_marker_types.png` (640x480).
- Ran `make test-ci` (120s per step) and all CI-fast tests passed locally.

Rationale
- Docs page linked to all_marker_types.png was empty/missing. Pre-generating the example ensures the media is present and copied into the docs build outputs.
