### PR TITLE
fix: handle colormap names case-insensitively

### DIFF
--- a/src/utilities/colors/fortplot_colormap.f90
+++ b/src/utilities/colors/fortplot_colormap.f90
@@ -3,6 +3,7 @@ module fortplot_colormap
     !! Provides color interpolation for different colormaps like matplotlib
     
     use, intrinsic :: iso_fortran_env, only: wp => real64
+    use fortplot_color_definitions, only: to_lowercase
     use fortplot_constants, only: EPSILON_COMPARE
     implicit none
     
@@ -16,13 +17,17 @@ contains
         real(wp), intent(in) :: value
         character(len=*), intent(in) :: colormap
         real(wp), dimension(3), intent(out) :: color
-        
+        character(len=:), allocatable :: cmap
         real(wp) :: t
         
         ! Clamp value to [0,1]
         t = max(0.0_wp, min(1.0_wp, value))
+
+        ! Normalize colormap name (case-insensitive)
+        cmap = trim(colormap)
+        call to_lowercase(cmap)
         
-        select case (trim(colormap))
+        select case (cmap)
         case ('seaborn', 'colorblind', 'crest')
             call crest_colormap(t, color)
         case ('viridis')
@@ -169,12 +174,16 @@ contains
         end if
     end subroutine interpolate_colormap
 
-    pure function validate_colormap_name(colormap) result(is_valid)
+    function validate_colormap_name(colormap) result(is_valid)
         !! Validate if colormap name is supported
         character(len=*), intent(in) :: colormap
         logical :: is_valid
-        
-        select case (trim(colormap))
+        character(len=:), allocatable :: cmap
+
+        cmap = trim(colormap)
+        call to_lowercase(cmap)
+
+        select case (cmap)
         case ('seaborn', 'colorblind', 'crest', 'viridis', 'plasma', 'inferno', &
               'coolwarm', 'jet')
             is_valid = .true.

--- a/test/test_colormap_case_insensitive.f90
+++ b/test/test_colormap_case_insensitive.f90
@@ -1,0 +1,49 @@
+program test_colormap_case_insensitive
+    !! Verify colormap names are handled case-insensitively
+    use iso_fortran_env, only: wp => real64
+    use fortplot_colormap, only: colormap_value_to_color, validate_colormap_name
+    implicit none
+
+    call run_tests()
+
+contains
+
+    subroutine run_tests()
+        real(wp) :: c1(3), c2(3)
+        logical :: ok
+
+        ! Plasma: lower vs mixed case should match
+        call colormap_value_to_color(0.25_wp, 0.0_wp, 1.0_wp, 'plasma', c1)
+        call colormap_value_to_color(0.25_wp, 0.0_wp, 1.0_wp, 'PlAsMa', c2)
+        call assert_close(c1, c2, 'plasma case-insensitive mapping')
+
+        ! Inferno: lower vs upper case should match
+        call colormap_value_to_color(0.75_wp, 0.0_wp, 1.0_wp, 'inferno', c1)
+        call colormap_value_to_color(0.75_wp, 0.0_wp, 1.0_wp, 'INFERNO', c2)
+        call assert_close(c1, c2, 'inferno case-insensitive mapping')
+
+        ! validate_colormap_name should accept mixed case as valid
+        ok = validate_colormap_name('ViRiDiS')
+        if (.not. ok) then
+            print *, 'FAIL: validate_colormap_name rejects mixed-case Viridis'
+            error stop 1
+        end if
+
+        print *, 'PASS: Colormap names are case-insensitive'
+    end subroutine run_tests
+
+    subroutine assert_close(a, b, label)
+        real(wp), intent(in) :: a(3), b(3)
+        character(len=*), intent(in) :: label
+        real(wp) :: tol
+        tol = 1.0e-12_wp
+        if (maxval(abs(a - b)) > tol) then
+            print *, 'FAIL: ', trim(label)
+            print *, '  a =', a
+            print *, '  b =', b
+            error stop 1
+        end if
+    end subroutine assert_close
+
+end program test_colormap_case_insensitive
+


### PR DESCRIPTION
Summary
- Make colormap names case-insensitive in `fortplot_colormap` and add a targeted test.

Scope
- Files: `src/utilities/colors/fortplot_colormap.f90`, `test/test_colormap_case_insensitive.f90`.
- No behavior changes beyond colormap name normalization.

Verification
- Locally ran `make test` (full) and `fpm test --target test_colormap_case_insensitive`; all pass.
- New test: verifies mapping equality across case variants and `validate_colormap_name` accepts mixed case.

Rationale
- Prevents subtle palette mismatches when users pass mixed-case colormap names (e.g., 'Viridis', 'INFERNO').
