### PR TITLE
fix(docs): resolve FORD warnings (titles, missing pages) (#1127)

### DIFF
--- a/doc/archive/CONSOLIDATION_SUMMARY.md
+++ b/doc/archive/CONSOLIDATION_SUMMARY.md
@@ -1,3 +1,6 @@
+title: Documentation Consolidation Summary
+---
+
 # Documentation Consolidation Summary
 
 ## Issue #271: Consolidate duplicate documentation content

--- a/doc/archive/implementation_plan_issue_19.md
+++ b/doc/archive/implementation_plan_issue_19.md
@@ -1,3 +1,6 @@
+title: Implementation Plan (Issue #19)
+---
+
 # Implementation Plan for Issue #19: Add Comprehensive Docstrings to Public Interface
 
 ## Overview

--- a/doc/archive/index.md
+++ b/doc/archive/index.md
@@ -1,3 +1,6 @@
+title: Archive
+---
+
 archive
 =======
 
@@ -10,4 +13,3 @@ part of the core user guide, but may be useful for contributors:
 
 These pages are intentionally brief to ensure a clean FORD build without
 spurious missing‑page warnings.
-

--- a/doc/cmake_example/index.md
+++ b/doc/cmake_example/index.md
@@ -1,3 +1,6 @@
+title: CMake Example
+---
+
 cmake_example
 =============
 
@@ -13,4 +16,3 @@ Usage
 This example is intended for reference and smoke‑testing only. It is not part of
 the primary build. See `doc/user_compilation_guide.md` for user‑focused build
 instructions with fpm.
-

--- a/doc/design/axes_layout.md
+++ b/doc/design/axes_layout.md
@@ -1,3 +1,6 @@
+title: Axes and Layout Design
+---
+
 # Axes and Layout Implementation Design
 
 ## Overview

--- a/doc/design/backends.md
+++ b/doc/design/backends.md
@@ -1,3 +1,6 @@
+title: Backend Architecture Design
+---
+
 # Backend Architecture Implementation Design
 
 ## Overview

--- a/doc/design/basic_plots.md
+++ b/doc/design/basic_plots.md
@@ -1,3 +1,6 @@
+title: Basic Plots Design
+---
+
 # Basic Plots Implementation Design
 
 ## Overview

--- a/doc/design/contour.md
+++ b/doc/design/contour.md
@@ -1,3 +1,6 @@
+title: Contour Plots Design
+---
+
 # Contour Plots Implementation Design
 
 ## Overview

--- a/doc/design/figure_management.md
+++ b/doc/design/figure_management.md
@@ -1,3 +1,6 @@
+title: Figure Management Design
+---
+
 # Figure Management Implementation Design
 
 ## Overview

--- a/doc/design/index.md
+++ b/doc/design/index.md
@@ -1,0 +1,15 @@
+title: Design Notes
+---
+
+# Design Notes
+
+This section contains design documents for fortplot. Use the links below to navigate:
+
+- [Axes Layout](axes_layout.md)
+- [Backends](backends.md)
+- [Basic Plots](basic_plots.md)
+- [Contour](contour.md)
+- [Figure Management](figure_management.md)
+- [Streamplot](streamplot.md)
+- [Styling](styling.md)
+

--- a/doc/design/streamplot.md
+++ b/doc/design/streamplot.md
@@ -1,3 +1,6 @@
+title: Streamplot Design
+---
+
 # Streamplot Implementation Design
 
 ## Overview

--- a/doc/design/styling.md
+++ b/doc/design/styling.md
@@ -1,3 +1,6 @@
+title: Styling and Appearance Design
+---
+
 # Styling and Appearance Implementation Design
 
 ## Overview

--- a/doc/examples/annotation_demo.md
+++ b/doc/examples/annotation_demo.md
@@ -1,3 +1,6 @@
+title: Annotation Demo
+---
+
 ## Source Code
 
 [annotation_demo.f90](https://github.com/lazy-fortran/fortplot/blob/main/example/fortran/annotation_demo/annotation_demo.f90)

--- a/doc/fpm_example/app/index.md
+++ b/doc/fpm_example/app/index.md
@@ -1,0 +1,16 @@
+title: fpm App Entry
+---
+
+# fpm App Entry
+
+This folder contains a minimal `main.f90` demonstrating fortplot usage from an `fpm` application.
+
+- Source: [main.f90](main.f90)
+
+Build and run with:
+
+```sh
+fpm build
+fpm run
+```
+

--- a/doc/fpm_example/index.md
+++ b/doc/fpm_example/index.md
@@ -1,0 +1,17 @@
+title: fpm Quick Start
+---
+
+# fpm Quick Start
+
+This example demonstrates how to set up a minimal Fortran project using `fpm` with fortplot.
+
+- Project manifest: [fpm.toml](fpm.toml)
+- Minimal application: see `app/` in this folder
+
+To build and run with fpm:
+
+```sh
+fpm build
+fpm run
+```
+

--- a/doc/module_architecture.md
+++ b/doc/module_architecture.md
@@ -1,3 +1,6 @@
+title: Module Architecture Guide
+---
+
 # Module Architecture Guide
 
 ## Overview

--- a/doc/python_example/index.md
+++ b/doc/python_example/index.md
@@ -1,0 +1,16 @@
+title: Python Bridge Example
+---
+
+# Python Bridge Example
+
+Minimal example of using the Python wrapper to call fortplot.
+
+- Script: [example.py](example.py)
+- Project config: [pyproject.toml](pyproject.toml)
+
+Run the example:
+
+```sh
+python3 example.py
+```
+

--- a/fpm.toml
+++ b/fpm.toml
@@ -30,7 +30,7 @@ summary = "Modern Fortran plotting library with multiple backends"
 src_dir = ["src", "example"]
 output_dir = "build/doc"
 page_dir = "doc"
-exclude = "fortplot_pdf_text.f90"
+exclude = "**/fortplot_pdf_text.f90"
 
 # Tests are auto-discovered from test/ directory
 


### PR DESCRIPTION
Summary
- Add `title:` metadata to affected pages and create missing `index.md` for design, fpm_example, python_example; adjust FORD exclude pattern to avoid spurious warnings.

Scope
- Files: doc/{archive,cmake_example,examples,design}/..., fpm.toml (FORD exclude), new index pages for missing dirs.

Verification
- Commands:
  - make doc
  - TEST_TIMEOUT=120s make test-ci
- Outputs (excerpts):
  - FORD build tail:
    ```
    Creating HTML documentation... done in …
    Writing files         … build/doc/search.html
    
    Browse the generated documentation: file:///home/ert/code/fortplot/build/doc/index.html
    ```
  - Page metadata check:
    ```
    OK: All pages have title metadata in first 5 lines
    ```
  - CI-fast tests:
    ```
    CI essential test suite completed successfully
    ```

Rationale
- Cleans up FORD documentation warnings to ensure navigation works and metadata is present, satisfying #1127.