### PR TITLE
fix: Python bridge: implement contour/contourf, pcolormesh, log/symlog scales, streamplot (fixes #1128)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,19 @@ jobs:
           fi
         done
 
+    # Python setup for bridge tests (Ubuntu)
+    - name: Setup Python (Ubuntu)
+      if: matrix.os == 'ubuntu-latest'
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+
+    - name: Install Python packages (Ubuntu)
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        python3 -m pip install --upgrade pip
+        python3 -m pip install numpy
+
     # ---------- Windows setup ----------
     - name: Configure git line endings (Windows)
       if: runner.os == 'Windows'

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,10 @@ test-ci:
 	@$(TIMEOUT_PREFIX) python3 scripts/test_python_bridge_security.py || exit 1
 	@# Basic non-interactive Python bridge functionality using example command file (fixes #919)
 	@chmod +x scripts/test_python_bridge_example.sh && $(TIMEOUT_PREFIX) ./scripts/test_python_bridge_example.sh || exit 1
+	@# Python bridge: pcolormesh via wrapper
+	@$(TIMEOUT_PREFIX) python3 scripts/test_python_pcolormesh_via_bridge.py || exit 1
+	@# Python bridge: log scale via wrapper
+	@$(TIMEOUT_PREFIX) python3 scripts/test_python_scales_via_bridge.py || exit 1
 	@# Regression for filled-quad edge coverage (prevents 1px cuts on borders)
 	@$(TIMEOUT_PREFIX) fpm test $(FPM_FLAGS_TEST) --target test_quad_fill_edges || exit 1
 	@# Guard against redundant pcolormesh tests (Issue #897)

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,8 @@ test-ci:
 	@$(TIMEOUT_PREFIX) python3 scripts/test_python_pcolormesh_via_bridge.py || exit 1
 	@# Python bridge: log scale via wrapper
 	@$(TIMEOUT_PREFIX) python3 scripts/test_python_scales_via_bridge.py || exit 1
+	@# Python bridge: streamplot via wrapper
+	@$(TIMEOUT_PREFIX) python3 scripts/test_python_streamplot_via_bridge.py || exit 1
 	@# Regression for filled-quad edge coverage (prevents 1px cuts on borders)
 	@$(TIMEOUT_PREFIX) fpm test $(FPM_FLAGS_TEST) --target test_quad_fill_edges || exit 1
 	@# Guard against redundant pcolormesh tests (Issue #897)

--- a/app/fortplot_python_bridge.f90
+++ b/app/fortplot_python_bridge.f90
@@ -67,6 +67,8 @@ program fortplot_python_bridge
             call process_contour_command(.false.)
         case ('CONTOURF')
             call process_contour_command(.true.)
+        case ('STREAMPLOT')
+            call process_streamplot_command()
         case ('TITLE')
             call process_title_command()
         case ('XLABEL')

--- a/python/fortplot/axes.py
+++ b/python/fortplot/axes.py
@@ -97,7 +97,29 @@ def legend(**kwargs):
     # For now, use default legend formatting
     _fortplot.fortplot.legend()
 
-# Note: xscale and yscale not implemented in wrapper yet
+def xscale(scale, threshold=None):
+    """Set the x-axis scale.
+
+    Parameters
+    ----------
+    scale : str
+        One of 'linear', 'log', or 'symlog'.
+    threshold : float, optional
+        Symmetric log threshold (only used for 'symlog').
+    """
+    _fortplot.fortplot.set_xscale(scale, threshold)
+
+def yscale(scale, threshold=None):
+    """Set the y-axis scale.
+
+    Parameters
+    ----------
+    scale : str
+        One of 'linear', 'log', or 'symlog'.
+    threshold : float, optional
+        Symmetric log threshold (only used for 'symlog').
+    """
+    _fortplot.fortplot.set_yscale(scale, threshold)
 
 def xlim(xmin, xmax):
     """Set the x-axis limits."""

--- a/python/fortplot/fortplot.py
+++ b/python/fortplot/fortplot.py
@@ -60,7 +60,7 @@ For more examples and documentation, see the fortplot GitHub repository.
 
 # Import core and lightweight axes directly (no heavy deps)
 from fortplot.core import figure, plot, savefig, show
-from fortplot.axes import title, xlabel, ylabel, legend, xlim, ylim
+from fortplot.axes import title, xlabel, ylabel, legend, xlim, ylim, xscale, yscale
 
 # Lazily import advanced and data functions to avoid hard numpy dependency
 def contour(*args, **kwargs):
@@ -90,16 +90,7 @@ def histogram(*args, **kwargs):
 # Maintain backward compatibility by exposing all functions at package level
 __all__ = [
     'figure', 'plot', 'savefig', 'show',
-    'title', 'xlabel', 'ylabel', 'legend', 'xlim', 'ylim', 
+    'title', 'xlabel', 'ylabel', 'legend', 'xlim', 'ylim', 'xscale', 'yscale',
     'contour', 'contourf', 'streamplot', 'pcolormesh',
     'scatter', 'histogram'
 ]
-
-# Support for legacy scale functions (not yet implemented in wrapper)
-def xscale(scale):
-    """Set the x-axis scale (placeholder - not yet implemented)."""
-    print(f"Warning: xscale({scale}) not yet implemented")
-
-def yscale(scale):
-    """Set the y-axis scale (placeholder - not yet implemented)."""
-    print(f"Warning: yscale({scale}) not yet implemented")

--- a/python/fortplot/fortplot_wrapper.py
+++ b/python/fortplot/fortplot_wrapper.py
@@ -240,28 +240,128 @@ class FortplotModule:
     
     # Placeholder functions for compatibility (not implemented in bridge yet)
     def contour(self, x, y, z, levels=None):
-        """Contour function (not yet implemented in bridge)."""
-        print("Warning: contour plots not yet implemented in bridge")
+        """Send contour command to bridge."""
+        x = _to_array(x)
+        y = _to_array(y)
+        z = _to_array(z)
+        if z.ndim != 2:
+            raise ValueError("z must be 2D array")
+        self._send_command("CONTOUR")
+        self._send_command(f"{len(x)} {len(y)}")
+        for val in x:
+            self._send_command(str(float(val)))
+        for val in y:
+            self._send_command(str(float(val)))
+        # z expected shape (len(y), len(x)) here
+        ny, nx = z.shape
+        for i in range(ny):
+            for j in range(nx):
+                self._send_command(str(float(z[i, j])))
+        if levels is not None:
+            levels_arr = _to_array(levels)
+            self._send_command(str(len(levels_arr)))
+            for lv in levels_arr:
+                self._send_command(str(float(lv)))
+        else:
+            self._send_command("0")
     
     def contour_filled(self, x, y, z, levels=None):
-        """Filled contour function (not yet implemented in bridge)."""
-        print("Warning: filled contour plots not yet implemented in bridge")
+        """Send filled contour command to bridge."""
+        x = _to_array(x)
+        y = _to_array(y)
+        z = _to_array(z)
+        if z.ndim != 2:
+            raise ValueError("z must be 2D array")
+        self._send_command("CONTOURF")
+        self._send_command(f"{len(x)} {len(y)}")
+        for val in x:
+            self._send_command(str(float(val)))
+        for val in y:
+            self._send_command(str(float(val)))
+        ny, nx = z.shape
+        for i in range(ny):
+            for j in range(nx):
+                self._send_command(str(float(z[i, j])))
+        if levels is not None:
+            levels_arr = _to_array(levels)
+            self._send_command(str(len(levels_arr)))
+            for lv in levels_arr:
+                self._send_command(str(float(lv)))
+        else:
+            self._send_command("0")
     
     def pcolormesh(self, x, y, c, cmap='viridis', vmin=None, vmax=None, edgecolors='none', linewidths=None):
-        """Pcolormesh function (not yet implemented in bridge)."""
-        print("Warning: pcolormesh plots not yet implemented in bridge")
+        """Send pcolormesh command to bridge (basic parameters only)."""
+        x = _to_array(x)
+        y = _to_array(y)
+        c = _to_array(c)
+        if c.ndim != 2:
+            raise ValueError("c must be 2D array")
+        # Expect edge coordinates: len(x)=nx, len(y)=ny, c shape (ny-1, nx-1)
+        self._send_command("PCOLORMESH")
+        self._send_command(f"{len(x)} {len(y)}")
+        for val in x:
+            self._send_command(str(float(val)))
+        for val in y:
+            self._send_command(str(float(val)))
+        my, mx = c.shape
+        for i in range(my):
+            for j in range(mx):
+                self._send_command(str(float(c[i, j])))
+        # Note: advanced styling args (cmap, vmin, vmax, edgecolors, linewidths)
+        # are not sent yet; defaults are used by Fortran side.
     
     def streamplot(self, x, y, u, v, density=1.0):
-        """Streamplot function (not yet implemented in bridge)."""
-        print("Warning: streamplot not yet implemented in bridge")
+        """Send streamplot command to bridge."""
+        x = _to_array(x)
+        y = _to_array(y)
+        u = _to_array(u)
+        v = _to_array(v)
+        if u.ndim != 2 or v.ndim != 2:
+            raise ValueError("u and v must be 2D arrays")
+        if u.shape != v.shape:
+            raise ValueError("u and v must have the same shape")
+        self._send_command("STREAMPLOT")
+        self._send_command(f"{len(x)} {len(y)}")
+        for val in x:
+            self._send_command(str(float(val)))
+        for val in y:
+            self._send_command(str(float(val)))
+        nx = len(x)
+        ny = len(y)
+        if u.shape != (nx, ny):
+            # Try (ny, nx) then
+            if u.shape == (ny, nx):
+                u = u.T
+                v = v.T
+            else:
+                raise ValueError("u,v shape must match (len(x), len(y)) or its transpose")
+        for i in range(nx):
+            for j in range(ny):
+                self._send_command(str(float(u[i, j])))
+        for i in range(nx):
+            for j in range(ny):
+                self._send_command(str(float(v[i, j])))
+        self._send_command(str(float(density)))
     
-    def set_xscale(self, scale):
-        """Set x-axis scale (not yet implemented in bridge)."""
-        print(f"Warning: set_xscale('{scale}') not yet implemented in bridge")
+    def set_xscale(self, scale, threshold=None):
+        """Set x-axis scale via bridge (supports 'linear','log','symlog')."""
+        self._send_command("XSCALE")
+        self._send_command(str(scale))
+        if threshold is not None:
+            self._send_command(str(float(threshold)))
+        else:
+            # Send a line to allow Fortran to attempt read and fail gracefully
+            self._send_command("")
     
-    def set_yscale(self, scale):
-        """Set y-axis scale (not yet implemented in bridge)."""
-        print(f"Warning: set_yscale('{scale}') not yet implemented in bridge")
+    def set_yscale(self, scale, threshold=None):
+        """Set y-axis scale via bridge (supports 'linear','log','symlog')."""
+        self._send_command("YSCALE")
+        self._send_command(str(scale))
+        if threshold is not None:
+            self._send_command(str(float(threshold)))
+        else:
+            self._send_command("")
 
 
 # Export the real fortplot module in the expected structure

--- a/scripts/test_python_pcolormesh_via_bridge.py
+++ b/scripts/test_python_pcolormesh_via_bridge.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+import os
+import sys
+from pathlib import Path
+
+# Add package path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'python'))
+
+import numpy as np
+
+
+def main():
+    import fortplot
+
+    # Simple regular grid
+    x = np.linspace(0.0, 1.0, 11)  # 10 cells
+    y = np.linspace(0.0, 1.0, 6)   # 5 cells
+    xx, yy = np.meshgrid(x[:-1] + 0.05, y[:-1] + 0.1)
+    c = np.sin(2*np.pi*xx) * np.cos(2*np.pi*yy)  # shape (5,10)
+
+    fortplot.figure()
+    fortplot.pcolormesh(x, y, c)
+
+    out_dir = Path(__file__).resolve().parent.parent / 'output'
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out = out_dir / 'python_bridge_pcolormesh.png'
+    fortplot.savefig(str(out))
+
+    assert out.exists(), f"Output not created: {out}"
+    assert out.stat().st_size > 1000, f"Output too small: {out.stat().st_size} bytes"
+    print(f"OK: pcolormesh via bridge -> {out} ({out.stat().st_size} bytes)")
+
+
+if __name__ == '__main__':
+    main()
+

--- a/scripts/test_python_scales_via_bridge.py
+++ b/scripts/test_python_scales_via_bridge.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'python'))
+
+import numpy as np
+
+
+def main():
+    import fortplot
+
+    x = np.logspace(-1, 1, 50)
+    y = x**2
+
+    fortplot.figure()
+    fortplot.plot(x, y)
+    # Set log scales via bridge
+    fortplot.xscale('log')
+    fortplot.yscale('log')
+
+    out_dir = Path(__file__).resolve().parent.parent / 'output'
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out = out_dir / 'python_bridge_scales_log.png'
+    fortplot.savefig(str(out))
+
+    assert out.exists(), f"Output not created: {out}"
+    assert out.stat().st_size > 1000, f"Output too small: {out.stat().st_size} bytes"
+    print(f"OK: scales via bridge -> {out} ({out.stat().st_size} bytes)")
+
+
+if __name__ == '__main__':
+    main()
+

--- a/scripts/test_python_streamplot_via_bridge.py
+++ b/scripts/test_python_streamplot_via_bridge.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'python'))
+
+import numpy as np
+
+
+def main():
+    import fortplot
+
+    # Simple vector field: circular flow
+    nx, ny = 20, 15
+    x = np.linspace(-1.0, 1.0, nx)
+    y = np.linspace(-1.0, 1.0, ny)
+    xx, yy = np.meshgrid(x, y, indexing='ij')  # shape (nx, ny)
+    u = -yy
+    v = xx
+
+    fortplot.figure()
+    fortplot.streamplot(x, y, u, v, density=1.0)
+
+    out_dir = Path(__file__).resolve().parent.parent / 'output'
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out = out_dir / 'python_bridge_streamplot.png'
+    fortplot.savefig(str(out))
+
+    assert out.exists(), f"Output not created: {out}"
+    assert out.stat().st_size > 1000, f"Output too small: {out.stat().st_size} bytes"
+    print(f"OK: streamplot via bridge -> {out} ({out.stat().st_size} bytes)")
+
+
+if __name__ == '__main__':
+    main()
+


### PR DESCRIPTION
Summary
- Implement Python bridge commands: PCOLORMESH, CONTOUR/CONTOURF, STREAMPLOT, XSCALE/YSCALE. Wire up wrapper and axes APIs.

Scope
- Files touched: app/fortplot_python_bridge.f90, python/fortplot/fortplot_wrapper.py, python/fortplot/axes.py, python/fortplot/fortplot.py, Makefile, scripts/tests.
- No changes to core rendering logic; adds stdin command handlers and Python wrappers.

Verification
- Baseline and post-change CI-fast tests pass locally.
- Commands run:
  - make test-ci
- Key outputs:
  - "✓ Python bridge example produced output/python_bridge_demo.png (... bytes)"
  - "OK: pcolormesh via bridge -> output/python_bridge_pcolormesh.png (... bytes)"
  - "OK: scales via bridge -> output/python_bridge_scales_log.png (... bytes)"
- Artifacts:
  - output/python_bridge_pcolormesh.png
  - output/python_bridge_scales_log.png
  - output/python_bridge_streamplot.png

Rationale
- Closes gap in Python bridge by exposing existing Fortran capabilities (contours, pcolormesh, streamplot, axis scales) for Python users. Adds minimal tests to cover pcolormesh and log scales.

