### PR TITLE
fix: No whitespaces in title in PDF (fixes #1137)

### DIFF
--- a/src/backends/vector/fortplot_pdf_text.f90
+++ b/src/backends/vector/fortplot_pdf_text.f90
@@ -344,11 +344,12 @@ contains
         character(len=*), intent(in) :: input
         character(len=*), intent(out) :: output
         integer, intent(out) :: output_len
-        integer :: i, j
+        integer :: i, j, n
         character :: ch
         
+        n = len(input)
         j = 0
-        do i = 1, len_trim(input)
+        do i = 1, n
             ch = input(i:i)
             
             ! Escape special PDF characters

--- a/test/test_pdf_title_whitespace.f90
+++ b/test/test_pdf_title_whitespace.f90
@@ -1,0 +1,64 @@
+program test_pdf_title_whitespace
+    !! Verifies PDF backend preserves spaces in titles (no whitespace loss)
+    use fortplot
+    implicit none
+
+    character(len=*), parameter :: out_pdf = 'test/output/test_pdf_title_whitespace.pdf'
+    integer :: unit, ios
+    integer(kind=8) :: fsize
+    character, allocatable :: data(:)
+    logical :: has_space_tj
+
+    call figure()
+    call title('HELLO WORLD TEST')
+    call plot([0.0_wp, 1.0_wp], [0.0_wp, 1.0_wp])
+    call savefig(out_pdf)
+
+    open(newunit=unit, file=out_pdf, access='stream', form='unformatted', status='old', iostat=ios)
+    if (ios /= 0) then
+        print *, 'FAIL: cannot open ', trim(out_pdf)
+        stop 1
+    end if
+    inquire(unit=unit, size=fsize)
+    if (fsize <= 0) then
+        print *, 'FAIL: zero-size PDF'
+        close(unit)
+        stop 1
+    end if
+    allocate(character(len=1) :: data(fsize))
+    read(unit, iostat=ios) data
+    close(unit)
+    if (ios /= 0) then
+        print *, 'FAIL: cannot read PDF data'
+        stop 1
+    end if
+
+    ! Ensure a space glyph is emitted as its own Tj segment: "( ) Tj"
+    has_space_tj = bytes_contains(data, fsize, '( ) Tj')
+    if (.not. has_space_tj) then
+        print *, 'FAIL: missing space Tj in PDF title rendering'
+        stop 1
+    end if
+
+    print *, 'PASS: PDF title preserves spaces'
+contains
+    logical function bytes_contains(arr, n, pat) result(found)
+        character(len=1), intent(in) :: arr(n)
+        integer(kind=8), intent(in) :: n
+        character(len=*), intent(in) :: pat
+        integer :: i, j, m
+        found = .false.
+        m = len_trim(pat)
+        if (m <= 0) return
+        do i = 1, int(n) - m + 1
+            do j = 1, m
+                if (arr(i+j-1) /= pat(j:j)) exit
+                if (j == m) then
+                    found = .true.
+                    return
+                end if
+            end do
+        end do
+    end function bytes_contains
+end program test_pdf_title_whitespace
+


### PR DESCRIPTION
Summary
- Preserve spaces in PDF text rendering by avoiding len_trim in escaping; titles now retain whitespace.

Scope
- Update: src/backends/vector/fortplot_pdf_text.f90 (escape logic)
- Test: test/test_pdf_title_whitespace.f90 (assert space Tj emission)

Verification
- Commands:
  - make test-ci
- Key outputs:
  - PASS: PDF title preserves spaces
- Artifacts:
  - test/output/test_pdf_title_whitespace.pdf

Rationale
- Fixes user-visible PDF rendering bug where spaces disappeared in titles due to trimming in escape routine.
