### PR TITLE
fix: DPI scale of PNG and PDF differ (fixes #1139)

### DIFF
--- a/test/test_axis_label_offsets_pdf.f90
+++ b/test/test_axis_label_offsets_pdf.f90
@@ -20,10 +20,20 @@ program test_axis_label_offsets_pdf
     logical :: found_xtick, dir_ok
 
     margins = plot_margins_t()
-    ! Use the PDF backend plot-area calculation to match PDF coordinates (Y=0 at bottom)
-    call calculate_pdf_plot_area(W, H, margins, plot_area)
+    ! Compute PDF canvas size in points (matplotlib semantics: 100 DPI, 1 in = 72 pt)
+    ! Match create_pdf_canvas rounding to integer points
+    block
+        real(wp) :: width_pts, height_pts
+        integer :: wpt_i, hpt_i
+        width_pts  = real(W,  wp) * 72.0_wp / 100.0_wp
+        height_pts = real(H,  wp) * 72.0_wp / 100.0_wp
+        wpt_i = max(1, nint(width_pts))
+        hpt_i = max(1, nint(height_pts))
+        ! Use the PDF backend plot-area calculation to match PDF coordinates (Y=0 at bottom)
+        call calculate_pdf_plot_area(wpt_i, hpt_i, margins, plot_area)
+    end block
 
-    ! Expected baseline for X tick labels: 15px below plot bottom in PDF coords
+    ! Expected baseline for X tick labels: 15 pt below plot bottom in PDF coords
     y_xtick_expect = real(plot_area%bottom, wp) - 15.0_wp
     write(y_xtick_expect_str, '(F0.3)') y_xtick_expect
 

--- a/test/test_pdf_dpi_parity.f90
+++ b/test/test_pdf_dpi_parity.f90
@@ -1,0 +1,74 @@
+program test_pdf_dpi_parity
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    use fortplot_pdf, only: pdf_context, create_pdf_canvas
+    use fortplot_system_runtime, only: create_directory_runtime
+    implicit none
+
+    integer, parameter :: W = 800, H = 600
+    type(pdf_context) :: ctx
+    character(len=:), allocatable :: path
+    integer :: u, ios
+    character(len=1024) :: line
+    logical :: found
+    real(wp) :: w_pt, h_pt
+    logical :: dir_ok
+
+    ! Create a simple PDF with a known pixel canvas size
+    ctx = create_pdf_canvas(W, H)
+    call create_directory_runtime('test/output', dir_ok)
+    path = 'test/output/pdf_dpi_parity.pdf'
+    call ctx%save(path)
+
+    ! Scan for the MediaBox line and parse page dimensions (points)
+    open(newunit=u, file=path, status='old', action='read', iostat=ios)
+    if (ios /= 0) then
+        print *, 'FAIL: cannot open ', trim(path)
+        stop 1
+    end if
+
+    found = .false.
+    do
+        read(u, '(A)', iostat=ios) line
+        if (ios /= 0) exit
+        if (index(line, '/MediaBox [0 0') > 0) then
+            ! Expect format like: /MediaBox [0 0 <w> <h>]
+            call parse_media_box(line, w_pt, h_pt, found)
+            exit
+        end if
+    end do
+    close(u)
+
+    if (.not. found) then
+        print *, 'FAIL: MediaBox not found in ', trim(path)
+        stop 2
+    end if
+
+    ! 800x600 px at 100 DPI => 8x6 inches => 576x432 points
+    if (abs(w_pt - 576.0_wp) > 0.5_wp .or. abs(h_pt - 432.0_wp) > 0.5_wp) then
+        print *, 'FAIL: PDF MediaBox not 576x432 pt. Got:', w_pt, h_pt
+        stop 3
+    end if
+
+    print *, 'PASS: PDF MediaBox scaled to 576x432 points for 800x600 px'
+
+contains
+
+    subroutine parse_media_box(s, w, h, ok)
+        character(len=*), intent(in) :: s
+        real(wp), intent(out) :: w, h
+        logical, intent(out) :: ok
+        integer :: i1, i2
+        character(len=256) :: nums
+        ok = .false.
+        w = -1.0_wp; h = -1.0_wp
+        i1 = index(s, '/MediaBox [0 0')
+        if (i1 <= 0) return
+        i2 = index(s(i1:), ']')
+        if (i2 <= 0) return
+        nums = adjustl(s(i1+len('/MediaBox [0 0'):i1+i2-2))
+        read(nums, *, iostat=ios) w, h
+        if (ios == 0) ok = .true.
+    end subroutine parse_media_box
+
+end program test_pdf_dpi_parity
+


### PR DESCRIPTION
Summary
- Convert PDF canvas to points using 72/100 scaling so PNG and PDF share the same physical size at 100 DPI. Add a focused test asserting MediaBox 576x432 pt for an 800x600 px figure. Align existing PDF axis-label baseline test to point units to match the new sizing.

Scope
- PDF backend page sizing: src/backends/vector/fortplot_pdf.f90
- New test: test/test_pdf_dpi_parity.f90
- Updated test: test/test_axis_label_offsets_pdf.f90 (compute expected baseline in points)

Verification
- Tests
  - Commands:
    - fpm test --target test_pdf_dpi_parity
    - fpm test --target test_axis_label_offsets_pdf
    - make test-ci
  - Outputs (excerpts):
    - PASS: PDF MediaBox scaled to 576x432 points for 800x600 px
    - PASS: X tick labels baseline (15px below) verified in PDF stream
    - ALL TESTS PASSED (fpm test)
- Artifacts
  - Command: make verify-artifacts
  - Result: Artifact verification passed (PDF parsing and color checks OK)

Rationale
- Addresses #1139 by aligning PDF units with the default 100 DPI semantics, matching matplotlib sizing (8x6 in -> 576x432 pt). Test suite adjusted accordingly to assert baselines in PDF point units.
