### PR TITLE
fix: y label cut off by white block in png - too nea (fixes #1136)

### DIFF
--- a/src/backends/raster/fortplot_raster_axes.f90
+++ b/src/backends/raster/fortplot_raster_axes.f90
@@ -407,8 +407,11 @@ contains
 
         integer :: clearance
 
+        ! Place the RIGHT edge of the rotated ylabel at a fixed clearance
+        ! from the y-tick label right edge. Since composite uses top-left
+        ! anchoring, subtract the full rotated_text_width here.
         clearance = TICK_MARK_LENGTH + Y_TICK_LABEL_RIGHT_PAD + max(0, y_tick_max_width) + YLABEL_EXTRA_GAP
-        x_pos = plot_area%left - clearance - rotated_text_width / 2
+        x_pos = plot_area%left - clearance - rotated_text_width
     end function compute_ylabel_x_pos
 
     pure function y_tick_label_right_edge_at_axis(plot_area) result(r_edge)

--- a/test/test_raster_label_layout_utils.f90
+++ b/test/test_raster_label_layout_utils.f90
@@ -53,9 +53,11 @@ contains
         y_tick_max_width = 40
 
         x_pos = compute_ylabel_x_pos(area, rotated_text_width, y_tick_max_width)
+        ! Expect the RIGHT edge of the rotated ylabel to align at the
+        ! computed clearance from the y-tick labels, hence subtract the
+        ! full rotated_text_width from the left edge calculation.
         expected = area%left - (TICK_MARK_LENGTH + Y_TICK_LABEL_RIGHT_PAD + &
-                y_tick_max_width + YLABEL_EXTRA_GAP) - &
-                rotated_text_width / 2
+                y_tick_max_width + YLABEL_EXTRA_GAP) - rotated_text_width
         if (x_pos /= expected) then
             print *, 'FAIL: ylabel x position mismatch:', x_pos, expected
             stop 1

--- a/test/test_ylabel_positioning.f90
+++ b/test/test_ylabel_positioning.f90
@@ -1,0 +1,51 @@
+! Verify PNG ylabel placement math is width-invariant (no half-width bug)
+program test_ylabel_positioning
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    use fortplot_layout,       only: plot_area_t
+    use fortplot_raster_axes,  only: compute_ylabel_x_pos, y_tick_label_right_edge_at_axis
+    implicit none
+
+    type(plot_area_t) :: pa
+    integer :: x1, x2, rw1, rw2, ytick_w
+    integer :: right1, right2, r_edge_axis
+    logical :: ok
+
+    ! Choose a plot area with ample left margin to keep text within bounds
+    pa%left = 200; pa%bottom = 50; pa%width = 400; pa%height = 300
+
+    ! Simulate a reasonable maximum y-tick label width (in pixels)
+    ytick_w = 30
+
+    ! Two different rotated text widths (simulate short vs long ylabel)
+    rw1 = 40
+    rw2 = 80
+
+    x1 = compute_ylabel_x_pos(pa, rw1, ytick_w)
+    x2 = compute_ylabel_x_pos(pa, rw2, ytick_w)
+
+    right1 = x1 + rw1
+    right2 = x2 + rw2
+    r_edge_axis = y_tick_label_right_edge_at_axis(pa)
+
+    ok = .true.
+
+    ! Property 1: Right edge of ylabel should not depend on rotated text width
+    if (right1 /= right2) then
+        print *, 'FAIL: ylabel right edge depends on text width (', right1, 'vs', right2, ')'
+        ok = .false.
+    end if
+
+    ! Property 2: Ylabel should stay left of y-tick label right edge
+    if (.not. (right1 <= r_edge_axis - 1)) then
+        print *, 'FAIL: ylabel overlaps y-tick labels (right=', right1, ', r_edge_axis=', r_edge_axis, ')'
+        ok = .false.
+    end if
+
+    if (ok) then
+        print *, 'PASS: Ylabel positioning is width-invariant and clears tick labels'
+        stop 0
+    else
+        stop 1
+    end if
+end program test_ylabel_positioning
+


### PR DESCRIPTION
Summary
- Fix PNG ylabel x-position: align right edge at tick-label clearance to avoid clipping/overlap.

Scope
- src/backends/raster/fortplot_raster_axes.f90
- test/test_ylabel_positioning.f90 (focused positioning test)

Verification
- Focused test:
  $ fpm test --target test_ylabel_positioning
  PASS: Ylabel positioning is width-invariant and clears tick labels
- CI-fast test set:
  $ make test-ci
  CI essential test suite completed successfully
- Artifacts check:
  $ make verify-artifacts
  Artifact verification passed.

Rationale
- Previous math anchored top-left using half-width, causing the ylabel to be too close to the axis and often clipped by the image border. Setting the right edge at the computed clearance matches intended spacing and mimics matplotlib-style layout.
