### PR TITLE
fix: Not all greek letters work yet in unicode example (fixes #1138)

### DIFF
--- a/src/backends/vector/fortplot_pdf_text.f90
+++ b/src/backends/vector/fortplot_pdf_text.f90
@@ -375,7 +375,7 @@ contains
         
         symbol_char = ""
         
-        ! Greek lowercase letters
+        ! Greek lowercase letters and uppercase via Symbol encoding
         select case(unicode_codepoint)
         case(945)  ! α (alpha)
             symbol_char = "\141"
@@ -425,6 +425,54 @@ contains
             symbol_char = "\171"
         case(969)  ! ω (omega)
             symbol_char = "\167"
+        case(913)  ! Α (Alpha)
+            symbol_char = "\101"
+        case(914)  ! Β (Beta)
+            symbol_char = "\102"
+        case(915)  ! Γ (Gamma)
+            symbol_char = "\107"
+        case(916)  ! Δ (Delta)
+            symbol_char = "\104"
+        case(917)  ! Ε (Epsilon)
+            symbol_char = "\105"
+        case(918)  ! Ζ (Zeta)
+            symbol_char = "\132"
+        case(919)  ! Η (Eta)
+            symbol_char = "\110"
+        case(920)  ! Θ (Theta)
+            symbol_char = "\121"
+        case(921)  ! Ι (Iota)
+            symbol_char = "\111"
+        case(922)  ! Κ (Kappa)
+            symbol_char = "\113"
+        case(923)  ! Λ (Lambda)
+            symbol_char = "\114"
+        case(924)  ! Μ (Mu)
+            symbol_char = "\115"
+        case(925)  ! Ν (Nu)
+            symbol_char = "\116"
+        case(926)  ! Ξ (Xi)
+            symbol_char = "\130"
+        case(927)  ! Ο (Omicron)
+            symbol_char = "\117"
+        case(928)  ! Π (Pi)
+            symbol_char = "\120"
+        case(929)  ! Ρ (Rho)
+            symbol_char = "\122"
+        case(931)  ! Σ (Sigma)
+            symbol_char = "\123"
+        case(932)  ! Τ (Tau)
+            symbol_char = "\124"
+        case(933)  ! Υ (Upsilon)
+            symbol_char = "\125"
+        case(934)  ! Φ (Phi)
+            symbol_char = "\106"
+        case(935)  ! Χ (Chi)
+            symbol_char = "\103"
+        case(936)  ! Ψ (Psi)
+            symbol_char = "\131"
+        case(937)  ! Ω (Omega)
+            symbol_char = "\127"
         end select
     end subroutine unicode_to_symbol_char
 

--- a/test/test_pdf_unicode_uppercase.f90
+++ b/test/test_pdf_unicode_uppercase.f90
@@ -1,0 +1,71 @@
+program test_pdf_unicode_uppercase
+    !! Verify PDF renders uppercase Greek letters (e.g., \Psi) via Symbol font
+    use fortplot
+    implicit none
+
+    character(len=*), parameter :: out_pdf = 'test/output/test_pdf_unicode_uppercase.pdf'
+    integer :: unit, ios
+    integer(kind=8) :: fsize
+    character, allocatable :: data(:)
+    logical :: has_symbol_font, has_upper_psi
+
+    call figure()
+    call title('Uppercase: \Psi test')
+    call xlabel('Theta \Theta and Omega \Omega')
+    call ylabel('Check Psi \Psi in label')
+    call plot([0.0_wp, 1.0_wp], [0.0_wp, 1.0_wp])
+    call savefig(out_pdf)
+
+    open(newunit=unit, file=out_pdf, access='stream', form='unformatted', status='old', iostat=ios)
+    if (ios /= 0) then
+        print *, 'FAIL: cannot open ', trim(out_pdf)
+        stop 1
+    end if
+    inquire(unit=unit, size=fsize)
+    if (fsize <= 0) then
+        print *, 'FAIL: zero-size PDF'
+        close(unit)
+        stop 1
+    end if
+    allocate(character(len=1) :: data(fsize))
+    read(unit, iostat=ios) data
+    close(unit)
+    if (ios /= 0) then
+        print *, 'FAIL: cannot read PDF data'
+        stop 1
+    end if
+
+    has_symbol_font = bytes_contains(data, fsize, '/F6')
+    has_upper_psi   = bytes_contains(data, fsize, '\131')
+    if (.not. has_symbol_font) then
+        print *, 'FAIL: missing Symbol font switch (/F6)'
+        stop 1
+    end if
+    if (.not. has_upper_psi) then
+        print *, 'FAIL: missing uppercase Psi (\\131) escape in PDF stream'
+        stop 1
+    end if
+
+    print *, 'PASS: PDF uppercase Greek (Psi) mapped via Symbol'
+
+contains
+    logical function bytes_contains(arr, n, pat) result(found)
+        character(len=1), intent(in) :: arr(n)
+        integer(kind=8), intent(in) :: n
+        character(len=*), intent(in) :: pat
+        integer :: i, j, m
+        found = .false.
+        m = len_trim(pat)
+        if (m <= 0) return
+        do i = 1, int(n) - m + 1
+            do j = 1, m
+                if (arr(i+j-1) /= pat(j:j)) exit
+                if (j == m) then
+                    found = .true.
+                    return
+                end if
+            end do
+        end do
+    end function bytes_contains
+end program test_pdf_unicode_uppercase
+


### PR DESCRIPTION
Summary
- Fix PDF Greek uppercase mapping by using Symbol font for all Greek letters and process LaTeX in titles/labels.

Scope
- src/backends/vector/fortplot_pdf_text.f90
- src/backends/vector/fortplot_pdf_axes.f90
- test/test_pdf_unicode_uppercase.f90

Verification
- Commands:
  make test-ci
  fpm test --target test_pdf_unicode_uppercase
  make verify-artifacts
- Excerpts:
  fpm test --target test_pdf_unicode_uppercase -> "PASS: PDF uppercase Greek (Psi) mapped via Symbol"
  Artifact gate: passed with standard PDF checks; Symbol font present (/F6).

Rationale
- Issue #1138 reports uppercase Greek (e.g., Ψ) not rendering in PDF titles/labels. Root cause: titles/labels were not LaTeX-processed and uppercase Greek mapped via Helvetica. Changes ensure LaTeX → Unicode processing and Symbol mapping for all Greek letters.
