### PR TITLE
fix: Too many digits in axes tick labels (fixes #1145)

### DIFF
--- a/src/backends/ascii/fortplot_ascii_elements.f90
+++ b/src/backends/ascii/fortplot_ascii_elements.f90
@@ -10,7 +10,7 @@ module fortplot_ascii_elements
     use fortplot_legend, only: legend_t, render_ascii_legend
     use fortplot_legend, only: LEGEND_UPPER_LEFT, LEGEND_UPPER_RIGHT, LEGEND_LOWER_LEFT, LEGEND_LOWER_RIGHT
     use fortplot_axes, only: compute_scale_ticks, format_tick_label, MAX_TICKS
-    use fortplot_tick_calculation, only: determine_decimal_places_from_step, &
+    use fortplot_tick_calculation, only: determine_decimals_from_ticks, &
         format_tick_value_consistent
     use fortplot_plot_data, only: plot_data_t
     use fortplot_ascii_utils, only: get_char_density, ASCII_CHARS
@@ -343,13 +343,7 @@ contains
         ! Determine decimals for linear scale based on tick spacing
         decimals = 0
         if (trim(xscale) == 'linear' .and. num_x_ticks >= 2) then
-            step = abs(x_tick_positions(2) - x_tick_positions(1))
-            do i = 3, num_x_ticks
-                if (abs(x_tick_positions(i) - x_tick_positions(i-1)) > 1.0e-12_wp) then
-                    step = min(step, abs(x_tick_positions(i) - x_tick_positions(i-1)))
-                end if
-            end do
-            decimals = determine_decimal_places_from_step(step)
+            decimals = determine_decimals_from_ticks(x_tick_positions, num_x_ticks)
         end if
         do i = 1, num_x_ticks
             tick_x = x_tick_positions(i)
@@ -370,13 +364,7 @@ contains
         ! Determine decimals for linear scale based on tick spacing
         decimals = 0
         if (trim(yscale) == 'linear' .and. num_y_ticks >= 2) then
-            step = abs(y_tick_positions(2) - y_tick_positions(1))
-            do i = 3, num_y_ticks
-                if (abs(y_tick_positions(i) - y_tick_positions(i-1)) > 1.0e-12_wp) then
-                    step = min(step, abs(y_tick_positions(i) - y_tick_positions(i-1)))
-                end if
-            end do
-            decimals = determine_decimal_places_from_step(step)
+            decimals = determine_decimals_from_ticks(y_tick_positions, num_y_ticks)
         end if
         do i = 1, num_y_ticks
             tick_y = y_tick_positions(i)

--- a/src/backends/ascii/fortplot_ascii_elements.f90
+++ b/src/backends/ascii/fortplot_ascii_elements.f90
@@ -10,6 +10,8 @@ module fortplot_ascii_elements
     use fortplot_legend, only: legend_t, render_ascii_legend
     use fortplot_legend, only: LEGEND_UPPER_LEFT, LEGEND_UPPER_RIGHT, LEGEND_LOWER_LEFT, LEGEND_LOWER_RIGHT
     use fortplot_axes, only: compute_scale_ticks, format_tick_label, MAX_TICKS
+    use fortplot_tick_calculation, only: determine_decimal_places_from_step, &
+        format_tick_value_consistent
     use fortplot_plot_data, only: plot_data_t
     use fortplot_ascii_utils, only: get_char_density, ASCII_CHARS
     use, intrinsic :: iso_fortran_env, only: wp => real64, real64
@@ -281,6 +283,8 @@ contains
         integer :: num_x_ticks, num_y_ticks, i
         character(len=50) :: tick_label
         real(wp) :: tick_x, tick_y
+        integer :: decimals
+        real(wp) :: step
         real(wp) :: luminance
         character(len=1) :: line_char
         character(len=500) :: processed_title
@@ -336,10 +340,25 @@ contains
         ! Generate tick marks and labels for ASCII
         ! X-axis ticks (drawn as characters along bottom axis)
         call compute_scale_ticks(xscale, x_min, x_max, symlog_threshold, x_tick_positions, num_x_ticks)
+        ! Determine decimals for linear scale based on tick spacing
+        decimals = 0
+        if (trim(xscale) == 'linear' .and. num_x_ticks >= 2) then
+            step = abs(x_tick_positions(2) - x_tick_positions(1))
+            do i = 3, num_x_ticks
+                if (abs(x_tick_positions(i) - x_tick_positions(i-1)) > 1.0e-12_wp) then
+                    step = min(step, abs(x_tick_positions(i) - x_tick_positions(i-1)))
+                end if
+            end do
+            decimals = determine_decimal_places_from_step(step)
+        end if
         do i = 1, num_x_ticks
             tick_x = x_tick_positions(i)
             ! For ASCII, draw tick marks as characters in the text output
-            tick_label = format_tick_label(tick_x, xscale)
+            if (trim(xscale) == 'linear') then
+                tick_label = format_tick_value_consistent(tick_x, decimals)
+            else
+                tick_label = format_tick_label(tick_x, xscale)
+            end if
             call add_text_element(text_elements, num_text_elements, &
                                  tick_x, y_min - 0.05_wp * (y_max - y_min), trim(tick_label), &
                                  current_r, current_g, current_b, &
@@ -348,9 +367,24 @@ contains
         
         ! Y-axis ticks (drawn as characters along left axis)
         call compute_scale_ticks(yscale, y_min, y_max, symlog_threshold, y_tick_positions, num_y_ticks)
+        ! Determine decimals for linear scale based on tick spacing
+        decimals = 0
+        if (trim(yscale) == 'linear' .and. num_y_ticks >= 2) then
+            step = abs(y_tick_positions(2) - y_tick_positions(1))
+            do i = 3, num_y_ticks
+                if (abs(y_tick_positions(i) - y_tick_positions(i-1)) > 1.0e-12_wp) then
+                    step = min(step, abs(y_tick_positions(i) - y_tick_positions(i-1)))
+                end if
+            end do
+            decimals = determine_decimal_places_from_step(step)
+        end if
         do i = 1, num_y_ticks
             tick_y = y_tick_positions(i)
-            tick_label = format_tick_label(tick_y, yscale)
+            if (trim(yscale) == 'linear') then
+                tick_label = format_tick_value_consistent(tick_y, decimals)
+            else
+                tick_label = format_tick_label(tick_y, yscale)
+            end if
             call add_text_element(text_elements, num_text_elements, &
                                  x_min - 0.1_wp * (x_max - x_min), tick_y, trim(tick_label), &
                                  current_r, current_g, current_b, &

--- a/src/backends/raster/fortplot_raster_axes.f90
+++ b/src/backends/raster/fortplot_raster_axes.f90
@@ -170,7 +170,7 @@ contains
                                        x_min, x_max, y_min, y_max)
         !! Draw X-axis tick marks and labels
         use fortplot_axes, only: compute_scale_ticks, format_tick_label, MAX_TICKS
-        use fortplot_tick_calculation, only: determine_decimal_places_from_step, &
+        use fortplot_tick_calculation, only: determine_decimals_from_ticks, &
             format_tick_value_consistent
         type(raster_image_t), intent(inout) :: raster
         integer, intent(in) :: width, height
@@ -196,7 +196,6 @@ contains
         ! Use generous buffer to avoid rare truncation of escaped labels
         character(len=500), allocatable :: labels(:)
         integer :: decimals
-        real(wp) :: step
         
         line_r = 0.0_wp; line_g = 0.0_wp; line_b = 0.0_wp  ! Black color
         text_r = 0; text_g = 0; text_b = 0
@@ -210,13 +209,7 @@ contains
             ! Determine decimals for linear scale based on tick spacing
             decimals = 0
             if (trim(xscale) == 'linear' .and. num_x_ticks >= 2) then
-                step = abs(x_tick_positions(2) - x_tick_positions(1))
-                do i = 3, num_x_ticks
-                    if (abs(x_tick_positions(i) - x_tick_positions(i-1)) > 1.0e-12_wp) then
-                        step = min(step, abs(x_tick_positions(i) - x_tick_positions(i-1)))
-                    end if
-                end do
-                decimals = determine_decimal_places_from_step(step)
+                decimals = determine_decimals_from_ticks(x_tick_positions, num_x_ticks)
             end if
 
             do i = 1, num_x_ticks
@@ -266,7 +259,7 @@ contains
                                        x_min, x_max, y_min, y_max)
         !! Draw Y-axis tick marks and labels
         use fortplot_axes, only: compute_scale_ticks, format_tick_label, MAX_TICKS
-        use fortplot_tick_calculation, only: determine_decimal_places_from_step, &
+        use fortplot_tick_calculation, only: determine_decimals_from_ticks, &
             format_tick_value_consistent
         type(raster_image_t), intent(inout) :: raster
         integer, intent(in) :: width, height
@@ -287,7 +280,6 @@ contains
         character(len=500) :: processed_text, escaped_text
         integer :: processed_len
         integer :: decimals
-        real(wp) :: step
         
         line_r = 0.0_wp; line_g = 0.0_wp; line_b = 0.0_wp  ! Black color
         text_r = 0; text_g = 0; text_b = 0
@@ -297,13 +289,7 @@ contains
         ! Determine decimals for linear scale based on tick spacing
         decimals = 0
         if (trim(yscale) == 'linear' .and. num_y_ticks >= 2) then
-            step = abs(y_tick_positions(2) - y_tick_positions(1))
-            do i = 3, num_y_ticks
-                if (abs(y_tick_positions(i) - y_tick_positions(i-1)) > 1.0e-12_wp) then
-                    step = min(step, abs(y_tick_positions(i) - y_tick_positions(i-1)))
-                end if
-            end do
-            decimals = determine_decimal_places_from_step(step)
+            decimals = determine_decimals_from_ticks(y_tick_positions, num_y_ticks)
         end if
         max_label_width = 0
         do i = 1, num_y_ticks

--- a/src/backends/vector/fortplot_pdf_axes.f90
+++ b/src/backends/vector/fortplot_pdf_axes.f90
@@ -11,7 +11,7 @@ module fortplot_pdf_axes
                                 draw_mixed_font_text, draw_rotated_mixed_font_text
     use fortplot_latex_parser, only: process_latex_in_text
     use fortplot_axes, only: compute_scale_ticks, format_tick_label, MAX_TICKS
-    use fortplot_tick_calculation, only: determine_decimal_places_from_step, &
+    use fortplot_tick_calculation, only: determine_decimals_from_ticks, &
         format_tick_value_consistent
     use fortplot_scales, only: apply_scale_transform
     implicit none
@@ -141,7 +141,6 @@ contains
         real(wp) :: min_t, max_t, tv_t, thr
         character(len=16) :: scale
         integer :: decimals
-        real(wp) :: step
 
         scale = 'linear'
         if (present(scale_type)) scale = scale_type
@@ -161,13 +160,7 @@ contains
         ! Determine a suitable decimal precision for linear ticks
         decimals = 0
         if (trim(scale) == 'linear' .and. nt >= 2) then
-            step = abs(tvals(2) - tvals(1))
-            do i = 3, nt
-                if (abs(tvals(i) - tvals(i-1)) > 1.0e-12_wp) then
-                    step = min(step, abs(tvals(i) - tvals(i-1)))
-                end if
-            end do
-            decimals = determine_decimal_places_from_step(step)
+            decimals = determine_decimals_from_ticks(tvals, nt)
         end if
 
         limit = min(num_ticks, size(positions))
@@ -205,7 +198,6 @@ contains
         real(wp) :: min_t, max_t, tv_t, thr
         character(len=16) :: scale
         integer :: decimals
-        real(wp) :: step
 
         scale = 'linear'
         if (present(scale_type)) scale = scale_type
@@ -225,13 +217,7 @@ contains
         ! Determine a suitable decimal precision for linear ticks
         decimals = 0
         if (trim(scale) == 'linear' .and. nt >= 2) then
-            step = abs(tvals(2) - tvals(1))
-            do i = 3, nt
-                if (abs(tvals(i) - tvals(i-1)) > 1.0e-12_wp) then
-                    step = min(step, abs(tvals(i) - tvals(i-1)))
-                end if
-            end do
-            decimals = determine_decimal_places_from_step(step)
+            decimals = determine_decimals_from_ticks(tvals, nt)
         end if
 
         limit = min(num_ticks, size(positions))

--- a/src/utilities/ticks/fortplot_tick_calculation.f90
+++ b/src/utilities/ticks/fortplot_tick_calculation.f90
@@ -14,6 +14,7 @@ module fortplot_tick_calculation
     private
     public :: calculate_tick_labels, calculate_nice_axis_limits
     public :: find_nice_tick_locations, determine_decimal_places_from_step
+    public :: format_tick_value_consistent
 
 contains
 

--- a/src/utilities/ticks/fortplot_tick_calculation.f90
+++ b/src/utilities/ticks/fortplot_tick_calculation.f90
@@ -14,6 +14,7 @@ module fortplot_tick_calculation
     private
     public :: calculate_tick_labels, calculate_nice_axis_limits
     public :: find_nice_tick_locations, determine_decimal_places_from_step
+    public :: determine_decimals_from_ticks
     public :: format_tick_value_consistent
 
 contains
@@ -160,6 +161,27 @@ contains
             decimal_places = 4
         end if
     end function determine_decimal_places_from_step
+
+    function determine_decimals_from_ticks(tick_positions, n) result(decimal_places)
+        !! Determine decimal places from an array of tick positions.
+        !! Uses the smallest non-zero spacing as representative step.
+        real(wp), intent(in) :: tick_positions(:)
+        integer, intent(in) :: n
+        integer :: decimal_places
+        real(wp) :: step, d
+        integer :: i
+
+        decimal_places = 0
+        if (n < 2) return
+
+        step = abs(tick_positions(2) - tick_positions(1))
+        do i = 3, n
+            d = abs(tick_positions(i) - tick_positions(i-1))
+            if (d > 1.0e-12_wp) step = min(step, d)
+        end do
+
+        decimal_places = determine_decimal_places_from_step(step)
+    end function determine_decimals_from_ticks
 
     function format_tick_value_consistent(value, decimal_places) result(formatted)
         !! Format tick value with consistent decimal places for uniform appearance

--- a/test/test_tick_formatting_digits.f90
+++ b/test/test_tick_formatting_digits.f90
@@ -1,0 +1,40 @@
+program test_tick_formatting_digits
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    use fortplot_axes, only: compute_scale_ticks, MAX_TICKS
+    use fortplot_tick_calculation, only: determine_decimal_places_from_step, &
+        format_tick_value_consistent
+    implicit none
+
+    real(wp) :: ticks(MAX_TICKS)
+    integer :: nt, i, decimals
+    real(wp) :: step
+    character(len=32) :: label
+    logical :: ok
+
+    ! Case 1: Linear range [0, 1] should produce ~0.2 step and 1 decimal
+    call compute_scale_ticks('linear', 0.0_wp, 1.0_wp, 1.0_wp, ticks, nt)
+    if (nt < 2) then
+        print *, 'FAIL: Expected at least 2 ticks for range [0,1], got', nt
+        stop 1
+    end if
+    step = abs(ticks(2) - ticks(1))
+    do i = 3, nt
+        if (abs(ticks(i) - ticks(i-1)) > 1.0e-12_wp) then
+            step = min(step, abs(ticks(i) - ticks(i-1)))
+        end if
+    end do
+    decimals = determine_decimal_places_from_step(step)
+    if (decimals /= 1) then
+        print *, 'FAIL: Expected 1 decimal for [0,1], got', decimals
+        stop 1
+    end if
+    label = format_tick_value_consistent(ticks(2), decimals)
+    ok = index(trim(label), '0.200') == 0 .and. index(trim(label), '0.20') == 0
+    if (.not. ok) then
+        print *, 'FAIL: Label has too many digits: ', trim(label)
+        stop 1
+    end if
+
+    print *, 'PASS: tick formatting digit selection'
+end program test_tick_formatting_digits
+


### PR DESCRIPTION
Summary
- Make linear tick labels step-aware to avoid excessive decimals.

Scope
- Update PDF/PNG/ASCII backends to format linear ticks based on computed step.
- Export helper from `fortplot_tick_calculation` and add a focused unit test.

Verification
- Ran: `TEST_TIMEOUT=120s make test-ci`
- Excerpt: `PASS: tick formatting digit selection`
- Added test: `test/test_tick_formatting_digits.f90` (checks [0,1] → 0.2 step → 1 decimal; no "0.200").

Rationale
- Issue #1145 reports too many digits on axes. This change aligns linear tick labels with the step size chosen by the locator (similar to Matplotlib’s MaxNLocator), reducing visual noise while keeping log/symlog formatting unchanged.

Additional Verification
- Ran: `make verify-artifacts`
- Excerpt: `Artifact verification passed.`

Artifacts
- Selected logs:
```text
[pdftotext] asserting needle=Symlog in .../symlog_scale.pdf
[pdfcolor] ... pcolormesh_basic.pdf has non-gray RGB fill commands
[png] ... all_marker_types.png size=15033
[colors] ... ripple_plasma.png => 808
Artifact verification passed.
```

