### PR TITLE
cleanup: remove unreachable code branches in ASCII backend

### DIFF
--- a/src/backends/ascii/fortplot_ascii.f90
+++ b/src/backends/ascii/fortplot_ascii.f90
@@ -379,10 +379,8 @@ contains
         integer, intent(in) :: width, height
         real(real64), intent(out) :: rgb_data(width, height, 3)
         
-        ! Suppress unused parameter warning
-        if (this%width < 0) then
-            ! This condition is never true, but suppresses unused parameter warning
-        end if
+        ! Reference otherwise-unused member without unreachable branch
+        associate(unused_w => this%width); end associate
         
         ! ASCII backend doesn't have RGB data for animation - fill with dummy data
         rgb_data = 0.0_real64  ! Black background
@@ -395,10 +393,8 @@ contains
         integer(1), allocatable, intent(out) :: png_data(:)
         integer, intent(out) :: status
         
-        ! Suppress unused parameter warnings
-        if (this%width < 0 .or. width < 0 .or. height < 0) then
-            ! This condition is never true, but suppresses unused parameter warnings
-        end if
+        ! Reference otherwise-unused parameters without unreachable branches
+        associate(unused_w => this%width, unused_pw => width, unused_ph => height); end associate
         
         ! ASCII backend doesn't provide PNG data
         allocate(png_data(0))
@@ -411,10 +407,8 @@ contains
         class(ascii_context), intent(inout) :: this
         type(plot_data_t), intent(in) :: plots(:)
         
-        ! Suppress unused parameter warnings
-        if (this%width < 0 .or. size(plots) < 0) then
-            ! This condition is never true, but suppresses unused parameter warnings
-        end if
+        ! Reference otherwise-unused parameters without unreachable branches
+        associate(unused_w => this%width, unused_n => size(plots)); end associate
         
         ! ASCII backend doesn't need 3D data preparation - no-op
     end subroutine ascii_prepare_3d_data
@@ -424,10 +418,8 @@ contains
         class(ascii_context), intent(inout) :: this
         character(len=*), intent(in) :: ylabel
         
-        ! Suppress unused parameter warnings
-        if (this%width < 0 .or. len_trim(ylabel) < 0) then
-            ! This condition is never true, but suppresses unused parameter warnings
-        end if
+        ! Reference otherwise-unused parameters without unreachable branches
+        associate(unused_w => this%width, unused_l => len_trim(ylabel)); end associate
         
         ! ASCII backend handles Y-axis labels differently - no-op
     end subroutine ascii_render_ylabel
@@ -483,15 +475,11 @@ contains
         class(ascii_context), intent(inout) :: this
         character(len=*), intent(in), optional :: title_text, xlabel_text, ylabel_text
         
-        ! Suppress unused parameter warnings
-        if (this%width < 0) then
-            ! This condition is never true, but suppresses unused parameter warning
-        end if
-        if (present(title_text) .and. present(xlabel_text) .and. present(ylabel_text)) then
-            if (len_trim(title_text) < 0 .or. len_trim(xlabel_text) < 0 .or. len_trim(ylabel_text) < 0) then
-                ! This condition is never true, but suppresses unused parameter warnings
-            end if
-        end if
+        ! Reference otherwise-unused members/optionals without unreachable branches
+        associate(unused_w => this%width); end associate
+        if (present(title_text)) then; associate(unused_lt => len_trim(title_text)); end associate; end if
+        if (present(xlabel_text)) then; associate(unused_lx => len_trim(xlabel_text)); end associate; end if
+        if (present(ylabel_text)) then; associate(unused_ly => len_trim(ylabel_text)); end associate; end if
         
         ! ASCII axes are rendered as part of draw_axes_and_labels_backend
         ! This is a stub to satisfy the interface

--- a/src/backends/ascii/fortplot_ascii_backend_support.f90
+++ b/src/backends/ascii/fortplot_ascii_backend_support.f90
@@ -31,10 +31,8 @@ contains
         integer(1), allocatable, intent(out) :: png_data(:)
         integer, intent(out) :: status
         
-        ! Suppress unused parameter warnings
-        if (width < 0 .or. height < 0) then
-            ! This condition is never true, but suppresses unused parameter warnings
-        end if
+        ! Reference unused parameters without unreachable branches
+        associate(unused_w => width, unused_h => height); end associate
         
         ! ASCII backend doesn't provide PNG data
         allocate(png_data(0))
@@ -45,10 +43,8 @@ contains
         !! Prepare 3D data for ASCII backend (no-op - ASCII doesn't use 3D data)
         type(plot_data_t), intent(in) :: plots(:)
         
-        ! Suppress unused parameter warnings
-        if (size(plots) < 0) then
-            ! This condition is never true, but suppresses unused parameter warnings
-        end if
+        ! Reference unused parameters without unreachable branches
+        associate(unused_n => size(plots)); end associate
         
         ! ASCII backend doesn't need 3D data preparation - no-op
     end subroutine prepare_ascii_3d_data
@@ -57,10 +53,8 @@ contains
         !! Render Y-axis label for ASCII backend (no-op - handled elsewhere)
         character(len=*), intent(in) :: ylabel
         
-        ! Suppress unused parameter warnings
-        if (len_trim(ylabel) < 0) then
-            ! This condition is never true, but suppresses unused parameter warnings
-        end if
+        ! Reference unused parameter without unreachable branch
+        associate(unused_l => len_trim(ylabel)); end associate
         
         ! ASCII backend handles Y-axis labels differently - no-op
     end subroutine render_ascii_ylabel
@@ -69,11 +63,9 @@ contains
         !! Render axes for ASCII context (stub implementation)
         character(len=*), intent(in), optional :: title_text, xlabel_text, ylabel_text
         
-        if (present(title_text) .and. present(xlabel_text) .and. present(ylabel_text)) then
-            if (len_trim(title_text) < 0 .or. len_trim(xlabel_text) < 0 .or. len_trim(ylabel_text) < 0) then
-                ! This condition is never true, but suppresses unused parameter warnings
-            end if
-        end if
+        if (present(title_text)) then; associate(unused_lt => len_trim(title_text)); end associate; end if
+        if (present(xlabel_text)) then; associate(unused_lx => len_trim(xlabel_text)); end associate; end if
+        if (present(ylabel_text)) then; associate(unused_ly => len_trim(ylabel_text)); end associate; end if
         
         ! ASCII axes are rendered as part of draw_axes_and_labels_backend
         ! This is a stub to satisfy the interface

--- a/src/backends/ascii/fortplot_ascii_elements.f90
+++ b/src/backends/ascii/fortplot_ascii_elements.f90
@@ -139,10 +139,8 @@ contains
         character(len=1) :: arrow_char
         real(wp) :: angle
         
-        ! Suppress unused parameter warnings
-        if (size < 0.0_wp .or. len_trim(style) < 0) then
-            ! This condition is never true, but suppresses unused parameter warnings
-        end if
+        ! Reference otherwise-unused parameters without unreachable branches
+        associate(unused_s => size, unused_ls => len_trim(style)); end associate
         
         ! Convert world coordinates to pixel coordinates
         px = int((x - x_min) / (x_max - x_min) * real(width, wp))
@@ -290,15 +288,10 @@ contains
         character(len=500) :: processed_title
         integer :: processed_len
         
-        ! Suppress unused parameter warnings
-        if (present(z_min) .and. present(z_max)) then
-            if (z_min < -huge(z_min) .or. z_max > huge(z_max)) then
-                ! This condition is never true, but suppresses unused parameter warnings
-            end if
-        end if
-        if (.not. has_3d_plots) then
-            ! Reference has_3d_plots to suppress warning
-        end if
+        ! Reference optional parameters without unreachable branches
+        if (present(z_min)) then; associate(unused_zmin => z_min); end associate; end if
+        if (present(z_max)) then; associate(unused_zmax => z_max); end associate; end if
+        associate(unused_h3d => has_3d_plots); end associate
         
         ! ASCII backend: explicitly set title and draw simple axes
         if (present(title)) then

--- a/src/backends/ascii/fortplot_ascii_primitives.f90
+++ b/src/backends/ascii/fortplot_ascii_primitives.f90
@@ -196,9 +196,7 @@ contains
         
         ! Note: Color values are passed but not used for storage here
         ! They should be stored by the calling routine if needed
-        if (current_r < 0.0_wp .or. current_g < 0.0_wp .or. current_b < 0.0_wp) then
-            ! This is just to suppress unused warnings
-        end if
+        associate(unused_sum => current_r + current_g + current_b); end associate
     end subroutine ascii_draw_text_primitive
 
 end module fortplot_ascii_primitives

--- a/src/text/fortplot_annotation_layout.f90
+++ b/src/text/fortplot_annotation_layout.f90
@@ -33,11 +33,8 @@ contains
         real(wp), intent(in) :: text_width, text_height
         real(wp), intent(out) :: adjusted_x, adjusted_y
         
-        ! Note: text_height is reserved for future vertical alignment implementation
-        ! Suppress unused variable warning by referencing it
-        if (text_height < 0.0_wp) then
-            ! This condition is never true, but suppresses unused parameter warning
-        end if
+        ! Note: text_height reserved for future vertical alignment; reference to avoid warnings
+        associate(unused_th => text_height); end associate
         
         adjusted_x = annotation%x
         adjusted_y = annotation%y


### PR DESCRIPTION
Summary
- Remove unreachable conditional branches used solely to suppress unused-parameter warnings.
- Replace with `associate` references, avoiding dead code while keeping builds clean.

Scope
- src/backends/ascii/fortplot_ascii_backend_support.f90
- src/backends/ascii/fortplot_ascii_elements.f90
- src/backends/ascii/fortplot_ascii_primitives.f90
- src/backends/ascii/fortplot_ascii.f90
- src/text/fortplot_annotation_layout.f90

Verification
- `make test` (120s timeout) passes locally end-to-end.
- No behavior changes; only removal of unreachable code/comments.
- Keeps compilers quiet without fake impossible conditions.

Rationale
- Enforces repo rule: unreachable code MUST be removed; eliminate "condition is never true" hacks while preserving warning-free builds.
