### PR TITLE
fix: normalize contour fill polygon orientation and allocation issues

### DIFF
--- a/src/backends/memory/fortplot_contour_rendering.f90
+++ b/src/backends/memory/fortplot_contour_rendering.f90
@@ -234,9 +234,16 @@ contains
             real(wp), intent(in) :: v
             real(wp), allocatable :: tmp(:)
             integer :: n
+            
+            if (.not. allocated(arr)) then
+                allocate(arr(1)); arr(1) = v; return
+            end if
+            
             n = size(arr)
             if (n == 0) then
-                allocate(arr(1)); arr(1) = v; return
+                allocate(tmp(1)); tmp(1) = v
+                call move_alloc(tmp, arr)
+                return
             end if
             if (any(abs(arr - v) <= 1.0e-12_wp)) return
             allocate(tmp(n+1))


### PR DESCRIPTION
## Summary
- Fixes random fill artifacts in contourf plots by ensuring consistent polygon orientation
- Resolves runtime allocation error in push_unique function
- Implements CCW (counter-clockwise) orientation normalization for proper even-odd fill rule

## Changes

### 1. Polygon Orientation Normalization (`fortplot_contour_regions.f90`)
- Added `normalize_and_append` subroutine to replace `append_boundary`
- Computes signed area of each polygon to determine winding order
- Reverses vertex order if necessary to ensure consistent CCW orientation
- This ensures the even-odd fill rule works correctly for all contour regions

### 2. Allocation Fix (`fortplot_contour_rendering.f90`)
- Fixed runtime error in `push_unique` where it attempted to allocate already allocated arrays
- Now properly checks allocation status before attempting allocation
- Handles zero-sized allocated arrays correctly using move_alloc

## Test Plan
✅ Built project successfully with `make build`
✅ All tests pass with `make test`
✅ Ran `colored_contours` example - completes without errors
✅ Ran `contour_filled_demo` example - completes without errors
✅ Verified contour fills render correctly without random artifacts

Fixes #1150

🤖 Generated with [Claude Code](https://claude.ai/code)