### PR TITLE
fix: all marker types plot is empty (fixes #1109)

### DIFF
--- a/src/plotting/fortplot_scatter_plots.f90
+++ b/src/plotting/fortplot_scatter_plots.f90
@@ -122,6 +122,9 @@ contains
         
         if (present(marker)) then
             self%plots(plot_idx)%marker = marker
+        else
+            ! Default marker for scatter plots - ensures they are visible
+            self%plots(plot_idx)%marker = 'o'
         end if
         
         if (present(markersize)) then


### PR DESCRIPTION
## Summary
- Fixed issue where scatter plots without explicit marker parameter showed no markers
- Added default marker 'o' (circle) for scatter plots when no marker is specified

## Verification
Ran tests:
- `make test`: All tests pass
- `fpm run --example marker_demo`: Executes successfully
- Created test program verifying scatter() without marker parameter now shows default markers
- Output files generated with visible markers at correct sizes