### PR TITLE
fix: y label cut off by white block in png - too near to axis (fixes #1136)

### DIFF
--- a/src/backends/raster/fortplot_raster_axes.f90
+++ b/src/backends/raster/fortplot_raster_axes.f90
@@ -25,7 +25,8 @@ module fortplot_raster_axes
     ! Y tick labels are right-aligned with a gap of Y_TICK_LABEL_RIGHT_PAD from the tick end
     integer, parameter :: X_TICK_LABEL_PAD = 14
     integer, parameter :: Y_TICK_LABEL_RIGHT_PAD = 8
-    integer, parameter :: YLABEL_EXTRA_GAP = 2
+    ! Increased gap to better match matplotlib's labelpad (approx 6-8 pixels at 100dpi)
+    integer, parameter :: YLABEL_EXTRA_GAP = 8
 
     ! Cache the maximum Y-tick label width measured during the last
     ! raster_draw_y_axis_ticks() call so ylabel placement can avoid overlap
@@ -438,13 +439,21 @@ contains
         integer, intent(in) :: y_tick_max_width
         integer :: x_pos
 
-        integer :: clearance
+        integer :: clearance, min_left_margin
 
         ! Place the RIGHT edge of the rotated ylabel at a fixed clearance
         ! from the y-tick label right edge. Since composite uses top-left
         ! anchoring, subtract the full rotated_text_width here.
         clearance = TICK_MARK_LENGTH + Y_TICK_LABEL_RIGHT_PAD + max(0, y_tick_max_width) + YLABEL_EXTRA_GAP
         x_pos = plot_area%left - clearance - rotated_text_width
+        
+        ! Ensure minimum left margin to prevent text cutoff
+        ! Reserve more space from canvas edge for better text rendering
+        ! This prevents ylabel from being cut off while maintaining proper spacing
+        min_left_margin = 15
+        if (x_pos < min_left_margin) then
+            x_pos = min_left_margin
+        end if
     end function compute_ylabel_x_pos
 
     pure function y_tick_label_right_edge_at_axis(plot_area) result(r_edge)

--- a/test/test_raster_label_layout_utils.f90
+++ b/test/test_raster_label_layout_utils.f90
@@ -47,7 +47,8 @@ contains
         integer :: y_tick_max_width
         integer :: x_pos, expected
         integer, parameter :: Y_TICK_LABEL_RIGHT_PAD = 8
-        integer, parameter :: YLABEL_EXTRA_GAP = 2
+        ! Updated to match the increased gap in fortplot_raster_axes
+        integer, parameter :: YLABEL_EXTRA_GAP = 8
 
         area%left = 100; area%bottom = 50; area%width = 400; area%height = 300
         rotated_text_width = 20
@@ -59,6 +60,8 @@ contains
         ! full rotated_text_width from the left edge calculation.
         expected = area%left - (TICK_MARK_LENGTH + Y_TICK_LABEL_RIGHT_PAD + &
                 y_tick_max_width + YLABEL_EXTRA_GAP) - rotated_text_width
+        ! Account for minimum margin protection (15 pixels from edge)
+        if (expected < 15) expected = 15
         if (x_pos /= expected) then
             print *, 'FAIL: ylabel x position mismatch:', x_pos, expected
             stop 1
@@ -88,7 +91,8 @@ contains
         integer :: y_tick_max_width
         integer :: x_pos
         integer, parameter :: Y_TICK_LABEL_RIGHT_PAD = 8
-        integer, parameter :: YLABEL_EXTRA_GAP = 2
+        ! Updated to match the increased gap in fortplot_raster_axes
+        integer, parameter :: YLABEL_EXTRA_GAP = 8
 
         ! Create a scenario where ylabel would be positioned at negative x
         ! Small plot area on the left with very wide tick labels

--- a/test/test_ylabel_no_cutoff.f90
+++ b/test/test_ylabel_no_cutoff.f90
@@ -1,0 +1,72 @@
+program test_ylabel_no_cutoff
+    !! Test that ylabel is not cut off at canvas edge with various configurations
+    use fortplot
+    use fortplot_raster_axes, only: compute_ylabel_x_pos
+    use fortplot_layout, only: plot_area_t, plot_margins_t, calculate_plot_area
+    implicit none
+    
+    integer :: canvas_width, canvas_height
+    type(plot_margins_t) :: margins
+    type(plot_area_t) :: plot_area
+    integer :: ylabel_width, ytick_max_width, x_pos
+    logical :: ok
+    
+    ok = .true.
+    
+    ! Test case 1: Standard 800x600 canvas with long ylabel and wide tick labels
+    canvas_width = 800
+    canvas_height = 600
+    call calculate_plot_area(canvas_width, canvas_height, margins, plot_area)
+    
+    ! Simulate a 40-pixel wide ylabel (rotated) and 60-pixel wide tick labels
+    ylabel_width = 40
+    ytick_max_width = 60
+    
+    x_pos = compute_ylabel_x_pos(plot_area, ylabel_width, ytick_max_width)
+    
+    ! Verify ylabel doesn't go negative (would be cut off)
+    if (x_pos < 1) then
+        print *, 'FAIL: Y-label would be cut off (x_pos=', x_pos, ')'
+        ok = .false.
+    end if
+    
+    ! Verify adequate spacing from tick labels
+    ! The ylabel right edge should have at least some gap from tick labels
+    if (x_pos + ylabel_width > plot_area%left - 15) then
+        print *, 'FAIL: Y-label too close to tick labels'
+        ok = .false.
+    end if
+    
+    ! Test case 2: Smaller canvas with same label sizes
+    canvas_width = 400
+    canvas_height = 300
+    call calculate_plot_area(canvas_width, canvas_height, margins, plot_area)
+    
+    x_pos = compute_ylabel_x_pos(plot_area, ylabel_width, ytick_max_width)
+    
+    if (x_pos < 1) then
+        print *, 'FAIL: Y-label cut off on small canvas (x_pos=', x_pos, ')'
+        ok = .false.
+    end if
+    
+    ! Test case 3: Very long ylabel
+    canvas_width = 800
+    canvas_height = 600
+    call calculate_plot_area(canvas_width, canvas_height, margins, plot_area)
+    ylabel_width = 80  ! Very long label
+    
+    x_pos = compute_ylabel_x_pos(plot_area, ylabel_width, ytick_max_width)
+    
+    if (x_pos < 1) then
+        print *, 'FAIL: Long y-label cut off (x_pos=', x_pos, ')'
+        ok = .false.
+    end if
+    
+    if (ok) then
+        print *, 'PASS: Y-label positioning prevents cutoff in all test cases'
+        stop 0
+    else
+        stop 1
+    end if
+    
+end program test_ylabel_no_cutoff


### PR DESCRIPTION
## Summary
- Fixed ylabel positioning to prevent cutoff at canvas edge
- Increased spacing between ylabel and tick labels to match matplotlib better
- Added minimum margin protection to ensure text remains visible

## Changes
- Increased YLABEL_EXTRA_GAP from 2 to 8 pixels for better separation from tick labels
- Added 15-pixel minimum left margin in compute_ylabel_x_pos to prevent cutoff
- Created comprehensive test_ylabel_no_cutoff test for various edge cases
- Updated test_raster_label_layout_utils to reflect new spacing

## Verification
Tested with:
- `make test` - all tests pass
- test_ylabel_no_cutoff - verifies ylabel positioning with various configurations
- test_ylabel_cutoff_verification - visual verification test (when ImageMagick available)
- Manual testing with large tick labels and long ylabels