### PR TITLE
fix: Audit for dead code in oversized backend modules (fixes #1177)

### DIFF
--- a/src/backends/vector/fortplot_pdf.f90
+++ b/src/backends/vector/fortplot_pdf.f90
@@ -41,8 +41,6 @@ module fortplot_pdf
         procedure :: save => write_pdf_file_facade
         procedure :: set_line_width => set_pdf_line_width
         procedure :: set_line_style => set_pdf_line_style
-        procedure :: save_graphics_state => save_graphics_state_wrapper
-        procedure :: restore_graphics_state => restore_graphics_state_wrapper
         procedure :: draw_marker => draw_pdf_marker_wrapper
         procedure :: set_marker_colors => set_marker_colors_wrapper
         procedure :: set_marker_colors_with_alpha => set_marker_colors_with_alpha_wrapper
@@ -232,14 +230,6 @@ contains
         ctx%core_ctx = this%core_ctx
     end function make_coord_context
 
-    subroutine save_graphics_state_wrapper(this)
-        class(pdf_context), intent(inout) :: this
-        call pdf_save_graphics_state(this%stream_writer)
-    end subroutine save_graphics_state_wrapper
-    subroutine restore_graphics_state_wrapper(this)
-        class(pdf_context), intent(inout) :: this
-        call pdf_restore_graphics_state(this%stream_writer)
-    end subroutine restore_graphics_state_wrapper
     subroutine draw_pdf_marker_wrapper(this, x, y, style)
         class(pdf_context), intent(inout) :: this
         real(wp), intent(in) :: x, y

--- a/src/plotting/fortplot_contour_regions.f90
+++ b/src/plotting/fortplot_contour_regions.f90
@@ -270,42 +270,6 @@ contains
         end subroutine resolve_saddle_connection
 
     end subroutine extract_region_boundaries
-
-    subroutine process_marching_squares(x_grid, y_grid, z_grid, level_min, level_max, &
-                                       contour_x, contour_y, contour_count)
-        !! Process grid cells using marching squares algorithm
-        real(wp), intent(in) :: x_grid(:), y_grid(:), z_grid(:, :)
-        real(wp), intent(in) :: level_min, level_max
-        real(wp), intent(inout) :: contour_x(:), contour_y(:)
-        integer, intent(inout) :: contour_count
-        
-        integer :: nx, ny, i, j
-        integer :: grid_case
-        real(wp) :: corner_values(4)
-        
-        nx = size(x_grid)
-        ny = size(y_grid)
-        
-        ! Process each grid cell
-        ! Note: z_grid is indexed as (ny, nx) i.e., (y, x)
-        do j = 1, ny - 1
-            do i = 1, nx - 1
-                ! Get corner values for current cell (y-major indexing)
-                corner_values(1) = z_grid(j    , i    )  ! Bottom-left
-                corner_values(2) = z_grid(j    , i + 1)  ! Bottom-right
-                corner_values(3) = z_grid(j + 1, i + 1)  ! Top-right
-                corner_values(4) = z_grid(j + 1, i    )  ! Top-left
-                
-                ! Calculate marching squares case
-                grid_case = calculate_marching_squares_case(corner_values, level_min, level_max)
-                
-                ! Handle the marching squares case
-                call handle_marching_squares_case(grid_case, i, j, corner_values, &
-                                                 level_min, level_max, x_grid, y_grid, &
-                                                 contour_x, contour_y, contour_count)
-            end do
-        end do
-    end subroutine process_marching_squares
     
     function calculate_marching_squares_case(corner_values, level_min, level_max) result(grid_case)
         !! Calculate marching squares case from corner values


### PR DESCRIPTION
## Summary
- Removed unused `process_marching_squares` function from fortplot_contour_regions.f90
- Removed unused graphics state wrapper procedures from fortplot_pdf.f90
- Total code reduction: 46 lines

## Verification
- All tests pass: `make test` completes successfully
- No functionality affected - removed code was never called
- Identified through static analysis: functions/procedures only defined but never referenced