### PR TITLE
fix: Links to source codes broken in example github pages (fixes #1193)

### DIFF
--- a/doc/examples/animation.md
+++ b/doc/examples/animation.md
@@ -3,7 +3,7 @@ title: Animation
 
 # Animation
 
-Source: [example/fortran/animation/save_animation_demo.f90](../../example/fortran/animation/save_animation_demo.f90)
+Source: [save_animation_demo.f90](../../sourcefile/save_animation_demo.f90.html)
 
 This example demonstrates creating animated plots and saving to video files.
 

--- a/doc/examples/ascii_heatmap.md
+++ b/doc/examples/ascii_heatmap.md
@@ -3,7 +3,7 @@ title: Ascii Heatmap
 
 # ASCII Heatmap
 
-Source: [example/fortran/ascii_heatmap/ascii_heatmap.f90](../../example/fortran/ascii_heatmap/ascii_heatmap.f90)
+Source: [ascii_heatmap.f90](../../sourcefile/ascii_heatmap.f90.html)
 
 This example demonstrates terminal-based heatmap visualization using ASCII characters.
 

--- a/doc/examples/basic_plots.md
+++ b/doc/examples/basic_plots.md
@@ -3,7 +3,7 @@ title: Basic Plots
 
 # Basic Plots
 
-Source: [example/fortran/basic_plots/basic_plots.f90](../../example/fortran/basic_plots/basic_plots.f90)
+Source: [basic_plots.f90](../../sourcefile/basic_plots.f90.html)
 
 This example demonstrates the fundamental plotting capabilities of fortplotlib using both the simple functional API and the object-oriented interface.
 

--- a/doc/examples/colored_contours.md
+++ b/doc/examples/colored_contours.md
@@ -3,7 +3,7 @@ title: Colored Contours
 
 # Colored Contours
 
-Source: [example/fortran/colored_contours/colored_contours.f90](../../example/fortran/colored_contours/colored_contours.f90)
+Source: [colored_contours.f90](../../sourcefile/colored_contours.f90.html)
 
 This example shows filled (colored) contour plots with customizable colormaps for visualizing 2D scalar fields.
 

--- a/doc/examples/contour_demo.md
+++ b/doc/examples/contour_demo.md
@@ -3,7 +3,7 @@ title: Contour Demo
 
 # Contour Demo
 
-Source: [example/fortran/contour_demo/contour_demo.f90](../../example/fortran/contour_demo/contour_demo.f90)
+Source: [contour_demo.f90](../../sourcefile/contour_demo.f90.html)
 
 This example demonstrates line contour plotting (level lines) with custom levels and a mixed plot combining contours with a line overlay.
 

--- a/doc/examples/format_string_demo.md
+++ b/doc/examples/format_string_demo.md
@@ -3,7 +3,7 @@ title: Format String Demo
 
 # Format String Demo
 
-Source: [example/fortran/format_string_demo/format_string_demo.f90](../../example/fortran/format_string_demo/format_string_demo.f90)
+Source: [format_string_demo.f90](../../sourcefile/format_string_demo.f90.html)
 
 This example demonstrates matplotlib-style format strings for quick and intuitive plot styling.
 

--- a/doc/examples/legend_box_demo.md
+++ b/doc/examples/legend_box_demo.md
@@ -3,7 +3,7 @@ title: Legend Box Demo
 
 # Legend Box Demo
 
-Source: [example/fortran/legend_demo/legend_demo.f90](../../example/fortran/legend_demo/legend_demo.f90)
+Source: [legend_demo.f90](../../sourcefile/legend_demo.f90.html)
 
 This demo showcases the legend box with different placements. Images are embedded below for quick viewing; PDFs are linked for high-quality output.
 

--- a/doc/examples/legend_demo.md
+++ b/doc/examples/legend_demo.md
@@ -3,7 +3,7 @@ title: Legend Demo
 
 # Legend Demo
 
-Source: [example/fortran/legend_demo/legend_demo.f90](../../example/fortran/legend_demo/legend_demo.f90)
+Source: [legend_demo.f90](../../sourcefile/legend_demo.f90.html)
 
 This example demonstrates legend placement and customization options.
 

--- a/doc/examples/line_styles.md
+++ b/doc/examples/line_styles.md
@@ -3,7 +3,7 @@ title: Line Styles
 
 # Line Styles
 
-Source: [example/fortran/line_styles/line_styles.f90](../../example/fortran/line_styles/line_styles.f90)
+Source: [line_styles.f90](../../sourcefile/line_styles.f90.html)
 
 This example demonstrates all available line styles in fortplotlib, showing how to customize the appearance of plotted lines.
 

--- a/doc/examples/marker_demo.md
+++ b/doc/examples/marker_demo.md
@@ -3,7 +3,7 @@ title: Marker Demo
 
 # Marker Demo
 
-Source: [example/fortran/marker_demo/marker_demo.f90](../../example/fortran/marker_demo/marker_demo.f90)
+Source: [marker_demo.f90](../../sourcefile/marker_demo.f90.html)
 
 This example showcases various marker types and scatter plot capabilities in fortplotlib.
 

--- a/doc/examples/pcolormesh_demo.md
+++ b/doc/examples/pcolormesh_demo.md
@@ -3,7 +3,7 @@ title: Pcolormesh Demo
 
 # Pcolormesh Demo
 
-Source: [example/fortran/pcolormesh_demo/pcolormesh_demo.f90](../../example/fortran/pcolormesh_demo/pcolormesh_demo.f90)
+Source: [pcolormesh_demo.f90](../../sourcefile/pcolormesh_demo.f90.html)
 
 This example demonstrates pseudocolor plots for efficient 2D data visualization.
 

--- a/doc/examples/scale_examples.md
+++ b/doc/examples/scale_examples.md
@@ -3,7 +3,7 @@ title: Scale Examples
 
 # Scale Examples
 
-Source: [example/fortran/scale_examples/scale_examples.f90](../../example/fortran/scale_examples/scale_examples.f90)
+Source: [scale_examples.f90](../../sourcefile/scale_examples.f90.html)
 
 This example demonstrates different axis scaling options including logarithmic and symmetric logarithmic (symlog) scales.
 

--- a/doc/examples/show_viewer_demo.md
+++ b/doc/examples/show_viewer_demo.md
@@ -3,7 +3,7 @@ title: Show Viewer Demo
 
 # Show Viewer Demo
 
-Source: [example/fortran/show_viewer_demo/show_viewer_demo.f90](../../example/fortran/show_viewer_demo/show_viewer_demo.f90)
+Source: [show_viewer_demo.f90](../../sourcefile/show_viewer_demo.f90.html)
 
 This example demonstrates using the built-in viewer for interactive display.
 

--- a/doc/examples/smart_show_demo.md
+++ b/doc/examples/smart_show_demo.md
@@ -3,7 +3,7 @@ title: Smart Show Demo
 
 # Smart Show Demo
 
-Source: [example/fortran/smart_show_demo/smart_show_demo.f90](../../example/fortran/smart_show_demo/smart_show_demo.f90)
+Source: [smart_show_demo.f90](../../sourcefile/smart_show_demo.f90.html)
 
 This example demonstrates intelligent display mode selection based on environment.
 

--- a/doc/examples/streamplot_demo.md
+++ b/doc/examples/streamplot_demo.md
@@ -3,7 +3,7 @@ title: Streamplot Demo
 
 # Streamplot Demo
 
-Source: [example/fortran/streamplot_demo/streamplot_demo.f90](../../example/fortran/streamplot_demo/streamplot_demo.f90)
+Source: [streamplot_demo.f90](../../sourcefile/streamplot_demo.f90.html)
 
 This example shows vector field visualization using streamlines.
 

--- a/doc/examples/unicode_demo.md
+++ b/doc/examples/unicode_demo.md
@@ -3,7 +3,7 @@ title: Unicode Demo
 
 # Unicode Demo
 
-Source: [example/fortran/unicode_demo/unicode_demo.f90](../../example/fortran/unicode_demo/unicode_demo.f90)
+Source: [unicode_demo.f90](../../sourcefile/unicode_demo.f90.html)
 
 This example demonstrates mathematical symbols and Unicode support in plots.
 


### PR DESCRIPTION
## Verification

Updated all example documentation files to link to FORD-generated source HTML pages instead of raw source files.

### Commands executed:
```bash
# Verified source HTML generation
ls build/doc/sourcefile/*.html | grep save_animation
# save_animation_demo.f90.html exists

# Fixed all links from:
# [example/fortran/*/file.f90](../../example/fortran/*/file.f90)
# To:
# [file.f90](../../sourcefile/file.f90.html)

# Tests pass:
make test
# ALL TESTS PASSED (fpm test)
```

### Files changed:
- Updated 16 documentation files in `doc/examples/`
- All links now point to `../../sourcefile/{filename}.f90.html`
- Verified generated HTML contains correct links

This ensures that source code links on GitHub Pages will work correctly by pointing to the FORD-generated documentation pages.