### PR TITLE
fix: Further improve ylabel spacing and title centering

### DIFF
--- a/src/backends/raster/fortplot_raster_axes.f90
+++ b/src/backends/raster/fortplot_raster_axes.f90
@@ -451,7 +451,7 @@ contains
         type(plot_area_t), intent(in) :: plot_area
         integer, intent(in) :: rotated_width, y_tick_max_width
         integer :: clearance, min_left_margin
-        integer, parameter :: YLABEL_EXTRA_GAP = 10
+        integer, parameter :: YLABEL_EXTRA_GAP = 15
         
         ! Original implementation logic for backward compatibility
         clearance = TICK_MARK_LENGTH + Y_TICK_LABEL_RIGHT_PAD + max(0, y_tick_max_width) + YLABEL_EXTRA_GAP

--- a/src/backends/raster/fortplot_raster_labels.f90
+++ b/src/backends/raster/fortplot_raster_labels.f90
@@ -21,7 +21,7 @@ module fortplot_raster_labels
     public :: y_tick_label_right_edge_at_axis
 
     ! Increased gap to better match matplotlib's labelpad (approx 6-8 pixels at 100dpi)
-    integer, parameter :: YLABEL_EXTRA_GAP = 10
+    integer, parameter :: YLABEL_EXTRA_GAP = 15
 
 contains
 
@@ -175,10 +175,9 @@ contains
         call escape_unicode_for_raster(processed_text(1:processed_len), escaped_text)
 
         title_width = calculate_text_width(trim(escaped_text))
-        ! If title width is 0, use approximate width based on character count
-        if (title_width <= 0) then
-            title_width = len_trim(escaped_text) * 8  ! Approximate 8 pixels per character
-        end if
+        ! Always use character count approximation for better centering
+        ! Average character width is approximately 9 pixels for the default font
+        title_width = len_trim(escaped_text) * 9
         title_px = real(plot_area%left + plot_area%width/2 - title_width/2, wp)
         title_py = real(max(5, plot_area%bottom - TITLE_VERTICAL_OFFSET), wp)
     end subroutine compute_title_position

--- a/test/test_raster_label_layout_utils.f90
+++ b/test/test_raster_label_layout_utils.f90
@@ -48,7 +48,7 @@ contains
         integer :: x_pos, expected
         integer, parameter :: Y_TICK_LABEL_RIGHT_PAD = 10
         ! Updated to match the increased gap in fortplot_raster_axes
-        integer, parameter :: YLABEL_EXTRA_GAP = 10
+        integer, parameter :: YLABEL_EXTRA_GAP = 15
 
         area%left = 100; area%bottom = 50; area%width = 400; area%height = 300
         rotated_text_width = 20
@@ -92,7 +92,7 @@ contains
         integer :: x_pos
         integer, parameter :: Y_TICK_LABEL_RIGHT_PAD = 10
         ! Updated to match the increased gap in fortplot_raster_axes
-        integer, parameter :: YLABEL_EXTRA_GAP = 10
+        integer, parameter :: YLABEL_EXTRA_GAP = 15
 
         ! Create a scenario where ylabel would be positioned at negative x
         ! Small plot area on the left with very wide tick labels


### PR DESCRIPTION
## Summary
- Improved ylabel spacing by moving it further left
- Enhanced title centering with consistent character width approximation
- Updated tests to match new spacing values

## Changes
- Increased YLABEL_EXTRA_GAP from 10 to 15 pixels for better ylabel separation
- Improved title centering using fixed 9-pixel character width approximation
- Updated test expectations to match the new spacing values

## Test plan
- [x] Run `make test` locally - all tests pass
- [x] Visual inspection shows improved ylabel spacing and title centering
- [ ] CI tests should pass on all platforms

## Visual Improvements
The ylabel now has better separation from the y-axis tick labels, and the title centering is more reliable.

🤖 Generated with [Claude Code](https://claude.ai/code)