### PR TITLE
fix: Use absolute GitHub URLs for source file links in docs

### DIFF
--- a/doc/examples/animation.md
+++ b/doc/examples/animation.md
@@ -3,7 +3,7 @@ title: Animation
 
 # Animation
 
-Source: [save_animation_demo.f90](../../sourcefile/save_animation_demo.f90.html)
+Source: [save_animation_demo.f90](https://github.com/lazy-fortran/fortplot/blob/main/example/fortran/animation/save_animation_demo.f90)
 
 This example demonstrates creating animated plots and saving to video files.
 

--- a/doc/examples/annotation_demo.md
+++ b/doc/examples/annotation_demo.md
@@ -3,7 +3,7 @@ title: Annotation Demo
 
 # Annotation Demo
 
-Source: [annotation_demo.f90](../../sourcefile/annotation_demo.f90.html)
+Source: [annotation_demo.f90](https://github.com/lazy-fortran/fortplot/blob/main/example/fortran/annotation_demo/annotation_demo.f90)
 ## Generated Outputs
 
 Output files generated in: example/fortran/annotation_demo

--- a/doc/examples/ascii_heatmap.md
+++ b/doc/examples/ascii_heatmap.md
@@ -3,7 +3,7 @@ title: Ascii Heatmap
 
 # ASCII Heatmap
 
-Source: [ascii_heatmap.f90](../../sourcefile/ascii_heatmap.f90.html)
+Source: [ascii_heatmap_demo.f90](https://github.com/lazy-fortran/fortplot/blob/main/example/fortran/ascii_heatmap/ascii_heatmap_demo.f90)
 
 This example demonstrates terminal-based heatmap visualization using ASCII characters.
 

--- a/doc/examples/basic_plots.md
+++ b/doc/examples/basic_plots.md
@@ -3,7 +3,7 @@ title: Basic Plots
 
 # Basic Plots
 
-Source: [basic_plots.f90](../../example/fortran/basic_plots/basic_plots.f90)
+Source: [basic_plots.f90](https://github.com/lazy-fortran/fortplot/blob/main/example/fortran/basic_plots/basic_plots.f90)
 
 This example demonstrates the fundamental plotting capabilities of fortplotlib using both the simple functional API and the object-oriented interface.
 

--- a/doc/examples/colored_contours.md
+++ b/doc/examples/colored_contours.md
@@ -3,7 +3,7 @@ title: Colored Contours
 
 # Colored Contours
 
-Source: [colored_contours.f90](../../sourcefile/colored_contours.f90.html)
+Source: [colored_contours.f90](https://github.com/lazy-fortran/fortplot/blob/main/example/fortran/colored_contours/colored_contours.f90)
 
 This example shows filled (colored) contour plots with customizable colormaps for visualizing 2D scalar fields.
 

--- a/doc/examples/contour_demo.md
+++ b/doc/examples/contour_demo.md
@@ -3,7 +3,7 @@ title: Contour Demo
 
 # Contour Demo
 
-Source: [contour_demo.f90](../../sourcefile/contour_demo.f90.html)
+Source: [contour_demo.f90](https://github.com/lazy-fortran/fortplot/blob/main/example/fortran/contour_demo/contour_demo.f90)
 
 This example demonstrates line contour plotting (level lines) with custom levels and a mixed plot combining contours with a line overlay.
 

--- a/doc/examples/format_string_demo.md
+++ b/doc/examples/format_string_demo.md
@@ -3,7 +3,7 @@ title: Format String Demo
 
 # Format String Demo
 
-Source: [format_string_demo.f90](../../sourcefile/format_string_demo.f90.html)
+Source: [format_string_demo.f90](https://github.com/lazy-fortran/fortplot/blob/main/example/fortran/format_string_demo/format_string_demo.f90)
 
 This example demonstrates matplotlib-style format strings for quick and intuitive plot styling.
 

--- a/doc/examples/legend_box_demo.md
+++ b/doc/examples/legend_box_demo.md
@@ -3,7 +3,7 @@ title: Legend Box Demo
 
 # Legend Box Demo
 
-Source: [legend_demo.f90](../../sourcefile/legend_demo.f90.html)
+Source: [legend_demo.f90](https://github.com/lazy-fortran/fortplot/blob/main/example/fortran/legend_demo/legend_demo.f90)
 
 This demo showcases the legend box with different placements. Images are embedded below for quick viewing; PDFs are linked for high-quality output.
 

--- a/doc/examples/legend_demo.md
+++ b/doc/examples/legend_demo.md
@@ -3,7 +3,7 @@ title: Legend Demo
 
 # Legend Demo
 
-Source: [legend_demo.f90](../../sourcefile/legend_demo.f90.html)
+Source: [legend_demo.f90](https://github.com/lazy-fortran/fortplot/blob/main/example/fortran/legend_demo/legend_demo.f90)
 
 This example demonstrates legend placement and customization options.
 

--- a/doc/examples/line_styles.md
+++ b/doc/examples/line_styles.md
@@ -3,7 +3,7 @@ title: Line Styles
 
 # Line Styles
 
-Source: [line_styles.f90](../../sourcefile/line_styles.f90.html)
+Source: [line_styles.f90](https://github.com/lazy-fortran/fortplot/blob/main/example/fortran/line_styles/line_styles.f90)
 
 This example demonstrates all available line styles in fortplotlib, showing how to customize the appearance of plotted lines.
 

--- a/doc/examples/marker_demo.md
+++ b/doc/examples/marker_demo.md
@@ -3,7 +3,7 @@ title: Marker Demo
 
 # Marker Demo
 
-Source: [marker_demo.f90](../../sourcefile/marker_demo.f90.html)
+Source: [marker_demo.f90](https://github.com/lazy-fortran/fortplot/blob/main/example/fortran/marker_demo/marker_demo.f90)
 
 This example showcases various marker types and scatter plot capabilities in fortplotlib.
 

--- a/doc/examples/pcolormesh_demo.md
+++ b/doc/examples/pcolormesh_demo.md
@@ -3,7 +3,7 @@ title: Pcolormesh Demo
 
 # Pcolormesh Demo
 
-Source: [pcolormesh_demo.f90](../../sourcefile/pcolormesh_demo.f90.html)
+Source: [pcolormesh_demo.f90](https://github.com/lazy-fortran/fortplot/blob/main/example/fortran/pcolormesh_demo/pcolormesh_demo.f90)
 
 This example demonstrates pseudocolor plots for efficient 2D data visualization.
 

--- a/doc/examples/scale_examples.md
+++ b/doc/examples/scale_examples.md
@@ -3,7 +3,7 @@ title: Scale Examples
 
 # Scale Examples
 
-Source: [scale_examples.f90](../../sourcefile/scale_examples.f90.html)
+Source: [scale_examples.f90](https://github.com/lazy-fortran/fortplot/blob/main/example/fortran/scale_examples/scale_examples.f90)
 
 This example demonstrates different axis scaling options including logarithmic and symmetric logarithmic (symlog) scales.
 

--- a/doc/examples/show_viewer_demo.md
+++ b/doc/examples/show_viewer_demo.md
@@ -3,7 +3,7 @@ title: Show Viewer Demo
 
 # Show Viewer Demo
 
-Source: [show_viewer_demo.f90](../../sourcefile/show_viewer_demo.f90.html)
+Source: [show_viewer_demo.f90](https://github.com/lazy-fortran/fortplot/blob/main/example/fortran/show_viewer_demo/show_viewer_demo.f90)
 
 This example demonstrates using the built-in viewer for interactive display.
 

--- a/doc/examples/smart_show_demo.md
+++ b/doc/examples/smart_show_demo.md
@@ -3,7 +3,7 @@ title: Smart Show Demo
 
 # Smart Show Demo
 
-Source: [smart_show_demo.f90](../../sourcefile/smart_show_demo.f90.html)
+Source: [smart_show_demo.f90](https://github.com/lazy-fortran/fortplot/blob/main/example/fortran/smart_show_demo/smart_show_demo.f90)
 
 This example demonstrates intelligent display mode selection based on environment.
 

--- a/doc/examples/streamplot_demo.md
+++ b/doc/examples/streamplot_demo.md
@@ -3,7 +3,7 @@ title: Streamplot Demo
 
 # Streamplot Demo
 
-Source: [streamplot_demo.f90](../../sourcefile/streamplot_demo.f90.html)
+Source: [streamplot_demo.f90](https://github.com/lazy-fortran/fortplot/blob/main/example/fortran/streamplot_demo/streamplot_demo.f90)
 
 This example shows vector field visualization using streamlines.
 

--- a/doc/examples/unicode_demo.md
+++ b/doc/examples/unicode_demo.md
@@ -3,7 +3,7 @@ title: Unicode Demo
 
 # Unicode Demo
 
-Source: [unicode_demo.f90](../../sourcefile/unicode_demo.f90.html)
+Source: [unicode_demo.f90](https://github.com/lazy-fortran/fortplot/blob/main/example/fortran/unicode_demo/unicode_demo.f90)
 
 This example demonstrates mathematical symbols and Unicode support in plots.
 


### PR DESCRIPTION
## Summary
Fixed broken source file links on GitHub Pages by replacing relative paths with absolute GitHub URLs.

## Problem
The documentation source file links were pointing to `../../sourcefile/*.html` which doesn't exist on GitHub Pages, causing 404 errors when users try to view source code.

## Solution
- Replaced all source file links with absolute GitHub URLs: `https://github.com/lazy-fortran/fortplot/blob/main/...`
- **Preserved** all working relative links for generated files (PNG/PDF/TXT) - these remain unchanged
- Fixed ascii_heatmap link text to match actual filename (ascii_heatmap_demo.f90)

## Files Changed
Updated 17 documentation files in `doc/examples/` to use absolute GitHub URLs for source files only.

## Testing
- Verified all linked source files exist at the specified GitHub paths
- Confirmed PNG/PDF/TXT links remain as relative paths (working correctly)
- All links will now work properly on GitHub Pages

Co-Authored-By: Claude <noreply@anthropic.com>