### PR TITLE
fix: Process LaTeX before mathtext in PDF backend

### DIFF
--- a/src/backends/vector/fortplot_pdf_axes.f90
+++ b/src/backends/vector/fortplot_pdf_axes.f90
@@ -514,17 +514,19 @@ contains
         character(len=512) :: processed
         integer :: plen
 
-        ! Check if text contains mathematical notation
-        if (index(text, '^') > 0 .or. index(text, '_') > 0) then
-            ! Use mathtext rendering for superscripts/subscripts
+        ! ALWAYS process LaTeX commands first to convert to Unicode
+        call process_latex_in_text(text, processed, plen)
+        
+        ! Now check if the processed text contains mathematical notation
+        if (index(processed(1:plen), '^') > 0 .or. index(processed(1:plen), '_') > 0) then
+            ! Use mathtext rendering for superscripts/subscripts on the processed text
             if (present(font_size)) then
-                call draw_pdf_mathtext(ctx, x, y, text, font_size)
+                call draw_pdf_mathtext(ctx, x, y, processed(1:plen), font_size)
             else
-                call draw_pdf_mathtext(ctx, x, y, text)
+                call draw_pdf_mathtext(ctx, x, y, processed(1:plen))
             end if
         else
-            ! Process LaTeX and use regular mixed-font rendering
-            call process_latex_in_text(text, processed, plen)
+            ! Use regular mixed-font rendering for the processed text
             if (present(font_size)) then
                 call draw_mixed_font_text(ctx, x, y, processed(1:plen), font_size)
             else


### PR DESCRIPTION
## Summary
- Fixed regression where PDF backend showed raw LaTeX commands instead of rendered symbols
- Ensured LaTeX is always processed before checking for mathtext notation
- Added proper LaTeX and mathtext support to legend rendering

## Problem
The previous mathtext implementation (commit 3762c7f) broke LaTeX rendering in PDFs:
- Titles showed raw LaTeX like '\alpha \beta \gamma' instead of Greek symbols
- Legend labels didn't process LaTeX or mathtext at all
- Incorrect spacing due to unprocessed escape sequences

## Solution
1. **Always process LaTeX first** to convert commands to Unicode
2. **Then check** if the processed text contains mathtext notation (^ or _)
3. **Updated legend rendering** to use the same LaTeX→mathtext pipeline

## Test plan
- [x] Run `fpm test test_pdf_mathtext` - verify superscripts/subscripts still work
- [x] Run `fpm run --example unicode_demo` - verify Greek letters render correctly 
- [x] Run `make test` - ensure all tests pass
- [x] Check unicode_demo.pdf output - Greek symbols should render, not LaTeX literals

🤖 Generated with Claude Code