### PR TITLE
fix: Improve legend superscripts and ylabel positioning in PDF backend

### DIFF
--- a/src/backends/vector/fortplot_pdf_axes.f90
+++ b/src/backends/vector/fortplot_pdf_axes.f90
@@ -496,8 +496,8 @@ contains
                 ! Process LaTeX commands for accurate width calculation
                 call process_latex_in_text(trim(ylabel), processed_ylabel, processed_len)
                 
-                ! Place y-label 60px left of plot frame (was 98px; too far left)
-                ylabel_x = plot_area_left - 60.0_wp
+                ! Place y-label 45px left of plot frame (reduced from 60px)
+                ylabel_x = plot_area_left - 45.0_wp
                 ylabel_y = plot_area_bottom + plot_area_height * 0.5_wp - &
                           real(processed_len, wp) * 3.0_wp
                 call render_rotated_mixed_text(ctx, ylabel_x, ylabel_y, trim(ylabel))

--- a/src/backends/vector/fortplot_pdf_coordinate.f90
+++ b/src/backends/vector/fortplot_pdf_coordinate.f90
@@ -109,14 +109,10 @@ contains
             ! Process LaTeX commands first to convert to Unicode
             call process_latex_in_text(entries(i)%label, processed, plen)
             
-            ! Check if processed text contains mathematical notation
-            if (index(processed(1:plen), '^') > 0 .or. index(processed(1:plen), '_') > 0) then
-                ! Use mathtext rendering for superscripts/subscripts
-                call draw_pdf_mathtext(ctx%core_ctx, x, y_pos, processed(1:plen))
-            else
-                ! Use regular mixed-font rendering
-                call draw_mixed_font_text(ctx%core_ctx, x, y_pos, processed(1:plen))
-            end if
+            ! Always use mathtext rendering for legend entries to handle any mathematical notation
+            ! This ensures superscripts, subscripts, and Unicode characters are rendered correctly
+            call draw_pdf_mathtext(ctx%core_ctx, x, y_pos, processed(1:plen))
+            
             y_pos = y_pos - 20.0_wp
         end do
     end subroutine pdf_render_legend_specialized
@@ -198,7 +194,7 @@ contains
         
         real(wp) :: x, y
         
-        x = real(ctx%plot_area%left - 40, wp)
+        x = real(ctx%plot_area%left - 30, wp)  ! Reduced spacing from 40 to 30
         y = real(ctx%plot_area%bottom + ctx%plot_area%height / 2, wp)
         
         call draw_rotated_mixed_font_text(ctx%core_ctx, x, y, ylabel)


### PR DESCRIPTION
## Summary
- Fixed legend superscript rendering by always using mathtext for legend entries
- Improved ylabel positioning by reducing excessive spacing in PDF backend

## Changes
- **Legend Fix**: Always use `draw_pdf_mathtext` for legend entries instead of conditionally checking for `^` or `_`
  - This ensures proper rendering of superscripts/subscripts after LaTeX processing
  - Fixes case where LaTeX commands are converted to Unicode but `^{}` notation remains
- **Ylabel Positioning**: Reduced spacing in two locations:
  - `pdf_render_ylabel`: 40px → 30px spacing from plot area
  - `draw_pdf_title_and_labels`: 60px → 45px spacing from plot area

## Test Plan
- [x] Run `make test` - all tests pass
- [x] Run unicode_demo - generates PDFs without errors
- [x] Verify legend entries with superscripts render correctly
- [x] Check ylabel positioning looks better balanced

## Affected Components
- `fortplot_pdf_coordinate.f90`: Legend rendering and ylabel positioning
- `fortplot_pdf_axes.f90`: Alternative ylabel positioning

Resolves user-reported issues with legend superscripts not working and ylabel being too far left in PDF output.

🤖 Generated with [Claude Code](https://claude.ai/code)