### PR TITLE
fix: Fix legend superscripts by using inline mathtext rendering

### DIFF
--- a/src/backends/vector/fortplot_pdf_coordinate.f90
+++ b/src/backends/vector/fortplot_pdf_coordinate.f90
@@ -98,17 +98,24 @@ contains
         type(legend_entry_t), dimension(:), intent(in) :: entries
         real(wp), intent(in) :: x, y, width, height
         
-        ! Simplified legend rendering with LaTeX and mathtext support
-        integer :: i, plen
+        ! Render legend with full text support (LaTeX and mathtext)
+        integer :: i
         real(wp) :: y_pos
-        character(len=512) :: processed
+        character(len=512) :: label_buffer
+        integer :: label_len
         associate(dummy_w => width, dummy_h => height); end associate
         
         y_pos = y
         do i = 1, size(entries)
-            ! Always use mathtext rendering for legend entries to handle mathematical notation
-            ! Skip LaTeX processing - let mathtext handle raw LaTeX commands and superscripts
-            call draw_pdf_mathtext(ctx%core_ctx, x, y_pos, trim(entries(i)%label))
+            ! Copy label to fixed-size buffer to ensure full text is passed
+            if (allocated(entries(i)%label)) then
+                label_len = len(entries(i)%label)
+                if (label_len > 0) then
+                    label_buffer = entries(i)%label
+                    ! Use mathtext rendering which handles both LaTeX and superscripts
+                    call draw_pdf_mathtext(ctx%core_ctx, x, y_pos, label_buffer(1:label_len))
+                end if
+            end if
             
             y_pos = y_pos - 20.0_wp
         end do

--- a/src/backends/vector/fortplot_pdf_text.f90
+++ b/src/backends/vector/fortplot_pdf_text.f90
@@ -560,8 +560,8 @@ contains
         
         type(mathtext_element_t), allocatable :: elements(:)
         real(wp) :: fs, current_x, baseline_y
-        integer :: i, processed_len
-        character(len=len(text)*2) :: preprocessed_text
+        integer :: i, processed_len, text_len
+        character(len=1024) :: preprocessed_text  ! Fixed size buffer for safety
         
         ! ALWAYS process LaTeX commands first (matches render_mixed_text logic)
         call process_latex_in_text(text, preprocessed_text, processed_len)
@@ -585,20 +585,14 @@ contains
         fs = PDF_LABEL_SIZE
         if (present(font_size)) fs = font_size
         
-        ! Begin text object
-        this%stream_data = this%stream_data // "BT" // new_line('a')
-        
-        ! Initialize position
+        ! Initialize position - directly render without BT/ET for inline use
         current_x = x
         baseline_y = y
         
-        ! Render each element
+        ! Render each element inline (for use within existing text objects like legends)
         do i = 1, size(elements)
-            call render_mathtext_element_pdf(this, elements(i), current_x, baseline_y, fs)
+            call render_mathtext_element_pdf_inline(this, elements(i), current_x, baseline_y, fs)
         end do
-        
-        ! End text object
-        this%stream_data = this%stream_data // "ET" // new_line('a')
         
         deallocate(elements)
     end subroutine draw_pdf_mathtext
@@ -674,6 +668,63 @@ contains
         x_pos = x_pos + char_width
         
     end subroutine render_mathtext_element_pdf
+    
+    subroutine render_mathtext_element_pdf_inline(this, element, x_pos, baseline_y, base_font_size)
+        !! Render a single mathematical text element inline (without BT/ET)
+        class(pdf_context_core), intent(inout) :: this
+        type(mathtext_element_t), intent(in) :: element
+        real(wp), intent(inout) :: x_pos
+        real(wp), intent(in) :: baseline_y, base_font_size
+        
+        real(wp) :: elem_font_size, elem_y
+        real(wp) :: char_width
+        integer :: i, char_len
+        character(len=256) :: pos_cmd
+        character(len=64) :: font_cmd
+        character(len=8) :: escaped_char
+        integer :: esc_len
+        
+        ! Calculate font size and position for this element
+        elem_font_size = base_font_size * element%font_size_ratio
+        elem_y = baseline_y - element%vertical_offset * base_font_size
+        
+        ! Set font size for this element
+        write(font_cmd, '("/F5 ", F0.1, " Tf")') elem_font_size
+        this%stream_data = this%stream_data // trim(adjustl(font_cmd)) // new_line('a')
+        
+        ! Set text position
+        write(pos_cmd, '("1 0 0 1 ", F0.3, " ", F0.3, " Tm")') x_pos, elem_y
+        this%stream_data = this%stream_data // trim(adjustl(pos_cmd)) // new_line('a')
+        
+        ! Render text character by character
+        i = 1
+        do while (i <= len_trim(element%text))
+            escaped_char = ''
+            esc_len = 0
+            
+            ! Check for special characters and escape them
+            char_len = utf8_char_length(element%text(i:i))
+            if (char_len == 0) char_len = 1
+            
+            ! Simple escape - just output the character
+            if (char_len == 1) then
+                call escape_pdf_string(element%text(i:i), escaped_char, esc_len)
+                this%stream_data = this%stream_data // "(" // escaped_char(1:esc_len) // ") Tj" // new_line('a')
+            else
+                ! UTF-8 character - handle specially
+                call escape_pdf_string(element%text(i:i+char_len-1), escaped_char, esc_len)
+                this%stream_data = this%stream_data // "(" // escaped_char(1:esc_len) // ") Tj" // new_line('a')
+            end if
+            
+            ! Move to next character
+            i = i + char_len
+        end do
+        
+        ! Update x position for next element
+        ! Estimate width based on font size and character count
+        char_width = elem_font_size * 0.6_wp * real(len_trim(element%text), wp)
+        x_pos = x_pos + char_width
+    end subroutine render_mathtext_element_pdf_inline
 
 
 end module fortplot_pdf_text


### PR DESCRIPTION
## Summary
- Fixed legend text truncation that was causing superscripts to be lost
- Implemented inline mathtext rendering for legend entries
- Legends now properly display superscripts like title text

## Problem
Legend entries were being truncated and superscripts weren't rendering because:
1. Character buffer size was calculated incorrectly using len(text)*2 for allocatable strings
2. Mathtext rendering was trying to create BT/ET blocks within existing legend text blocks
3. Legend text was being cut off at first few characters

## Solution  
- Changed to fixed 1024-char buffer for LaTeX preprocessing
- Created render_mathtext_element_pdf_inline that works without BT/ET blocks
- Fixed buffer handling in pdf_render_legend_specialized
- Legends now render full text with proper superscript positioning

## Test Results
- Build passes: make build succeeds
- All tests pass: make test completes successfully  
- Legend entries like "α damped: sin(ω t)e^{-λτ}" now render with superscripts
- No regression in existing functionality

Generated with Claude Code