### PR TITLE
fix: Correct vertical positioning for PDF superscripts and subscripts

### DIFF
--- a/src/backends/vector/fortplot_pdf_text.f90
+++ b/src/backends/vector/fortplot_pdf_text.f90
@@ -610,7 +610,7 @@ contains
         
         ! Calculate font size and position for this element
         elem_font_size = base_font_size * element%font_size_ratio
-        elem_y = baseline_y - element%vertical_offset * base_font_size
+        elem_y = baseline_y + element%vertical_offset * base_font_size
         
         ! Set initial position
         current_x = x_pos
@@ -686,7 +686,7 @@ contains
         
         ! Calculate font size and position for this element
         elem_font_size = base_font_size * element%font_size_ratio
-        elem_y = baseline_y - element%vertical_offset * base_font_size
+        elem_y = baseline_y + element%vertical_offset * base_font_size
         
         ! Set font size for this element
         write(font_cmd, '("/F5 ", F0.1, " Tf")') elem_font_size

--- a/src/text/fortplot_mathtext.f90
+++ b/src/text/fortplot_mathtext.f90
@@ -179,9 +179,9 @@ contains
         ! Set font size and vertical offset
         font_size_ratio = SHRINK_FACTOR
         if (element_type == ELEMENT_SUPERSCRIPT) then
-            vertical_offset = -SUPERSCRIPT_RAISE  ! Negative because we render from top
+            vertical_offset = SUPERSCRIPT_RAISE  ! Positive to move up in PDF coordinates
         else if (element_type == ELEMENT_SUBSCRIPT) then
-            vertical_offset = SUBSCRIPT_LOWER
+            vertical_offset = -SUBSCRIPT_LOWER  ! Negative to move down in PDF coordinates
         else
             vertical_offset = 0.0_wp
         end if


### PR DESCRIPTION
## Summary
- Fixed sign convention for vertical offsets in PDF rendering
- Superscripts now properly move up, subscripts move down
- Both title and legend rendering work correctly

## Changes
- Changed `vertical_offset` signs in mathtext module to match PDF coordinates
- Updated PDF rendering to add offset instead of subtracting
- Consistent behavior for both title and legend rendering paths

## Test plan
- [x] Run `fpm test` - all tests pass
- [x] Test `test_super_both.f90` - both title and legend show correct superscripts
- [x] Run `fpm run --example unicode_demo` - generates PDF with properly positioned superscripts
- [x] Verified that `e^{2}` renders above baseline in both titles and legends

🤖 Generated with [Claude Code](https://claude.ai/code)