### PR TITLE
fix: Correct vertical positioning for PNG superscripts and subscripts

### DIFF
--- a/src/text/fortplot_text_rendering.f90
+++ b/src/text/fortplot_text_rendering.f90
@@ -613,7 +613,8 @@ contains
             element_font_size = base_font_size * elements(i)%font_size_ratio
             
             ! Calculate vertical position based on element type and offset
-            pen_y = y + int(elements(i)%vertical_offset * base_font_size)
+            ! PNG uses inverted Y axis (y=0 at top), so negate vertical offset
+            pen_y = y - int(elements(i)%vertical_offset * base_font_size)
             
             ! Render the element using internal function
             call render_text_with_size_internal(image_data, width, height, pen_x, pen_y, &


### PR DESCRIPTION
## Summary
- Fixed inverted vertical positioning of superscripts and subscripts in PNG rendering
- Superscripts now appear above the baseline (as expected)
- Subscripts now appear below the baseline (as expected)

## Problem
PNG unicode plots were rendering superscripts as subscripts and vice versa due to coordinate system differences between PNG and PDF backends.

## Solution
PNG uses an inverted Y-axis (y=0 at top, positive y goes down) compared to PDF coordinates (y=0 at bottom, positive y goes up). The fix negates the vertical offset when rendering mathtext elements to PNG images.

## Changes
- Modified `src/text/fortplot_text_rendering.f90` line 617
- Changed from: `pen_y = y + int(elements(i)%vertical_offset * base_font_size)`
- Changed to: `pen_y = y - int(elements(i)%vertical_offset * base_font_size)`

## Test plan
- [x] Tested with mathtext_demo example
- [x] Verified superscripts appear above baseline
- [x] Verified subscripts appear below baseline
- [x] All examples run successfully with `make example`

🤖 Generated with [Claude Code](https://claude.ai/code)