### PR TITLE
fix: Fix mathtext rendering in PDF legends and PNG sqrt baseline

### DIFF
--- a/src/backends/vector/fortplot_pdf.f90
+++ b/src/backends/vector/fortplot_pdf.f90
@@ -4,7 +4,7 @@ module fortplot_pdf
     use fortplot_pdf_core
     use fortplot_pdf_text
     use fortplot_pdf_drawing
-    use fortplot_pdf_axes
+    use fortplot_pdf_axes, only: draw_pdf_axes_and_labels, render_mixed_text
     use fortplot_pdf_io
     use fortplot_pdf_coordinate
     use fortplot_pdf_markers
@@ -159,14 +159,14 @@ contains
         real(wp), intent(in) :: x, y
         character(len=*), intent(in) :: text
         real(wp) :: pdf_x, pdf_y
-        character(len=500) :: processed_text
-        integer :: processed_len
 
-        call process_latex_in_text(text, processed_text, processed_len)
-        ! Keep context in sync for text coordinate normalization as well
+        ! Keep context in sync for text coordinate normalization
         call this%update_coord_context()
         call normalize_to_pdf_coords(this%coord_ctx, x, y, pdf_x, pdf_y)
-        call draw_mixed_font_text(this%core_ctx, pdf_x, pdf_y, processed_text(1:processed_len))
+        
+        ! Use render_mixed_text which handles LaTeX processing and mathtext
+        ! (superscripts/subscripts) properly, just like titles do
+        call render_mixed_text(this%core_ctx, pdf_x, pdf_y, text)
     end subroutine draw_pdf_text_wrapper
 
     subroutine write_pdf_file_facade(this, filename)

--- a/src/backends/vector/fortplot_pdf_axes.f90
+++ b/src/backends/vector/fortplot_pdf_axes.f90
@@ -28,6 +28,7 @@ module fortplot_pdf_axes
     public :: draw_pdf_title_and_labels
     public :: setup_axes_data_ranges
     public :: generate_tick_data
+    public :: render_mixed_text
 
 contains
 

--- a/src/text/fortplot_text_rendering.f90
+++ b/src/text/fortplot_text_rendering.f90
@@ -653,8 +653,9 @@ contains
             element_font_size = base_font_size * elements(i)%font_size_ratio
 
             if (elements(i)%element_type == 3) then
-                ! Reset baseline for sqrt element
-                pen_y = y - int(elements(i)%vertical_offset * base_font_size)
+                ! Reset baseline for sqrt element to original y position
+                ! This ensures sqrt aligns properly after superscripts/subscripts
+                pen_y = y
                 
                 ! Calculate radicand width, handling nested mathtext
                 if (has_mathtext(elements(i)%text)) then


### PR DESCRIPTION
## Summary
- Fixed PDF legend text to properly render mathematical notation (superscripts/subscripts)  
- Fixed PNG sqrt baseline alignment after superscripts/subscripts

## Problem
1. **PDF legends showed literal `^` characters** instead of proper superscripts (e.g., `e^{-λτ}` instead of e⁻ᵏᵗ)
2. **PNG sqrt symbols appeared misaligned** when following superscripts or subscripts in mathematical expressions

## Solution
1. **PDF**: Modified `draw_pdf_text_wrapper` to use `render_mixed_text` (which handles mathtext) instead of `draw_mixed_font_text` for all text rendering, matching how titles are rendered
2. **PNG**: Reset sqrt element baseline to original y position, preventing carry-over of vertical offset from previous super/subscripts

## Test plan
- [x] Run `fpm run --example unicode_demo` and verify PDF legends show proper superscripts
- [x] Verify PNG sqrt symbols align correctly after superscripts/subscripts
- [x] All existing tests pass

## Before/After
**PDF Legend (Before)**: `α damped: sin(ω t)e^{-λτ}` (showing curly braces)
**PDF Legend (After)**: `α damped: sin(ω t)e⁻ᵏᵗ` (proper superscript)