### PR TITLE
fix: Fix legend box width calculation for long labels

### DIFF
--- a/src/ui/fortplot_legend.f90
+++ b/src/ui/fortplot_legend.f90
@@ -384,7 +384,7 @@ contains
             ! Note: labels not used in ASCII path, but must be declared due to Fortran scoping
         else
             ! Standard backends with margin support
-            allocate(character(len=20) :: labels(legend%num_entries))
+            allocate(character(len=50) :: labels(legend%num_entries))
             do i = 1, legend%num_entries
                 labels(i) = legend%entries(i)%label
             end do


### PR DESCRIPTION
## Summary
Fixed legend box width calculation that was causing boxes to appear too wide for labels longer than 20 characters.

## Problem
The legend box appeared excessively wide when labels contained mathematical notation or other long text (>20 chars). This was particularly noticeable in the unicode_demo example where labels like `α damped: sin(ω t)e^{-λτ}` were being used.

## Root Cause
In `calculate_legend_position` (fortplot_legend.f90:387), the label array was allocated with only 20 characters:
```fortran
allocate(character(len=20) :: labels(legend%num_entries))
```

This truncated longer labels to 20 characters when calculating the legend box position, while the width calculation in `calculate_legend_box` was using the full text. This mismatch caused the box to be sized for the full text but positioned based on truncated text.

## Solution
Changed the allocation to 50 characters to match the allocation used elsewhere in the legend code:
```fortran
allocate(character(len=50) :: labels(legend%num_entries))
```

## Test Results
- [x] Tested with unicode_demo - legend box now properly fits the text
- [x] Tested with various label lengths - all render correctly
- [x] No regression in existing examples

## Before/After
**Before**: Legend box extended far beyond the text
**After**: Legend box properly sized to fit the actual text content

This is a minimal fix that ensures consistent label handling throughout the legend rendering pipeline.