### PR TITLE
fix: Calculate legend box width using processed text after LaTeX conversion

### DIFF
--- a/src/ui/fortplot_legend_layout.f90
+++ b/src/ui/fortplot_legend_layout.f90
@@ -111,16 +111,18 @@ contains
         do i = 1, size(labels)
             trimmed_label = trim(labels(i))
             
+            ! Process LaTeX to Unicode first for accurate width calculation
+            call process_latex_in_text(trimmed_label, temp_processed_label, processed_len)
+            processed_label = temp_processed_label(1:processed_len)
+            
             if (text_system_available) then
-                ! Pass original text directly - calculate_text_width handles mathtext internally
-                text_width_pixels = calculate_text_width(trimmed_label) + fudge_pixels
-                text_height_pixels = calculate_text_height(trimmed_label)
+                ! Calculate width of the processed text (after LaTeX conversion)
+                text_width_pixels = calculate_text_width(processed_label) + fudge_pixels
+                text_height_pixels = calculate_text_height(processed_label)
                 max_text_height_pixels = max(max_text_height_pixels, text_height_pixels)
                 entry_text_width = real(text_width_pixels, wp) / data_to_pixel_ratio_x
             else
-                ! For fallback, process LaTeX to get accurate character count
-                call process_latex_in_text(trimmed_label, temp_processed_label, processed_len)
-                processed_label = temp_processed_label(1:processed_len)
+                ! For fallback, use processed text length
                 entry_text_width = real(len_trim(processed_label), wp) * data_width * TEXT_WIDTH_RATIO
             end if
             total_text_width = total_text_width + entry_text_width


### PR DESCRIPTION
## Summary
Fixed legend box width calculation to use text after LaTeX conversion instead of raw LaTeX commands.

## Problem
Legend boxes were too wide when labels contained LaTeX commands like `\alpha`, `\omega`, etc. The width was calculated based on the full LaTeX command strings (e.g., 6 characters for `\alpha`) while the actual rendered text used single Unicode characters (e.g., 1 character for `α`).

This was particularly noticeable in the unicode_demo example where labels like:
- `\alpha damped: sin(\omega t)e^{-\lambda\tau}` 

Were being measured with all the LaTeX markup included, resulting in boxes much wider than needed.

## Solution
Modified `measure_label_dimensions` in `fortplot_legend_layout.f90` to:
1. Process LaTeX to Unicode conversion first using `process_latex_in_text`
2. Calculate text width using the converted text

This ensures the box width matches the actual rendered text content.

## Changes
- Process LaTeX commands to Unicode before width calculation
- Both text system and fallback paths now use processed text
- Removed duplicate LaTeX processing in fallback path

## Test Results
- [x] Tested with unicode_demo - legend box now fits text properly
- [x] All existing examples work correctly
- [x] No regression in legend rendering

## Before/After
**Before**: Legend box extended far to the right of the actual text
**After**: Legend box properly sized to fit the rendered Unicode text