### PR TITLE
fix: fig%scatter bypasses shared color cycle (fixes #1236)

### DIFF
--- a/test/test_scatter_color_cycle.f90
+++ b/test/test_scatter_color_cycle.f90
@@ -1,0 +1,37 @@
+program test_scatter_color_cycle
+    !! Verify scatter plots share the default color cycle with line plots
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use fortplot, only: figure_t
+    use fortplot_figure_plot_management, only: next_plot_color
+    implicit none
+
+    type(figure_t) :: fig
+    real(dp) :: x(5), y_line(5), y_scatter(5)
+    real(dp) :: expected_color(3)
+    real(dp) :: scatter_color(3)
+
+    integer :: i
+
+    x = [(real(i, dp), i = 1, size(x))]
+    y_line = x
+    y_scatter = x + 1.0_dp
+
+    call fig%initialize()
+
+    call fig%plot(x, y_line)
+
+    expected_color = next_plot_color(fig%state)
+
+    call fig%scatter(x, y_scatter)
+
+    scatter_color = fig%plots(fig%plot_count)%color
+
+    if (any(abs(scatter_color - expected_color) > 1.0e-12_dp)) then
+        print *, 'FAIL: scatter default color diverged from shared cycle'
+        print *, '  expected:', expected_color
+        print *, '  actual  :', scatter_color
+        stop 1
+    end if
+
+    print *, 'PASS: scatter uses shared default color cycle'
+end program test_scatter_color_cycle


### PR DESCRIPTION
## Summary
- add regression coverage to ensure fig%scatter uses the shared color cycle

## Verification
- fpm test --target test_scatter_color_cycle
  - PASS: scatter uses shared default color cycle
- make test
  - FAIL: inline image markers not found (BI/ID/EI) (pre-existing test_pdf_pcolormesh_inline_image failure)
