### PR TITLE
fix: orange markers not visible in https://lazy-fortran.github.io/for (fixes #1242)

### DIFF
--- a/src/backends/vector/fortplot_pdf_markers.f90
+++ b/src/backends/vector/fortplot_pdf_markers.f90
@@ -38,7 +38,7 @@ contains
             call draw_pdf_circle_with_outline(stream_writer, pdf_x, pdf_y, size)
         case('s', 'square')
             call draw_pdf_square_with_outline(stream_writer, pdf_x, pdf_y, size)
-        case('d', 'diamond')
+        case('D', 'd', 'diamond')
             call draw_pdf_diamond_with_outline(stream_writer, pdf_x, pdf_y, size)
         case('x', 'cross')
             call draw_pdf_x_marker(stream_writer, pdf_x, pdf_y, size)


### PR DESCRIPTION
## Summary
- include uppercase `D` when dispatching PDF diamond markers so scatter plots render the third dataset
- regenerated marker demo locally to ensure marker colors now appear in PDF/PDF→PNG conversions

## Verification
- make test # fails: inline image markers not found (BI/ID/EI); test_pdf_pcolormesh_inline_image (pre-existing)
- make verify-artifacts
- pdftoppm -png output/example/fortran/marker_demo/marker_colors.pdf output/example/fortran/marker_demo/marker_colors_pdf
- magick convert output/example/fortran/marker_demo/marker_colors_pdf-1.png -format %c -depth 8 -colors 1024 histogram:info:- | rg "D55E00" # 571: (213,94,0) #D55E00
