### PR TITLE
fix: feat: align figure_t naming with pyplot-fortran (fixes #1251)

### DIFF
--- a/doc/design/figure_management.md
+++ b/doc/design/figure_management.md
@@ -7,6 +7,16 @@ title: Figure Management Design
 
 This document describes the matplotlib-compatible figure management system in fortplot, covering figure creation, sizing, layout management, and state handling. The implementation follows matplotlib's Figure class architecture and pyplot interface patterns to ensure familiar behavior and API compatibility.
 
+### API Naming Alignment (2025-09)
+
+The object-oriented `figure_t` API now mirrors the long-standing naming scheme
+used by `pyplot-fortran`. Newer helpers such as image, pie, polar, step, stem,
+and fill operations are exposed as `add_*` procedures on `figure_t`, while the
+stateful facade continues to provide matplotlib-style names like `imshow` and
+`fill_between`. Update any OO call sites to use `add_imshow`, `add_pie`,
+`add_polar`, `add_step`, `add_stem`, `add_fill`, and `add_fill_between` to stay
+source-compatible with both projects.
+
 ## Problem Statement
 
 The current figure management implementation has several limitations:

--- a/src/figures/core/fortplot_figure_core_main.f90
+++ b/src/figures/core/fortplot_figure_core_main.f90
@@ -98,13 +98,13 @@ module fortplot_figure_core
         procedure :: hist
         procedure :: boxplot
         procedure :: scatter
-        procedure :: imshow
-        procedure :: pie
-        procedure :: polar
-        procedure :: step
-        procedure :: stem
-        procedure :: fill
-        procedure :: fill_between
+        procedure :: add_imshow
+        procedure :: add_pie
+        procedure :: add_polar
+        procedure :: add_step
+        procedure :: add_stem
+        procedure :: add_fill
+        procedure :: add_fill_between
         procedure :: twinx
         procedure :: twiny
         ! Subplot methods
@@ -445,8 +445,8 @@ contains
                          show_colorbar, default_color)
     end subroutine scatter
 
-    subroutine imshow(self, z, cmap, alpha, vmin, vmax, origin, extent, &
-                      interpolation, aspect)
+    subroutine add_imshow(self, z, cmap, alpha, vmin, vmax, origin, extent, &
+                          interpolation, aspect)
         !! Display 2D array as an image using the pcolormesh backend
         class(figure_t), intent(inout) :: self
         real(wp), intent(in) :: z(:,:)
@@ -530,9 +530,9 @@ contains
         end if
 
         deallocate(x_edges, y_edges)
-    end subroutine imshow
+    end subroutine add_imshow
 
-    subroutine polar(self, theta, r, fmt, label, linestyle, marker, color)
+    subroutine add_polar(self, theta, r, fmt, label, linestyle, marker, color)
         !! Plot data provided in polar coordinates by converting to Cartesian
         class(figure_t), intent(inout) :: self
         real(wp), intent(in) :: theta(:), r(:)
@@ -566,9 +566,9 @@ contains
 
         call self%add_plot(x, y, label=label, linestyle=linestyle)
         deallocate(x, y)
-    end subroutine polar
+    end subroutine add_polar
 
-    subroutine step(self, x, y, where, label, linestyle, color, linewidth)
+    subroutine add_step(self, x, y, where, label, linestyle, color, linewidth)
         !! Create a stepped line plot using repeated x positions
         class(figure_t), intent(inout) :: self
         real(wp), intent(in) :: x(:), y(:)
@@ -648,9 +648,9 @@ contains
 
         call self%add_plot(x_step, y_step, label=label, linestyle=linestyle)
         deallocate(x_step, y_step)
-    end subroutine step
+    end subroutine add_step
 
-    subroutine stem(self, x, y, linefmt, markerfmt, basefmt, label, bottom)
+    subroutine add_stem(self, x, y, linefmt, markerfmt, basefmt, label, bottom)
         !! Draw vertical stems from a baseline to each data point
         class(figure_t), intent(inout) :: self
         real(wp), intent(in) :: x(:), y(:)
@@ -703,9 +703,9 @@ contains
         deallocate(xs, ys)
 
         call self%add_plot(x(1:n), y(1:n))
-    end subroutine stem
+    end subroutine add_stem
 
-    subroutine fill(self, x, y, color, alpha, label)
+    subroutine add_fill(self, x, y, color, alpha, label)
         !! Fill area between curve and baseline using fill_between helper
         class(figure_t), intent(inout) :: self
         real(wp), intent(in) :: x(:), y(:)
@@ -720,10 +720,11 @@ contains
             call log_warning('fill: transparency not implemented for current backend')
         end if
 
-        call self%fill_between(x, y1=y, label=label)
-    end subroutine fill
+        call self%add_fill_between(x, y1=y, label=label)
+    end subroutine add_fill
 
-    subroutine fill_between(self, x, y1, y2, where, color, alpha, label, interpolate)
+    subroutine add_fill_between(self, x, y1, y2, where, color, alpha, label, &
+                                interpolate)
         !! Fill area between two curves by constructing a closed polygon
         class(figure_t), intent(inout) :: self
         real(wp), intent(in) :: x(:)
@@ -791,7 +792,7 @@ contains
         call self%add_plot(x_poly, y_poly, label=label)
 
         deallocate(y1_vals, y2_vals, x_poly, y_poly)
-    end subroutine fill_between
+    end subroutine add_fill_between
 
     subroutine twinx(self)
         !! Placeholder for twin x-axis support (not yet implemented)
@@ -805,7 +806,7 @@ contains
         call log_warning('twiny: dual axis plots not yet implemented')
     end subroutine twiny
 
-    subroutine pie(self, values, labels, colors, explode, autopct, startangle)
+    subroutine add_pie(self, values, labels, colors, explode, autopct, startangle)
         !! Draw a simple pie chart using line segments for wedges
         class(figure_t), intent(inout) :: self
         real(wp), intent(in) :: values(:)
@@ -879,7 +880,7 @@ contains
             deallocate(x_pts, y_pts)
             angle_start = angle_start + angle_span
         end do
-    end subroutine pie
+    end subroutine add_pie
 
     !! SUBPLOT OPERATIONS - Delegated to management module
     

--- a/src/interfaces/fortplot_matplotlib_plots_new.f90
+++ b/src/interfaces/fortplot_matplotlib_plots_new.f90
@@ -25,9 +25,9 @@ contains
         real(wp), intent(in), optional :: extent(4)
 
         call ensure_fig_init()
-        call fig%imshow(z, cmap=cmap, alpha=alpha, vmin=vmin, vmax=vmax, &
-                        origin=origin, extent=extent, interpolation=interpolation, &
-                        aspect=aspect)
+        call fig%add_imshow(z, cmap=cmap, alpha=alpha, vmin=vmin, vmax=vmax, &
+                            origin=origin, extent=extent, interpolation=interpolation, &
+                            aspect=aspect)
     end subroutine imshow
 
     subroutine pie(values, labels, colors, explode, autopct, startangle)
@@ -40,8 +40,8 @@ contains
         real(wp), intent(in), optional :: startangle
 
         call ensure_fig_init()
-        call fig%pie(values, labels=labels, colors=colors, explode=explode, &
-                     autopct=autopct, startangle=startangle)
+        call fig%add_pie(values, labels=labels, colors=colors, explode=explode, &
+                         autopct=autopct, startangle=startangle)
     end subroutine pie
 
     subroutine polar(theta, r, fmt, label, linestyle, marker, color)
@@ -51,8 +51,8 @@ contains
         character(len=*), intent(in), optional :: linestyle, marker, color
 
         call ensure_fig_init()
-        call fig%polar(theta, r, fmt=fmt, label=label, linestyle=linestyle, &
-                       marker=marker, color=color)
+        call fig%add_polar(theta, r, fmt=fmt, label=label, linestyle=linestyle, &
+                           marker=marker, color=color)
     end subroutine polar
 
     subroutine step(x, y, where, label, linestyle, color, linewidth)
@@ -63,8 +63,8 @@ contains
         real(wp), intent(in), optional :: linewidth
 
         call ensure_fig_init()
-        call fig%step(x, y, where=where, label=label, linestyle=linestyle, &
-                      color=color, linewidth=linewidth)
+        call fig%add_step(x, y, where=where, label=label, linestyle=linestyle, &
+                          color=color, linewidth=linewidth)
     end subroutine step
 
     subroutine stem(x, y, linefmt, markerfmt, basefmt, label, bottom)
@@ -75,8 +75,8 @@ contains
         real(wp), intent(in), optional :: bottom
 
         call ensure_fig_init()
-        call fig%stem(x, y, linefmt=linefmt, markerfmt=markerfmt, &
-                      basefmt=basefmt, label=label, bottom=bottom)
+        call fig%add_stem(x, y, linefmt=linefmt, markerfmt=markerfmt, &
+                          basefmt=basefmt, label=label, bottom=bottom)
     end subroutine stem
 
     subroutine fill(x, y, color, alpha, label)
@@ -87,7 +87,7 @@ contains
         character(len=*), intent(in), optional :: label
 
         call ensure_fig_init()
-        call fig%fill(x, y, color=color, alpha=alpha, label=label)
+        call fig%add_fill(x, y, color=color, alpha=alpha, label=label)
     end subroutine fill
 
     subroutine fill_between(x, y1, y2, where, color, alpha, label, interpolate)
@@ -101,8 +101,8 @@ contains
         logical, intent(in), optional :: interpolate
 
         call ensure_fig_init()
-        call fig%fill_between(x, y1=y1, y2=y2, where=where, color=color, &
-                              alpha=alpha, label=label, interpolate=interpolate)
+        call fig%add_fill_between(x, y1=y1, y2=y2, where=where, color=color, &
+                                  alpha=alpha, label=label, interpolate=interpolate)
     end subroutine fill_between
 
     subroutine twinx()

--- a/test/test_matplotlib_new_functions_oo.f90
+++ b/test/test_matplotlib_new_functions_oo.f90
@@ -21,15 +21,15 @@ program test_matplotlib_new_functions_oo
                       cos(real(j, real64) / 5.0_real64)
         end do
     end do
-    call fig%imshow(z)
-    call fig%set_title('OO imshow() test - 2D heatmap')
+    call fig%add_imshow(z)
+    call fig%set_title('OO add_imshow() test - 2D heatmap')
     call fig%savefig('test_imshow_oo.png')
     call fig%clear()
 
     allocate(values(5))
     values = [30.0_real64, 25.0_real64, 20.0_real64, 15.0_real64, 10.0_real64]
-    call fig%pie(values)
-    call fig%set_title('OO pie() test - Pie chart')
+    call fig%add_pie(values)
+    call fig%set_title('OO add_pie() test - Pie chart')
     call fig%savefig('test_pie_oo.png')
     call fig%clear()
 
@@ -38,8 +38,8 @@ program test_matplotlib_new_functions_oo
         theta(i) = 2.0_real64 * 3.14159_real64 * real(i - 1, real64) / 99.0_real64
         r(i) = 1.0_real64 + 0.5_real64 * sin(5.0_real64 * theta(i))
     end do
-    call fig%polar(theta, r)
-    call fig%set_title('OO polar() test - Polar plot')
+    call fig%add_polar(theta, r)
+    call fig%set_title('OO add_polar() test - Polar plot')
     call fig%savefig('test_polar_oo.png')
     call fig%clear()
 
@@ -48,18 +48,18 @@ program test_matplotlib_new_functions_oo
         x(i) = real(i, real64)
         y(i) = sin(real(i, real64) / 3.0_real64)
     end do
-    call fig%step(x, y)
-    call fig%set_title('OO step() test - Step plot')
+    call fig%add_step(x, y)
+    call fig%set_title('OO add_step() test - Step plot')
     call fig%savefig('test_step_oo.png')
     call fig%clear()
 
-    call fig%stem(x, y)
-    call fig%set_title('OO stem() test - Stem plot')
+    call fig%add_stem(x, y)
+    call fig%set_title('OO add_stem() test - Stem plot')
     call fig%savefig('test_stem_oo.png')
     call fig%clear()
 
-    call fig%fill(x, y)
-    call fig%set_title('OO fill() test - Area under curve')
+    call fig%add_fill(x, y)
+    call fig%set_title('OO add_fill() test - Area under curve')
     call fig%savefig('test_fill_oo.png')
     call fig%clear()
 
@@ -69,12 +69,12 @@ program test_matplotlib_new_functions_oo
         x(i) = real(i - 25, real64) / 5.0_real64
         y(i) = x(i)**2
     end do
-    call fig%fill_between(x, y1=y, y2=y * 0.5_real64)
-    call fig%set_title('OO fill_between() test - Area between curves')
+    call fig%add_fill_between(x, y1=y, y2=y * 0.5_real64)
+    call fig%set_title('OO add_fill_between() test - Area between curves')
     call fig%savefig('test_fill_between_oo.png')
     call fig%clear()
 
-    call fig%step(x, y)
+    call fig%add_step(x, y)
     call fig%twinx()
     call fig%twiny()
     call fig%set_title('OO twin axis placeholder test')


### PR DESCRIPTION
Summary:
- switch the OO figure_t helpers to add_* names to stay source-compatible with pyplot-fortran
- update stateful wrappers, OO regression test, and docs to reflect the renamed entry points

Verification:
- make test
