### PR TITLE
fix: harmonize OO argument ordering (fixes #1252)

### DIFF
--- a/src/figures/core/fortplot_figure_core_main.f90
+++ b/src/figures/core/fortplot_figure_core_main.f90
@@ -445,11 +445,12 @@ contains
                          show_colorbar, default_color)
     end subroutine scatter
 
-    subroutine add_imshow(self, z, cmap, alpha, vmin, vmax, origin, extent, &
-                          interpolation, aspect)
+    subroutine add_imshow(self, z, xlim, ylim, cmap, alpha, vmin, vmax, origin, &
+                          extent, interpolation, aspect)
         !! Display 2D array as an image using the pcolormesh backend
         class(figure_t), intent(inout) :: self
         real(wp), intent(in) :: z(:,:)
+        real(wp), intent(in), optional :: xlim(2), ylim(2)
         character(len=*), intent(in), optional :: cmap, origin, interpolation, aspect
         real(wp), intent(in), optional :: alpha, vmin, vmax
         real(wp), intent(in), optional :: extent(4)
@@ -475,6 +476,18 @@ contains
             end if
             x0 = extent(1); x1 = extent(2)
             y0 = extent(3); y1 = extent(4)
+            if (present(xlim) .or. present(ylim)) then
+                call log_warning('imshow: ignoring xlim/ylim because extent is set')
+            end if
+        else
+            if (present(xlim)) then
+                x0 = xlim(1)
+                x1 = xlim(2)
+            end if
+            if (present(ylim)) then
+                y0 = ylim(1)
+                y1 = ylim(2)
+            end if
         end if
 
         allocate(x_edges(nx+1), y_edges(ny+1))
@@ -532,11 +545,11 @@ contains
         deallocate(x_edges, y_edges)
     end subroutine add_imshow
 
-    subroutine add_polar(self, theta, r, fmt, label, linestyle, marker, color)
+    subroutine add_polar(self, theta, r, label, fmt, linestyle, marker, color)
         !! Plot data provided in polar coordinates by converting to Cartesian
         class(figure_t), intent(inout) :: self
         real(wp), intent(in) :: theta(:), r(:)
-        character(len=*), intent(in), optional :: fmt, label
+        character(len=*), intent(in), optional :: label, fmt
         character(len=*), intent(in), optional :: linestyle, marker, color
 
         integer :: n, i
@@ -568,11 +581,11 @@ contains
         deallocate(x, y)
     end subroutine add_polar
 
-    subroutine add_step(self, x, y, where, label, linestyle, color, linewidth)
+    subroutine add_step(self, x, y, label, where, linestyle, color, linewidth)
         !! Create a stepped line plot using repeated x positions
         class(figure_t), intent(inout) :: self
         real(wp), intent(in) :: x(:), y(:)
-        character(len=*), intent(in), optional :: where, label, linestyle, color
+        character(len=*), intent(in), optional :: label, where, linestyle, color
         real(wp), intent(in), optional :: linewidth
 
         integer :: n, i, n_points
@@ -650,11 +663,11 @@ contains
         deallocate(x_step, y_step)
     end subroutine add_step
 
-    subroutine add_stem(self, x, y, linefmt, markerfmt, basefmt, label, bottom)
+    subroutine add_stem(self, x, y, label, linefmt, markerfmt, basefmt, bottom)
         !! Draw vertical stems from a baseline to each data point
         class(figure_t), intent(inout) :: self
         real(wp), intent(in) :: x(:), y(:)
-        character(len=*), intent(in), optional :: linefmt, markerfmt, basefmt, label
+        character(len=*), intent(in), optional :: label, linefmt, markerfmt, basefmt
         real(wp), intent(in), optional :: bottom
 
         integer :: n, i
@@ -705,13 +718,13 @@ contains
         call self%add_plot(x(1:n), y(1:n))
     end subroutine add_stem
 
-    subroutine add_fill(self, x, y, color, alpha, label)
+    subroutine add_fill(self, x, y, label, color, alpha)
         !! Fill area between curve and baseline using fill_between helper
         class(figure_t), intent(inout) :: self
         real(wp), intent(in) :: x(:), y(:)
+        character(len=*), intent(in), optional :: label
         character(len=*), intent(in), optional :: color
         real(wp), intent(in), optional :: alpha
-        character(len=*), intent(in), optional :: label
 
         if (present(color)) then
             call log_warning('fill: color strings not yet supported; using default')
@@ -723,16 +736,16 @@ contains
         call self%add_fill_between(x, y1=y, label=label)
     end subroutine add_fill
 
-    subroutine add_fill_between(self, x, y1, y2, where, color, alpha, label, &
+    subroutine add_fill_between(self, x, y1, y2, label, color, alpha, where, &
                                 interpolate)
         !! Fill area between two curves by constructing a closed polygon
         class(figure_t), intent(inout) :: self
         real(wp), intent(in) :: x(:)
         real(wp), intent(in), optional :: y1(:), y2(:)
-        logical, intent(in), optional :: where(:)
+        character(len=*), intent(in), optional :: label
         character(len=*), intent(in), optional :: color
         real(wp), intent(in), optional :: alpha
-        character(len=*), intent(in), optional :: label
+        logical, intent(in), optional :: where(:)
         logical, intent(in), optional :: interpolate
 
         integer :: n, i
@@ -806,15 +819,15 @@ contains
         call log_warning('twiny: dual axis plots not yet implemented')
     end subroutine twiny
 
-    subroutine add_pie(self, values, labels, colors, explode, autopct, startangle)
+    subroutine add_pie(self, values, labels, autopct, startangle, colors, explode)
         !! Draw a simple pie chart using line segments for wedges
         class(figure_t), intent(inout) :: self
         real(wp), intent(in) :: values(:)
         character(len=*), intent(in), optional :: labels(:)
-        character(len=*), intent(in), optional :: colors(:)
-        real(wp), intent(in), optional :: explode(:)
         character(len=*), intent(in), optional :: autopct
         real(wp), intent(in), optional :: startangle
+        character(len=*), intent(in), optional :: colors(:)
+        real(wp), intent(in), optional :: explode(:)
 
         integer :: n, i, seg_count, j
         real(wp) :: total, angle_start, angle_span, radius

--- a/src/interfaces/fortplot_matplotlib_plots_new.f90
+++ b/src/interfaces/fortplot_matplotlib_plots_new.f90
@@ -40,8 +40,8 @@ contains
         real(wp), intent(in), optional :: startangle
 
         call ensure_fig_init()
-        call fig%add_pie(values, labels=labels, colors=colors, explode=explode, &
-                         autopct=autopct, startangle=startangle)
+        call fig%add_pie(values, labels=labels, autopct=autopct, startangle=startangle, &
+                         colors=colors, explode=explode)
     end subroutine pie
 
     subroutine polar(theta, r, fmt, label, linestyle, marker, color)
@@ -51,7 +51,7 @@ contains
         character(len=*), intent(in), optional :: linestyle, marker, color
 
         call ensure_fig_init()
-        call fig%add_polar(theta, r, fmt=fmt, label=label, linestyle=linestyle, &
+        call fig%add_polar(theta, r, label=label, fmt=fmt, linestyle=linestyle, &
                            marker=marker, color=color)
     end subroutine polar
 
@@ -63,7 +63,7 @@ contains
         real(wp), intent(in), optional :: linewidth
 
         call ensure_fig_init()
-        call fig%add_step(x, y, where=where, label=label, linestyle=linestyle, &
+        call fig%add_step(x, y, label=label, where=where, linestyle=linestyle, &
                           color=color, linewidth=linewidth)
     end subroutine step
 
@@ -75,8 +75,8 @@ contains
         real(wp), intent(in), optional :: bottom
 
         call ensure_fig_init()
-        call fig%add_stem(x, y, linefmt=linefmt, markerfmt=markerfmt, &
-                          basefmt=basefmt, label=label, bottom=bottom)
+        call fig%add_stem(x, y, label=label, linefmt=linefmt, markerfmt=markerfmt, &
+                          basefmt=basefmt, bottom=bottom)
     end subroutine stem
 
     subroutine fill(x, y, color, alpha, label)
@@ -87,7 +87,7 @@ contains
         character(len=*), intent(in), optional :: label
 
         call ensure_fig_init()
-        call fig%add_fill(x, y, color=color, alpha=alpha, label=label)
+        call fig%add_fill(x, y, label=label, color=color, alpha=alpha)
     end subroutine fill
 
     subroutine fill_between(x, y1, y2, where, color, alpha, label, interpolate)
@@ -101,8 +101,8 @@ contains
         logical, intent(in), optional :: interpolate
 
         call ensure_fig_init()
-        call fig%add_fill_between(x, y1=y1, y2=y2, where=where, color=color, &
-                                  alpha=alpha, label=label, interpolate=interpolate)
+        call fig%add_fill_between(x, y1=y1, y2=y2, label=label, color=color, &
+                                  alpha=alpha, where=where, interpolate=interpolate)
     end subroutine fill_between
 
     subroutine twinx()

--- a/test/test_legacy_positional_order.f90
+++ b/test/test_legacy_positional_order.f90
@@ -1,0 +1,170 @@
+program test_legacy_positional_order
+    !! Ensure figure_t add_* helpers accept legacy pyplot positional ordering
+    use fortplot, only: figure_t
+    use fortplot_figure_core, only: plot_data_t
+    use iso_fortran_env, only: wp => real64
+    implicit none
+
+    call test_step()
+    call test_stem()
+    call test_fill()
+    call test_fill_between()
+    call test_polar()
+    call test_pie()
+    call test_imshow()
+
+    print *, '✓ Legacy positional ordering works for figure_t add_* helpers'
+
+contains
+
+    subroutine test_step()
+        type(figure_t) :: fig
+        type(plot_data_t), pointer :: plots(:)
+        real(wp) :: x(5), y(5)
+        integer :: n, i
+
+        call fig%initialize()
+        x = [(real(i, wp), i = 1, size(x))]
+        y = sin(x)
+
+        call fig%add_step(x, y, 'legacy-step')
+        call fetch_plots(fig, plots, n)
+        call assert_label(plots(n), 'legacy-step')
+    end subroutine test_step
+
+    subroutine test_stem()
+        type(figure_t) :: fig
+        type(plot_data_t), pointer :: plots(:)
+        real(wp) :: x(4), y(4)
+        integer :: n, i
+
+        call fig%initialize()
+        x = [(real(i, wp), i = 1, size(x))]
+        y = x * 0.5_wp
+
+        call fig%add_stem(x, y, 'legacy-stem')
+        call fetch_plots(fig, plots, n)
+        call assert_any_label(plots, n, 'legacy-stem')
+    end subroutine test_stem
+
+    subroutine test_fill()
+        type(figure_t) :: fig
+        type(plot_data_t), pointer :: plots(:)
+        real(wp) :: x(6), y(6)
+        integer :: n, i
+
+        call fig%initialize()
+        x = [(real(i, wp), i = 1, size(x))]
+        y = sin(x)
+
+        call fig%add_fill(x, y, 'legacy-fill')
+        call fetch_plots(fig, plots, n)
+        call assert_any_label(plots, n, 'legacy-fill')
+    end subroutine test_fill
+
+    subroutine test_fill_between()
+        type(figure_t) :: fig
+        type(plot_data_t), pointer :: plots(:)
+        real(wp) :: x(6), y1(6), y2(6)
+        integer :: n, i
+
+        call fig%initialize()
+        x = [(real(i, wp), i = 1, size(x))]
+        y1 = sin(x)
+        y2 = y1 * 0.5_wp
+
+        call fig%add_fill_between(x, y1, y2, 'legacy-fill-between')
+        call fetch_plots(fig, plots, n)
+        call assert_any_label(plots, n, 'legacy-fill-between')
+    end subroutine test_fill_between
+
+    subroutine test_polar()
+        type(figure_t) :: fig
+        type(plot_data_t), pointer :: plots(:)
+        real(wp) :: theta(5), r(5)
+        integer :: n, i
+
+        call fig%initialize()
+        theta = [(2.0_wp * acos(-1.0_wp) * real(i - 1, wp) / real(size(theta), wp), &
+                 i = 1, size(theta))]
+        r = 1.0_wp + 0.1_wp * [(real(i, wp), i = 1, size(r))]
+
+        call fig%add_polar(theta, r, 'legacy-polar')
+        call fetch_plots(fig, plots, n)
+        call assert_label(plots(n), 'legacy-polar')
+    end subroutine test_polar
+
+    subroutine test_pie()
+        type(figure_t) :: fig
+        type(plot_data_t), pointer :: plots(:)
+        real(wp) :: values(3)
+        integer :: n
+
+        call fig%initialize()
+        values = [0.5_wp, 0.3_wp, 0.2_wp]
+
+        call fig%add_pie(values, ['A', 'B', 'C'], '%.1f', 45.0_wp)
+        call fetch_plots(fig, plots, n)
+        call assert_any_label(plots, n, 'A')
+    end subroutine test_pie
+
+    subroutine test_imshow()
+        type(figure_t) :: fig
+        real(wp) :: z(4, 4)
+        integer :: i
+
+        call fig%initialize()
+        z = reshape([(real(i, wp), i = 1, size(z))], shape(z))
+
+        call fig%add_imshow(z, xlim=[-1.0_wp, 1.0_wp], ylim=[0.0_wp, 2.0_wp])
+        if (fig%get_plot_count() <= 0) then
+            error stop 'test_imshow: expected plot after legacy xlim/ylim call'
+        end if
+    end subroutine test_imshow
+
+    subroutine fetch_plots(fig, plots, count)
+        class(figure_t), intent(inout) :: fig
+        type(plot_data_t), pointer :: plots(:)
+        integer, intent(out) :: count
+
+        count = fig%get_plot_count()
+        if (count <= 0) then
+            error stop 'fetch_plots: expected at least one plot'
+        end if
+        plots => fig%get_plots()
+        if (.not. associated(plots)) then
+            error stop 'fetch_plots: plots pointer not associated'
+        end if
+    end subroutine fetch_plots
+
+    subroutine assert_label(plot, expected)
+        type(plot_data_t), intent(in) :: plot
+        character(len=*), intent(in) :: expected
+        character(len=:), allocatable :: label_value
+
+        if (allocated(plot%label)) then
+            label_value = trim(plot%label)
+        else
+            label_value = ''
+        end if
+
+        if (trim(expected) /= trim(label_value)) then
+            error stop 'assert_label: label mismatch'
+        end if
+    end subroutine assert_label
+
+    subroutine assert_any_label(plots, count, expected)
+        type(plot_data_t), intent(in) :: plots(:)
+        integer, intent(in) :: count
+        character(len=*), intent(in) :: expected
+        integer :: i
+
+        do i = 1, count
+            if (allocated(plots(i)%label)) then
+                if (trim(plots(i)%label) == trim(expected)) return
+            end if
+        end do
+        error stop 'assert_any_label: expected label not found'
+    end subroutine assert_any_label
+
+end program test_legacy_positional_order


### PR DESCRIPTION
## Summary
- align figure_t add_* helpers with legacy pyplot ordering while keeping matplotlib keywords
- pass legacy synonyms through the stateful wrappers and accept xlim/ylim for add_imshow
- add regression test covering positional calls against the OO API

## Verification
- make test
