### PR TITLE
fix: docs: document OO/stateful compatibility expectations (fixes #1253)

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -54,6 +54,7 @@ Complete working examples with source code and generated plots.
 ### Development
 - [Testing Guide](testing_guide.md) - Testing procedures and warning control
 - [Module Architecture](module_architecture.md) - Code organization and refactoring
+- [OO vs Stateful Compatibility](oo_stateful_compatibility.md) - Migration and argument parity
 - [Security](security.md) - Security features and compliance
 
 ### Platform-Specific

--- a/doc/oo_stateful_compatibility.md
+++ b/doc/oo_stateful_compatibility.md
@@ -1,0 +1,78 @@
+title: OO vs Stateful Compatibility
+---
+
+# OO vs Stateful Compatibility Guide
+
+fortplot intentionally ships two user-facing interfaces:
+
+- **Stateful (matplotlib-style)** — thin wrappers that mirror
+  `pyplot-fortran` and maintain positional-call compatibility with
+  `matplotlib.pyplot`.
+- **Object-oriented (`figure_t`)** — explicit figure instances that provide
+  richer composition APIs while sharing the same plotting engine.
+
+This guide documents how the two styles relate, what naming differences exist,
+and which keyword arguments must be kept in sync when adding new helpers.
+
+## API Mapping
+
+| Stateful helper | OO helper | Notes |
+| --------------- | --------- | ----- |
+| `plot`          | `figure_t%add_plot`          | Primary line plotting entry point |
+| `scatter`       | `figure_t%add_scatter`       | 3D scatter available via optional `z` array |
+| `step`          | `figure_t%add_step`          | Supports legacy `where` positional argument |
+| `stem`          | `figure_t%add_stem`          | Mirrors `linefmt`, `markerfmt`, `basefmt` order |
+| `fill`          | `figure_t%add_fill`          | Delegates to `add_fill_between` with baseline |
+| `fill_between`  | `figure_t%add_fill_between`  | Preserves mask/interpolate keyword semantics |
+| `polar`         | `figure_t%add_polar`         | `fmt` positional arg kept for pyplot parity |
+| `pie`           | `figure_t%add_pie`           | Uses identical ordering for labels/colors |
+| `imshow`        | `figure_t%add_imshow`        | Shares `cmap`, `origin`, `extent` permutations |
+| `pcolormesh`    | `figure_t%add_pcolormesh`    | Column-major data layout shared |
+| `hist`/`histogram` | `figure_t%hist`           | Density/bin handling identical |
+| `boxplot`       | `figure_t%boxplot`           | Optional keyword set aligned |
+| `bar`/`barh`    | `figure_t%add_bar` variants | Width/align defaults tracked together |
+
+When introducing a new stateful helper, first add the corresponding
+`figure_t%...` routine. Then implement a thin wrapper that calls
+`ensure_fig_init()` and forwards arguments without reordering or renaming.
+
+## Argument Ordering Expectations
+
+The stateful façade must continue to accept legacy positional calls copied from
+`pyplot-fortran`. Key rules:
+
+- **No reordering** — keep optional arguments in the same order as the OO
+  helper. Add new optional arguments to the **end** of both signatures.
+- **Keyword parity** — optional keywords supported by the OO API should remain
+  available on the stateful wrapper. Unsupported keywords must raise a clear
+  warning while leaving existing behavior unchanged.
+- **Default consistency** — both paths should derive defaults from a single
+  implementation. Avoid duplicating default values in wrappers.
+
+Examples of valid positional calls that must continue compiling:
+
+```fortran
+call step(x, y, 'pre', 'sample', '--', 'blue', 2.0_wp)
+call stem(x, y, 'r-', 'ro', 'g-', 'baseline', 0.0_wp)
+call fill_between(x, y1, y2, mask, 'orange', 0.4_wp, 'band', .false.)
+call imshow(z, 'viridis', 0.5_wp, 0.0_wp, 1.0_wp, 'lower', extent, &
+            'nearest', 'equal')
+```
+
+## Contributor Checklist
+
+Before merging changes that touch plotting helpers:
+
+1. Update both the stateful wrapper and the `figure_t` method together.
+2. Verify legacy positional calls compile by running:
+   ```bash
+   make test ARGS="--target test_pyplot_legacy_order"
+   make test ARGS="--target test_legacy_positional_order"
+   ```
+3. Document any intentional keyword deviations in commit messages and module
+   comments.
+4. If a keyword is unsupported, emit a warning (not a silent no-op) in both
+   code paths.
+
+Following this checklist keeps new helpers compatible with downstream users who
+ported code from `pyplot-fortran` or reference matplotlib snippets.

--- a/doc/testing_guide.md
+++ b/doc/testing_guide.md
@@ -107,6 +107,21 @@ make test ARGS="--target test_contour_filled_backend_rendering"  # Was >3min, no
 
 See [Windows CI Performance Guide](windows_ci_performance.md) for detailed optimization documentation.
 
+## OO/Stateful Compatibility Checks
+
+Run these guards after introducing or modifying plotting helpers so that OO and
+stateful APIs stay aligned with `pyplot-fortran` positional expectations.
+
+```bash
+make test ARGS="--target test_pyplot_legacy_order"
+make test ARGS="--target test_legacy_positional_order"
+```
+
+**Passing criteria**
+- Legacy positional calls compile without keyword reordering.
+- Global pyplot façade and `figure_t` helpers report matching plot counts.
+
+
 ## General Testing
 
 ### All Tests

--- a/test/test_pyplot_legacy_order.f90
+++ b/test/test_pyplot_legacy_order.f90
@@ -1,0 +1,178 @@
+program test_pyplot_legacy_order
+    !! Ensure stateful pyplot wrappers preserve legacy positional ordering
+    use fortplot, only: figure, get_global_figure, step, stem, fill
+    use fortplot, only: fill_between, polar, pie, imshow
+    use fortplot_figure_core, only: figure_t, plot_data_t
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    implicit none
+
+    call test_step()
+    call test_stem()
+    call test_fill()
+    call test_fill_between()
+    call test_polar()
+    call test_pie()
+    call test_imshow()
+
+    print *, '✓ Pyplot positional wrappers remain OO-compatible'
+
+contains
+
+    subroutine test_step()
+        real(wp) :: x(4), y(4)
+        class(figure_t), pointer :: fig
+        integer :: i
+
+        call reset_global(fig)
+        do i = 1, size(x)
+            x(i) = real(i, wp)
+            y(i) = sin(real(i, wp))
+        end do
+
+        call step(x, y, 'pre', 'legacy-step', '--', 'blue', 2.0_wp)
+        call assert_label_anywhere(fig, 'legacy-step')
+    end subroutine test_step
+
+    subroutine test_stem()
+        real(wp) :: x(5), y(5)
+        class(figure_t), pointer :: fig
+        integer :: i
+
+        call reset_global(fig)
+        do i = 1, size(x)
+            x(i) = real(i - 1, wp)
+            y(i) = 0.5_wp * real(i, wp)
+        end do
+
+        call stem(x, y, 'r-', 'ro', 'g-', 'legacy-stem', 0.0_wp)
+        call assert_label_anywhere(fig, 'legacy-stem')
+    end subroutine test_stem
+
+    subroutine test_fill()
+        real(wp) :: x(6), y(6)
+        class(figure_t), pointer :: fig
+        integer :: i
+
+        call reset_global(fig)
+        do i = 1, size(x)
+            x(i) = real(i - 1, wp)
+            y(i) = 0.1_wp * real(i * i, wp)
+        end do
+
+        call fill(x, y, 'orange', 0.4_wp, 'legacy-fill')
+        call assert_label_anywhere(fig, 'legacy-fill')
+    end subroutine test_fill
+
+    subroutine test_fill_between()
+        real(wp) :: x(6), y1(6), y2(6)
+        logical :: mask(6)
+        class(figure_t), pointer :: fig
+        integer :: i
+
+        call reset_global(fig)
+        do i = 1, size(x)
+            x(i) = real(i - 1, wp)
+            y1(i) = sin(real(i, wp))
+            y2(i) = 0.5_wp * y1(i)
+        end do
+        mask = .true.
+
+        call fill_between(x, y1, y2, mask, 'green', 0.3_wp, 'legacy-band', .false.)
+        call assert_label_anywhere(fig, 'legacy-band')
+    end subroutine test_fill_between
+
+    subroutine test_polar()
+        real(wp) :: theta(5), r(5)
+        class(figure_t), pointer :: fig
+        integer :: i
+        real(wp), parameter :: PI = acos(-1.0_wp)
+
+        call reset_global(fig)
+        do i = 1, size(theta)
+            theta(i) = 2.0_wp * PI * real(i - 1, wp) / real(size(theta), wp)
+            r(i) = 1.0_wp + 0.2_wp * real(i, wp)
+        end do
+
+        call polar(theta, r, 'r-', 'legacy-polar', '--', 'o', 'red')
+        call assert_label_anywhere(fig, 'legacy-polar')
+    end subroutine test_polar
+
+    subroutine test_pie()
+        real(wp) :: values(3)
+        character(len=1) :: labels(3)
+        character(len=5) :: colors(3)
+        real(wp) :: explode(3)
+        class(figure_t), pointer :: fig
+
+        call reset_global(fig)
+        values = [0.5_wp, 0.3_wp, 0.2_wp]
+        labels = ['A', 'B', 'C']
+        colors = ['red  ', 'green', 'blue ']
+        explode = [0.0_wp, 0.1_wp, 0.0_wp]
+
+        call pie(values, labels, colors, explode, '%.1f', 45.0_wp)
+        call assert_label_anywhere(fig, 'A')
+    end subroutine test_pie
+
+    subroutine test_imshow()
+        real(wp) :: z(3, 3)
+        real(wp) :: extent_vals(4)
+        class(figure_t), pointer :: fig
+        integer :: i
+
+        call reset_global(fig)
+        z = reshape([(real(i, wp), i = 1, size(z))], shape(z))
+        extent_vals = [-1.0_wp, 1.0_wp, 0.0_wp, 2.0_wp]
+
+        call imshow(z, 'viridis', 0.5_wp, 0.0_wp, 1.0_wp, 'lower', extent_vals, &
+                    'nearest', 'equal')
+        call assert_plot_count(fig, 1)
+    end subroutine test_imshow
+
+    subroutine reset_global(fig)
+        class(figure_t), pointer :: fig
+
+        call figure()
+        fig => get_global_figure()
+        if (.not. associated(fig)) then
+            error stop 'reset_global: global figure not associated'
+        end if
+    end subroutine reset_global
+
+    subroutine assert_label_anywhere(fig, expected)
+        class(figure_t), pointer, intent(in) :: fig
+        character(len=*), intent(in) :: expected
+        type(plot_data_t), pointer :: plots(:)
+        integer :: count, i
+
+        count = fig%get_plot_count()
+        if (count <= 0) then
+            error stop 'assert_label_anywhere: expected plots to exist'
+        end if
+
+        plots => fig%get_plots()
+        if (.not. associated(plots)) then
+            error stop 'assert_label_anywhere: plots pointer not associated'
+        end if
+
+        do i = 1, count
+            if (allocated(plots(i)%label)) then
+                if (trim(plots(i)%label) == trim(expected)) return
+            end if
+        end do
+
+        error stop 'assert_label_anywhere: expected label not found'
+    end subroutine assert_label_anywhere
+
+    subroutine assert_plot_count(fig, min_expected)
+        class(figure_t), pointer, intent(in) :: fig
+        integer, intent(in) :: min_expected
+        integer :: count
+
+        count = fig%get_plot_count()
+        if (count < min_expected) then
+            error stop 'assert_plot_count: not enough plots'
+        end if
+    end subroutine assert_plot_count
+
+end program test_pyplot_legacy_order


### PR DESCRIPTION
## Summary
- document the relationship between the stateful wrappers and the OO figure API
- add an OO/stateful compatibility checklist to the testing guide and surface the new doc in the index
- add a regression test that exercises legacy positional calls through the pyplot facade

## Verification
- `make test ARGS="--target test_pyplot_legacy_order"`  
  ✓ Pyplot positional wrappers remain OO-compatible
- `make test`
