### PR TITLE
fix: label argument not needed in all plot types, examples, naming (fixes #1259)

### DIFF
--- a/doc/oo_stateful_compatibility.md
+++ b/doc/oo_stateful_compatibility.md
@@ -54,10 +54,14 @@ Examples of valid positional calls that must continue compiling:
 ```fortran
 call step(x, y, 'pre', 'sample', '--', 'blue', 2.0_wp)
 call stem(x, y, 'r-', 'ro', 'g-', 'baseline', 0.0_wp)
-call fill_between(x, y1, y2, mask, 'orange', 0.4_wp, 'band', .false.)
+call fill_between(x, y1, y2, mask, 'orange', 0.4_wp, .false.)
 call imshow(z, 'viridis', 0.5_wp, 0.0_wp, 1.0_wp, 'lower', extent, &
             'nearest', 'equal')
 ```
+
+`fill` and `fill_between` intentionally omit label keywords because shaded
+regions currently reuse the surrounding line styling. Attach legend entries to
+line plots instead of fills when highlighting areas.
 
 ## Contributor Checklist
 

--- a/example/fortran/README.md
+++ b/example/fortran/README.md
@@ -21,6 +21,7 @@ make example ARGS="example_name"
 - [marker_demo](./marker_demo/) - Marker types and scatter plots
 - [format_string_demo](./format_string_demo/) - Matplotlib-style format strings
 - [scatter_demo](./scatter_demo/) - Enhanced scatter plots with color mapping
+- [fill_between_demo](./fill_between_demo/) - Stateful and OO area fills
 
 ### Statistical and Categorical
 - [errorbar_demo](./errorbar_demo/) - Error bars for scientific data

--- a/example/fortran/fill_between_demo/README.md
+++ b/example/fortran/fill_between_demo/README.md
@@ -1,0 +1,15 @@
+# fill_between_demo
+
+Demonstrates how to create filled regions using both the stateful and object
+APIs. The program first applies `fill_between` with a mask to highlight part of
+an oscillatory curve, then uses `figure_t%add_fill_between` to shade a baseline
+response computed from an exponential envelope.
+
+## Run It
+
+```bash
+make example ARGS="fill_between_demo"
+```
+
+Generated files are written to `output/example/fortran/fill_between_demo/` in
+both PNG and ASCII formats.

--- a/example/fortran/fill_between_demo/fill_between_demo.f90
+++ b/example/fortran/fill_between_demo/fill_between_demo.f90
@@ -1,0 +1,78 @@
+program fill_between_demo
+    !! Demonstrates stateful and object-oriented fill_between usage
+    use iso_fortran_env, only: wp => real64
+    use fortplot, only: figure, plot, fill_between, xlabel, ylabel, title, legend
+    use fortplot, only: savefig_with_status, figure_t
+    use fortplot_errors, only: SUCCESS
+    implicit none
+
+    call demo_stateful()
+    call demo_object()
+
+contains
+
+    subroutine demo_stateful()
+        real(wp) :: x(200), upper(200), lower(200)
+        logical :: mask(200)
+        integer :: i, status
+        logical :: ok
+
+        do i = 1, size(x)
+            x(i) = 2.0_wp * acos(-1.0_wp) * real(i - 1, wp) / &
+                   real(size(x) - 1, wp)
+            upper(i) = sin(x(i))
+            lower(i) = 0.5_wp * sin(x(i))
+        end do
+        mask = x <= acos(-1.0_wp)
+
+        call figure()
+        call plot(x, upper, label='sin(x)')
+        call fill_between(x, upper, lower, mask)
+        call title('Stateful fill_between with mask')
+        call xlabel('angle (rad)')
+        call ylabel('amplitude')
+        call legend()
+
+        ok = .true.
+        call savefig_with_status('output/example/fortran/fill_between_demo/' // &
+                                 'stateful_fill_between.png', status)
+        if (status /= SUCCESS) ok = .false.
+        call savefig_with_status('output/example/fortran/fill_between_demo/' // &
+                                 'stateful_fill_between.txt', status)
+        if (status /= SUCCESS) ok = .false.
+        if (.not. ok) then
+            print *, 'WARNING: Failed to write stateful fill_between outputs'
+        end if
+    end subroutine demo_stateful
+
+    subroutine demo_object()
+        type(figure_t) :: fig
+        real(wp) :: x(120), profile(120)
+        integer :: i, status
+        logical :: ok
+
+        call fig%initialize()
+        do i = 1, size(x)
+            x(i) = real(i - 1, wp) / 20.0_wp
+            profile(i) = exp(-0.1_wp * x(i)) * sin(0.8_wp * x(i))
+        end do
+
+        call fig%set_title('Object API fill_between baseline')
+        call fig%set_xlabel('time')
+        call fig%set_ylabel('response')
+        call fig%add_plot(x, profile)
+        call fig%add_fill_between(x, y1=profile)
+
+        ok = .true.
+        call fig%savefig_with_status('output/example/fortran/fill_between_demo/' // &
+                                     'oo_fill_between.png', status)
+        if (status /= SUCCESS) ok = .false.
+        call fig%savefig_with_status('output/example/fortran/fill_between_demo/' // &
+                                     'oo_fill_between.txt', status)
+        if (status /= SUCCESS) ok = .false.
+        if (.not. ok) then
+            print *, 'WARNING: Failed to write OO fill_between outputs'
+        end if
+    end subroutine demo_object
+
+end program fill_between_demo

--- a/src/interfaces/fortplot_matplotlib_plot_wrappers.f90
+++ b/src/interfaces/fortplot_matplotlib_plot_wrappers.f90
@@ -134,7 +134,8 @@ contains
         real(wp), intent(in), optional :: color(3)
 
         call ensure_fig_init()
-        call fig%hist(data, bins=bins, density=density, label=label, color=color)
+        call fig%add_hist(data, bins=bins, density=density, label=label, &
+                          color=color)
     end subroutine hist
 
     subroutine histogram(data, bins, density, label, color)

--- a/src/interfaces/fortplot_matplotlib_plots_new.f90
+++ b/src/interfaces/fortplot_matplotlib_plots_new.f90
@@ -79,30 +79,28 @@ contains
                           basefmt=basefmt, bottom=bottom)
     end subroutine stem
 
-    subroutine fill(x, y, color, alpha, label)
+    subroutine fill(x, y, color, alpha)
         !! Fill the area under a curve
         real(wp), intent(in) :: x(:), y(:)
         character(len=*), intent(in), optional :: color
         real(wp), intent(in), optional :: alpha
-        character(len=*), intent(in), optional :: label
 
         call ensure_fig_init()
-        call fig%add_fill(x, y, label=label, color=color, alpha=alpha)
+        call fig%add_fill(x, y, color=color, alpha=alpha)
     end subroutine fill
 
-    subroutine fill_between(x, y1, y2, where, color, alpha, label, interpolate)
+    subroutine fill_between(x, y1, y2, where, color, alpha, interpolate)
         !! Fill the area between two curves
         real(wp), intent(in) :: x(:)
         real(wp), intent(in), optional :: y1(:), y2(:)
         logical, intent(in), optional :: where(:)
         character(len=*), intent(in), optional :: color
         real(wp), intent(in), optional :: alpha
-        character(len=*), intent(in), optional :: label
         logical, intent(in), optional :: interpolate
 
         call ensure_fig_init()
-        call fig%add_fill_between(x, y1=y1, y2=y2, label=label, color=color, &
-                                  alpha=alpha, where=where, interpolate=interpolate)
+        call fig%add_fill_between(x, y1=y1, y2=y2, color=color, alpha=alpha, &
+                                  where=where, interpolate=interpolate)
     end subroutine fill_between
 
     subroutine twinx()

--- a/test/test_figure_refactoring.f90
+++ b/test/test_figure_refactoring.f90
@@ -23,7 +23,7 @@ program test_figure_refactoring
     print *, "✓ Line plot"
     
     ! Test histogram 
-    call fig%hist(data, bins=5, label='Test Histogram')
+    call fig%add_hist(data, bins=5, label='Test Histogram')
     print *, "✓ Histogram"
     
     ! Test grid

--- a/test/test_histogram_functionality.f90
+++ b/test/test_histogram_functionality.f90
@@ -77,7 +77,7 @@ contains
         end do
         
         ! Add histogram with default 10 bins
-        call fig%hist(data)
+        call fig%add_hist(data)
         call assert_equal(real(fig%plot_count, wp), 1.0_wp, "Histogram plot count")
         
         call end_test()
@@ -98,7 +98,7 @@ contains
         end do
         
         ! Add histogram with 5 bins
-        call fig%hist(data, bins=5)
+        call fig%add_hist(data, bins=5)
         call assert_equal(real(fig%plot_count, wp), 1.0_wp, "Custom bins histogram count")
         
         call end_test()
@@ -119,7 +119,7 @@ contains
         end do
         
         ! Add histogram with density normalization
-        call fig%hist(data, density=.true.)
+        call fig%add_hist(data, density=.true.)
         call assert_equal(real(fig%plot_count, wp), 1.0_wp, "Density histogram count")
         
         call end_test()
@@ -134,7 +134,7 @@ contains
         call fig%initialize(640, 480)
         
         ! Add histogram with empty data - should handle gracefully
-        call fig%hist(data)
+        call fig%add_hist(data)
         call assert_equal(real(fig%plot_count, wp), 0.0_wp, "Empty data histogram count")
         
         call end_test()
@@ -162,7 +162,7 @@ contains
         call fig%initialize(640, 480)
         
         ! This should not crash with segmentation fault
-        call fig%hist(data, bins=0)
+        call fig%add_hist(data, bins=0)
         
         ! Verify no plot was added
         call assert_equal(real(fig%plot_count, wp), 0.0_wp, "Zero bins adds no plots")
@@ -181,7 +181,7 @@ contains
         call fig%initialize(640, 480)
         
         ! This should not crash with segmentation fault
-        call fig%hist(data, bins=-5)
+        call fig%add_hist(data, bins=-5)
         
         ! Verify no plot was added
         call assert_equal(real(fig%plot_count, wp), 0.0_wp, "Negative bins adds no plots")
@@ -200,7 +200,7 @@ contains
         call fig%initialize(640, 480)
         
         ! This should work normally
-        call fig%hist(data, bins=1)
+        call fig%add_hist(data, bins=1)
         call assert_equal(real(fig%plot_count, wp), 1.0_wp, "Valid minimal histogram")
         
         call end_test()
@@ -228,7 +228,7 @@ contains
         data = 5.0_wp
         
         call fig%initialize(600, 400)
-        call fig%hist(data, bins=10)
+        call fig%add_hist(data, bins=10)
         
         call assert_equal(real(fig%plot_count, wp), 1.0_wp, "Identical values histogram")
         call end_test()
@@ -249,7 +249,7 @@ contains
         end do
         
         call fig%initialize(600, 400)
-        call fig%hist(data, bins=50)
+        call fig%add_hist(data, bins=50)
         
         call assert_equal(real(fig%plot_count, wp), 1.0_wp, "Large dataset histogram")
         
@@ -292,7 +292,7 @@ contains
         
         call cpu_time(start_time)
         call fig%initialize(600, 400)  ! Smaller for speed
-        call fig%hist(large_data, bins=50)
+        call fig%add_hist(large_data, bins=50)
         call fig%set_title('Large Dataset (10K points)')
         
         filename = 'test/output/histogram_large.png'
@@ -325,14 +325,14 @@ contains
         
         ! Test with many bins
         call fig%initialize(600, 400)
-        call fig%hist(data, bins=100)  ! Reduced from 500 for speed
+        call fig%add_hist(data, bins=100)  ! Reduced from 500 for speed
         call fig%set_title('Many Bins Test')
         filename = 'test/output/histogram_many_bins.png'
         call fig%savefig(filename)
         
         ! Test with minimal bins
         call fig%initialize(600, 400)
-        call fig%hist(data, bins=1)
+        call fig%add_hist(data, bins=1)
         call fig%set_title('Single Bin Test')
         filename = 'test/output/histogram_one_bin.png'
         call fig%savefig(filename)
@@ -342,7 +342,7 @@ contains
         data(501:1000) = 1.0e6_wp
         
         call fig%initialize(600, 400)
-        call fig%hist(data, bins=20)
+        call fig%add_hist(data, bins=20)
         call fig%set_title('Wide Range Data')
         filename = 'test/output/histogram_wide_range.png'
         call fig%savefig(filename)
@@ -367,7 +367,7 @@ contains
             data = real([(j, j=1,size)], wp) * 0.001_wp
             
             call fig%initialize(400, 300)  ! Smaller for speed
-            call fig%hist(data, bins=20)
+            call fig%add_hist(data, bins=20)
             call fig%set_title('Memory Test')
             
             filename = 'test/output/histogram_memory.png'
@@ -381,8 +381,8 @@ contains
         data = real([(i, i=1,2000)], wp) * 0.01_wp
         
         call fig%initialize(600, 400)
-        call fig%hist(data(1:1000), bins=30, label='First Half')
-        call fig%hist(data(1000:2000), bins=30, label='Second Half')
+        call fig%add_hist(data(1:1000), bins=30, label='First Half')
+        call fig%add_hist(data(1000:2000), bins=30, label='Second Half')
         call fig%legend()
         call fig%set_title('Overlapping Histograms')
         filename = 'test/output/histogram_overlapping.png'

--- a/test/test_legacy_positional_order.f90
+++ b/test/test_legacy_positional_order.f90
@@ -57,25 +57,27 @@ contains
         x = [(real(i, wp), i = 1, size(x))]
         y = sin(x)
 
-        call fig%add_fill(x, y, 'legacy-fill')
+        call fig%add_fill(x, y)
         call fetch_plots(fig, plots, n)
-        call assert_any_label(plots, n, 'legacy-fill')
+        call assert_no_labels(plots, n)
     end subroutine test_fill
 
     subroutine test_fill_between()
         type(figure_t) :: fig
         type(plot_data_t), pointer :: plots(:)
         real(wp) :: x(6), y1(6), y2(6)
+        logical :: mask(6)
         integer :: n, i
 
         call fig%initialize()
         x = [(real(i, wp), i = 1, size(x))]
         y1 = sin(x)
         y2 = y1 * 0.5_wp
+        mask = .true.
 
-        call fig%add_fill_between(x, y1, y2, 'legacy-fill-between')
+        call fig%add_fill_between(x, y1, y2, mask)
         call fetch_plots(fig, plots, n)
-        call assert_any_label(plots, n, 'legacy-fill-between')
+        call assert_no_labels(plots, n)
     end subroutine test_fill_between
 
     subroutine test_polar()
@@ -166,5 +168,19 @@ contains
         end do
         error stop 'assert_any_label: expected label not found'
     end subroutine assert_any_label
+
+    subroutine assert_no_labels(plots, count)
+        type(plot_data_t), intent(in) :: plots(:)
+        integer, intent(in) :: count
+        integer :: i
+
+        do i = 1, count
+            if (allocated(plots(i)%label)) then
+                if (len_trim(plots(i)%label) /= 0) then
+                    error stop 'assert_no_labels: unexpected label assigned'
+                end if
+            end if
+        end do
+    end subroutine assert_no_labels
 
 end program test_legacy_positional_order

--- a/test/test_pyplot_legacy_order.f90
+++ b/test/test_pyplot_legacy_order.f90
@@ -59,8 +59,8 @@ contains
             y(i) = 0.1_wp * real(i * i, wp)
         end do
 
-        call fill(x, y, 'orange', 0.4_wp, 'legacy-fill')
-        call assert_label_anywhere(fig, 'legacy-fill')
+        call fill(x, y, 'orange', 0.4_wp)
+        call assert_no_labels(fig)
     end subroutine test_fill
 
     subroutine test_fill_between()
@@ -77,8 +77,8 @@ contains
         end do
         mask = .true.
 
-        call fill_between(x, y1, y2, mask, 'green', 0.3_wp, 'legacy-band', .false.)
-        call assert_label_anywhere(fig, 'legacy-band')
+        call fill_between(x, y1, y2, mask, 'green', 0.3_wp, .false.)
+        call assert_no_labels(fig)
     end subroutine test_fill_between
 
     subroutine test_polar()
@@ -163,6 +163,30 @@ contains
 
         error stop 'assert_label_anywhere: expected label not found'
     end subroutine assert_label_anywhere
+
+    subroutine assert_no_labels(fig)
+        class(figure_t), pointer, intent(in) :: fig
+        type(plot_data_t), pointer :: plots(:)
+        integer :: count, i
+
+        count = fig%get_plot_count()
+        if (count <= 0) then
+            error stop 'assert_no_labels: expected plots to exist'
+        end if
+
+        plots => fig%get_plots()
+        if (.not. associated(plots)) then
+            error stop 'assert_no_labels: plots pointer not associated'
+        end if
+
+        do i = 1, count
+            if (allocated(plots(i)%label)) then
+                if (len_trim(plots(i)%label) /= 0) then
+                    error stop 'assert_no_labels: unexpected label discovered'
+                end if
+            end if
+        end do
+    end subroutine assert_no_labels
 
     subroutine assert_plot_count(fig, min_expected)
         class(figure_t), pointer, intent(in) :: fig

--- a/test/test_scientific_workflow.f90
+++ b/test/test_scientific_workflow.f90
@@ -36,7 +36,7 @@ contains
         end do
         
         call fig%initialize(800, 600)
-        call fig%hist(measurements, bins=30, density=.true., &
+        call fig%add_hist(measurements, bins=30, density=.true., &
                      label='Experimental Data', &
                      color=[0.2_wp, 0.4_wp, 0.8_wp])
         call fig%set_title('Experimental Measurement Distribution')
@@ -63,7 +63,7 @@ contains
         end do
         
         call fig%initialize(800, 600)
-        call fig%hist(simulation_data, bins=40, &
+        call fig%add_hist(simulation_data, bins=40, &
                      label='Simulation Results', &
                      color=[0.8_wp, 0.2_wp, 0.2_wp])
         call fig%set_title('Monte Carlo Simulation Results')
@@ -90,10 +90,10 @@ contains
         end do
         
         call fig%initialize(1000, 600)
-        call fig%hist(control_group, bins=25, density=.true., &
+        call fig%add_hist(control_group, bins=25, density=.true., &
                      label='Control Group', &
                      color=[0.3_wp, 0.7_wp, 0.3_wp])
-        call fig%hist(treatment_group, bins=25, density=.true., &
+        call fig%add_hist(treatment_group, bins=25, density=.true., &
                      label='Treatment Group', &
                      color=[0.7_wp, 0.3_wp, 0.7_wp])
         call fig%set_title('Control vs Treatment Group Comparison')
@@ -120,7 +120,7 @@ contains
         end do
         
         call fig%initialize(1200, 800)
-        call fig%hist(publication_data, bins=35, density=.true., &
+        call fig%add_hist(publication_data, bins=35, density=.true., &
                      label='Dataset A', &
                      color=[0.0_wp, 0.447_wp, 0.698_wp])
         call fig%set_title('Publication Quality Histogram')


### PR DESCRIPTION
## Summary
- remove label keywords from fill/fill_between and align OO/stateful optional order
- rename the histogram helper to figure_t%add_hist and update wrappers/tests
- add a fill_between_demo example covering both APIs and document the change

## Verification
- make test
- make example ARGS="fill_between_demo"
