### PR TITLE
fix: render fill_between polygons correctly

### DIFF
--- a/src/backends/memory/fortplot_rendering.f90
+++ b/src/backends/memory/fortplot_rendering.f90
@@ -15,6 +15,7 @@ module fortplot_rendering
     public :: render_line_plot
     public :: render_contour_plot
     public :: render_pcolormesh_plot
+    public :: render_fill_between_plot
     public :: render_markers
     public :: render_solid_line
     public :: draw_filled_quad

--- a/src/figures/core/fortplot_figure_core_ops.f90
+++ b/src/figures/core/fortplot_figure_core_ops.f90
@@ -139,7 +139,8 @@ module fortplot_figure_core_operations
 
     private
     public :: core_initialize, core_add_plot, core_add_contour, core_add_contour_filled
-    public :: core_add_pcolormesh, core_streamplot, core_savefig, core_savefig_with_status
+    public :: core_add_pcolormesh, core_add_fill_between
+    public :: core_streamplot, core_savefig, core_savefig_with_status
     public :: core_show
 
 contains
@@ -219,6 +220,23 @@ contains
         plot_count = state%plot_count
         call update_data_ranges_pcolormesh_figure(plots, state, state%plot_count)
     end subroutine core_add_pcolormesh
+
+    subroutine core_add_fill_between(plots, state, x, upper, lower, mask, color_string, alpha, &
+                                     plot_count)
+        type(plot_data_t), allocatable, intent(inout) :: plots(:)
+        type(figure_state_t), intent(inout) :: state
+        real(wp), intent(in) :: x(:)
+        real(wp), intent(in) :: upper(:)
+        real(wp), intent(in) :: lower(:)
+        logical, intent(in), optional :: mask(:)
+        character(len=*), intent(in), optional :: color_string
+        real(wp), intent(in), optional :: alpha
+        integer, intent(inout) :: plot_count
+
+        call figure_add_fill_between_operation(plots, state, x, upper, lower, mask, color_string, alpha)
+        plot_count = state%plot_count
+        call update_data_ranges_figure(plots, state, state%plot_count)
+    end subroutine core_add_fill_between
 
     subroutine core_streamplot(plots, state, plot_count, x, y, u, v, density, color)
         type(plot_data_t), allocatable, intent(inout) :: plots(:)

--- a/src/figures/fortplot_figure_comprehensive_operations.f90
+++ b/src/figures/fortplot_figure_comprehensive_operations.f90
@@ -33,7 +33,8 @@ module fortplot_figure_comprehensive_operations
     ! Re-export ALL operations needed by core module
     ! Operations module functions (exact names used by core)
     public :: figure_add_plot_operation, figure_add_contour_operation, figure_add_contour_filled_operation
-    public :: figure_add_pcolormesh_operation, figure_streamplot_operation, figure_hist_operation
+    public :: figure_add_pcolormesh_operation, figure_add_fill_between_operation
+    public :: figure_streamplot_operation, figure_hist_operation
     public :: figure_boxplot_operation, figure_scatter_operation, figure_set_xlabel_operation
     public :: figure_set_ylabel_operation, figure_set_title_operation, figure_set_xscale_operation
     public :: figure_set_yscale_operation, figure_set_xlim_operation, figure_set_ylim_operation
@@ -61,7 +62,8 @@ module fortplot_figure_comprehensive_operations
     
     ! Core operations extracted from main module
     public :: core_initialize, core_add_plot, core_add_contour, core_add_contour_filled
-    public :: core_add_pcolormesh, core_streamplot, core_savefig, core_savefig_with_status
+    public :: core_add_pcolormesh, core_add_fill_between
+    public :: core_streamplot, core_savefig, core_savefig_with_status
     public :: core_show
     
     ! Configuration operations from core_config module

--- a/src/figures/management/fortplot_figure_operations.f90
+++ b/src/figures/management/fortplot_figure_operations.f90
@@ -18,7 +18,8 @@ module fortplot_figure_operations
     use fortplot_figure_initialization, only: figure_state_t
     use fortplot_legend, only: legend_t
     use fortplot_figure_plots, only: figure_add_plot, figure_add_contour, &
-                                     figure_add_contour_filled, figure_add_pcolormesh
+                                     figure_add_contour_filled, figure_add_pcolormesh, &
+                                     figure_add_fill_between
     use fortplot_figure_histogram, only: hist_figure
     use fortplot_figure_streamlines, only: streamplot_figure
     use fortplot_figure_boxplot, only: add_boxplot
@@ -40,7 +41,8 @@ module fortplot_figure_operations
 
     private
     public :: figure_add_plot_operation, figure_add_contour_operation, figure_add_contour_filled_operation
-    public :: figure_add_pcolormesh_operation, figure_streamplot_operation, figure_hist_operation
+    public :: figure_add_pcolormesh_operation, figure_add_fill_between_operation
+    public :: figure_streamplot_operation, figure_hist_operation
     public :: figure_boxplot_operation, figure_scatter_operation, figure_set_xlabel_operation
     public :: figure_set_ylabel_operation, figure_set_title_operation, figure_set_xscale_operation
     public :: figure_set_yscale_operation, figure_set_xlim_operation, figure_set_ylim_operation
@@ -99,6 +101,21 @@ contains
         call figure_add_pcolormesh(plots, state, x, y, c, colormap, &
                                   vmin, vmax, edgecolors, linewidths)
     end subroutine figure_add_pcolormesh_operation
+
+    subroutine figure_add_fill_between_operation(plots, state, x, upper, lower, mask, &
+                                                color_string, alpha)
+        !! Add an area fill between two curves
+        type(plot_data_t), intent(inout) :: plots(:)
+        type(figure_state_t), intent(inout) :: state
+        real(wp), intent(in) :: x(:)
+        real(wp), intent(in) :: upper(:)
+        real(wp), intent(in) :: lower(:)
+        logical, intent(in), optional :: mask(:)
+        character(len=*), intent(in), optional :: color_string
+        real(wp), intent(in), optional :: alpha
+
+        call figure_add_fill_between(plots, state, x, upper, lower, mask, color_string, alpha)
+    end subroutine figure_add_fill_between_operation
 
     subroutine figure_streamplot_operation(plots, state, plot_count, x, y, u, v, &
                                           density, color)

--- a/src/testing/fortplot_plot_data.f90
+++ b/src/testing/fortplot_plot_data.f90
@@ -14,8 +14,8 @@ module fortplot_plot_data
     private
     public :: plot_data_t, arrow_data_t, subplot_t, subplot_data_t
     public :: PLOT_TYPE_LINE, PLOT_TYPE_CONTOUR, PLOT_TYPE_PCOLORMESH, &
-              PLOT_TYPE_ERRORBAR, PLOT_TYPE_BAR, PLOT_TYPE_HISTOGRAM, PLOT_TYPE_BOXPLOT, &
-              PLOT_TYPE_SCATTER
+              PLOT_TYPE_ERRORBAR, PLOT_TYPE_BAR, PLOT_TYPE_HISTOGRAM, &
+              PLOT_TYPE_BOXPLOT, PLOT_TYPE_SCATTER, PLOT_TYPE_FILL
     public :: HALF_WIDTH, IQR_WHISKER_MULTIPLIER
 
     ! Plot type constants
@@ -27,6 +27,7 @@ module fortplot_plot_data
     integer, parameter :: PLOT_TYPE_HISTOGRAM = 6
     integer, parameter :: PLOT_TYPE_BOXPLOT = 7
     integer, parameter :: PLOT_TYPE_SCATTER = 8
+    integer, parameter :: PLOT_TYPE_FILL = 9
 
     ! Constants for calculations
     real(wp), parameter :: HALF_WIDTH = 0.5_wp
@@ -42,6 +43,15 @@ module fortplot_plot_data
         real(wp) :: size = 1.0_wp       ! Arrow size scaling factor
         character(len=10) :: style = '->' ! Arrow style (matplotlib compatible)
     end type arrow_data_t
+
+    type :: fill_between_data_t
+        !! Storage for fill_between polygon samples
+        real(wp), allocatable :: x(:)
+        real(wp), allocatable :: upper(:)
+        real(wp), allocatable :: lower(:)
+        logical, allocatable :: mask(:)
+        logical :: has_mask = .false.
+    end type fill_between_data_t
 
     type :: plot_data_t
         !! Data container for individual plots
@@ -98,6 +108,9 @@ module fortplot_plot_data
         character(len=:), allocatable :: label
         character(len=:), allocatable :: linestyle
         character(len=:), allocatable :: marker
+        ! Filled polygon data (fill_between)
+        type(fill_between_data_t) :: fill_between_data
+        real(wp) :: fill_alpha = 1.0_wp
     contains
         procedure :: is_3d
     end type plot_data_t


### PR DESCRIPTION
## Summary
- add a dedicated fill plot storage and keep alpha/color metadata
- render fill_between quads via the backend instead of synthesizing lines
- validate docs generation to ensure the demo assets ship

## Testing
- fpm build
- fpm test --target test_matplotlib_new_functions
- make example ARGS="fill_between_demo"
- make doc
