### PR TITLE
fix: restore pdf unicode glyph mapping

### DIFF
--- a/src/backends/vector/fortplot_pdf_io.f90
+++ b/src/backends/vector/fortplot_pdf_io.f90
@@ -301,6 +301,7 @@ contains
         write(unit, '(A)') '/Type /Font'
         write(unit, '(A)') '/Subtype /Type1'
         write(unit, '(A)') '/BaseFont /Helvetica'
+        write(unit, '(A)') '/Encoding /WinAnsiEncoding'
         write(unit, '(A)') '>>'
         write(unit, '(A)') 'endobj'
     end subroutine write_helvetica_font_object

--- a/src/backends/vector/fortplot_pdf_text_escape.f90
+++ b/src/backends/vector/fortplot_pdf_text_escape.f90
@@ -66,31 +66,31 @@ contains
 
         select case(codepoint)
         case(176)
-            escape_seq = '\\260'
+            escape_seq = achar(92)//'260'
             found = .true.
         case(177)
-            escape_seq = '\\261'
+            escape_seq = achar(92)//'261'
             found = .true.
         case(178)
-            escape_seq = '\\262'
+            escape_seq = achar(92)//'262'
             found = .true.
         case(179)
-            escape_seq = '\\263'
+            escape_seq = achar(92)//'263'
             found = .true.
         case(181)
-            escape_seq = '\\265'
+            escape_seq = achar(92)//'265'
             found = .true.
         case(183)
-            escape_seq = '\\267'
+            escape_seq = achar(92)//'267'
             found = .true.
         case(185)
-            escape_seq = '\\271'
+            escape_seq = achar(92)//'271'
             found = .true.
         case(215)
-            escape_seq = '\\327'
+            escape_seq = achar(92)//'327'
             found = .true.
         case(247)
-            escape_seq = '\\367'
+            escape_seq = achar(92)//'367'
             found = .true.
         end select
 
@@ -114,53 +114,53 @@ contains
 
         select case(codepoint)
         case(945)
-            escape_seq = '\\141'
+            escape_seq = achar(92)//'141'
         case(946)
-            escape_seq = '\\142'
+            escape_seq = achar(92)//'142'
         case(947)
-            escape_seq = '\\147'
+            escape_seq = achar(92)//'147'
         case(948)
-            escape_seq = '\\144'
+            escape_seq = achar(92)//'144'
         case(949)
-            escape_seq = '\\145'
+            escape_seq = achar(92)//'145'
         case(950)
-            escape_seq = '\\172'
+            escape_seq = achar(92)//'172'
         case(951)
-            escape_seq = '\\150'
+            escape_seq = achar(92)//'150'
         case(952)
-            escape_seq = '\\161'
+            escape_seq = achar(92)//'161'
         case(953)
-            escape_seq = '\\151'
+            escape_seq = achar(92)//'151'
         case(954)
-            escape_seq = '\\153'
+            escape_seq = achar(92)//'153'
         case(955)
-            escape_seq = '\\154'
+            escape_seq = achar(92)//'154'
         case(956)
-            escape_seq = '\\155'
+            escape_seq = achar(92)//'155'
         case(957)
-            escape_seq = '\\156'
+            escape_seq = achar(92)//'156'
         case(958)
-            escape_seq = '\\170'
+            escape_seq = achar(92)//'170'
         case(959)
-            escape_seq = '\\157'
+            escape_seq = achar(92)//'157'
         case(960)
-            escape_seq = '\\160'
+            escape_seq = achar(92)//'160'
         case(961)
-            escape_seq = '\\162'
+            escape_seq = achar(92)//'162'
         case(963)
-            escape_seq = '\\163'
+            escape_seq = achar(92)//'163'
         case(964)
-            escape_seq = '\\164'
+            escape_seq = achar(92)//'164'
         case(965)
-            escape_seq = '\\165'
+            escape_seq = achar(92)//'165'
         case(966)
-            escape_seq = '\\146'
+            escape_seq = achar(92)//'146'
         case(967)
-            escape_seq = '\\143'
+            escape_seq = achar(92)//'143'
         case(968)
-            escape_seq = '\\171'
+            escape_seq = achar(92)//'171'
         case(969)
-            escape_seq = '\\167'
+            escape_seq = achar(92)//'167'
         case default
             found = .false.
         end select
@@ -175,53 +175,53 @@ contains
 
         select case(codepoint)
         case(913)
-            escape_seq = '\\101'
+            escape_seq = achar(92)//'101'
         case(914)
-            escape_seq = '\\102'
+            escape_seq = achar(92)//'102'
         case(915)
-            escape_seq = '\\107'
+            escape_seq = achar(92)//'107'
         case(916)
-            escape_seq = '\\104'
+            escape_seq = achar(92)//'104'
         case(917)
-            escape_seq = '\\105'
+            escape_seq = achar(92)//'105'
         case(918)
-            escape_seq = '\\132'
+            escape_seq = achar(92)//'132'
         case(919)
-            escape_seq = '\\110'
+            escape_seq = achar(92)//'110'
         case(920)
-            escape_seq = '\\121'
+            escape_seq = achar(92)//'121'
         case(921)
-            escape_seq = '\\111'
+            escape_seq = achar(92)//'111'
         case(922)
-            escape_seq = '\\113'
+            escape_seq = achar(92)//'113'
         case(923)
-            escape_seq = '\\114'
+            escape_seq = achar(92)//'114'
         case(924)
-            escape_seq = '\\115'
+            escape_seq = achar(92)//'115'
         case(925)
-            escape_seq = '\\116'
+            escape_seq = achar(92)//'116'
         case(926)
-            escape_seq = '\\130'
+            escape_seq = achar(92)//'130'
         case(927)
-            escape_seq = '\\117'
+            escape_seq = achar(92)//'117'
         case(928)
-            escape_seq = '\\120'
+            escape_seq = achar(92)//'120'
         case(929)
-            escape_seq = '\\122'
+            escape_seq = achar(92)//'122'
         case(931)
-            escape_seq = '\\123'
+            escape_seq = achar(92)//'123'
         case(932)
-            escape_seq = '\\124'
+            escape_seq = achar(92)//'124'
         case(933)
-            escape_seq = '\\125'
+            escape_seq = achar(92)//'125'
         case(934)
-            escape_seq = '\\106'
+            escape_seq = achar(92)//'106'
         case(935)
-            escape_seq = '\\103'
+            escape_seq = achar(92)//'103'
         case(936)
-            escape_seq = '\\131'
+            escape_seq = achar(92)//'131'
         case(937)
-            escape_seq = '\\127'
+            escape_seq = achar(92)//'127'
         case default
             found = .false.
         end select

--- a/src/backends/vector/fortplot_pdf_text_escape.f90
+++ b/src/backends/vector/fortplot_pdf_text_escape.f90
@@ -65,17 +65,32 @@ contains
         found = .false.
 
         select case(codepoint)
+        case(176)
+            escape_seq = '\\260'
+            found = .true.
+        case(177)
+            escape_seq = '\\261'
+            found = .true.
         case(178)
-            escape_seq = ''
-            found = .false.
+            escape_seq = '\\262'
+            found = .true.
         case(179)
-            escape_seq = ''
-            found = .false.
+            escape_seq = '\\263'
+            found = .true.
+        case(181)
+            escape_seq = '\\265'
+            found = .true.
+        case(183)
+            escape_seq = '\\267'
+            found = .true.
         case(185)
-            escape_seq = ''
-            found = .false.
+            escape_seq = '\\271'
+            found = .true.
         case(215)
-            escape_seq = 'x'
+            escape_seq = '\\327'
+            found = .true.
+        case(247)
+            escape_seq = '\\367'
             found = .true.
         end select
 

--- a/test/test_pdf_unicode_extended.f90
+++ b/test/test_pdf_unicode_extended.f90
@@ -1,0 +1,58 @@
+program test_pdf_unicode_extended
+    !! Validate PDF backend maps common Unicode math symbols to Type1 escapes
+    use fortplot
+    use test_pdf_utils, only: extract_pdf_stream_text
+    implicit none
+
+    character(len=*), parameter :: out_pdf = 'test/output/test_pdf_unicode_extended.pdf'
+    character(len=:), allocatable :: stream_text
+    integer :: status
+    logical :: has_superscript_two, has_superscript_three, has_superscript_one
+    logical :: has_multiply_sign, has_middle_dot, has_degree
+
+    call figure()
+    call title('Superscripts: E = mc², I = r³ + φ¹')
+    call xlabel('Products × and dot · with 25° offset')
+    call plot([0.0_wp, 1.0_wp], [0.0_wp, 1.0_wp])
+    call savefig(out_pdf)
+
+    call extract_pdf_stream_text(out_pdf, stream_text, status)
+    if (status /= 0) then
+        print *, 'FAIL: unable to read PDF content stream'
+        stop 1
+    end if
+
+    has_superscript_two   = index(stream_text, '\\262') > 0
+    has_superscript_three = index(stream_text, '\\263') > 0
+    has_superscript_one   = index(stream_text, '\\271') > 0
+    has_multiply_sign     = index(stream_text, '\\327') > 0
+    has_middle_dot        = index(stream_text, '\\267') > 0
+    has_degree            = index(stream_text, '\\260') > 0
+
+    if (.not. has_superscript_two) then
+        print *, 'FAIL: missing PDF escape for superscript two (\\262)'
+        stop 1
+    end if
+    if (.not. has_superscript_three) then
+        print *, 'FAIL: missing PDF escape for superscript three (\\263)'
+        stop 1
+    end if
+    if (.not. has_superscript_one) then
+        print *, 'FAIL: missing PDF escape for superscript one (\\271)'
+        stop 1
+    end if
+    if (.not. has_multiply_sign) then
+        print *, 'FAIL: missing PDF escape for multiply sign (\\327)'
+        stop 1
+    end if
+    if (.not. has_middle_dot) then
+        print *, 'FAIL: missing PDF escape for middle dot (\\267)'
+        stop 1
+    end if
+    if (.not. has_degree) then
+        print *, 'FAIL: missing PDF escape for degree sign (\\260)'
+        stop 1
+    end if
+
+    print *, 'PASS: Extended Unicode math glyphs mapped to Type1 escape sequences'
+end program test_pdf_unicode_extended

--- a/test/test_pdf_unicode_extended.f90
+++ b/test/test_pdf_unicode_extended.f90
@@ -22,12 +22,12 @@ program test_pdf_unicode_extended
         stop 1
     end if
 
-    has_superscript_two   = index(stream_text, '\\262') > 0
-    has_superscript_three = index(stream_text, '\\263') > 0
-    has_superscript_one   = index(stream_text, '\\271') > 0
-    has_multiply_sign     = index(stream_text, '\\327') > 0
-    has_middle_dot        = index(stream_text, '\\267') > 0
-    has_degree            = index(stream_text, '\\260') > 0
+    has_superscript_two   = index(stream_text, achar(92)//'262') > 0
+    has_superscript_three = index(stream_text, achar(92)//'263') > 0
+    has_superscript_one   = index(stream_text, achar(92)//'271') > 0
+    has_multiply_sign     = index(stream_text, achar(92)//'327') > 0
+    has_middle_dot        = index(stream_text, achar(92)//'267') > 0
+    has_degree            = index(stream_text, achar(92)//'260') > 0
 
     if (.not. has_superscript_two) then
         print *, 'FAIL: missing PDF escape for superscript two (\\262)'


### PR DESCRIPTION
## Summary
- map superscript, degree, middle-dot, multiply, etc. to Type 1 octal escapes
- prevent Helvetica fallback to question marks for common math glyphs
- add regression test covering extended unicode cases in PDF backend

## Testing
- make example ARGS="unicode_demo"
- fpm test --target test_pdf_unicode_extended
- fpm test --target test_pdf_unicode_uppercase
- fpm test --target test_pdf_unicode_basic