### PR TITLE
fix: y ticklabels too far from axis and overlap with axis label in PD (fixes #1267)

### DIFF
--- a/src/backends/vector/fortplot_pdf_axes.f90
+++ b/src/backends/vector/fortplot_pdf_axes.f90
@@ -446,8 +446,6 @@ contains
         real(wp) :: label_x, label_y, bottom_y
         real(wp), parameter :: TICK_CHAR_W = 6.0_wp   ! Legacy fallback width (unused for mathtext)
         real(wp), parameter :: X_TICK_GAP = 15.0_wp   ! Distance below plot for X tick labels
-        real(wp), parameter :: Y_TICK_GAP = 19.0_wp   ! Distance left of plot edge to end of Y tick labels
-
         associate(dch=>canvas_height); end associate
         bottom_y = plot_bottom  ! PDF Y=0 is at bottom, no conversion needed
 
@@ -459,9 +457,9 @@ contains
             call render_mixed_text(ctx, label_x, label_y, trim(x_labels(i)))
         end do
 
-        ! Draw Y-axis labels with overlap detection (right-aligned to end at plot_left - Y_TICK_GAP)
+        ! Draw Y-axis labels with overlap detection (right-aligned relative to axis)
         call draw_pdf_y_labels_with_overlap_detection(ctx, y_positions, y_labels, num_y, &
-                                                     plot_left - Y_TICK_GAP, 0.0_wp)
+                                                     plot_left, 0.0_wp)
     end subroutine draw_pdf_tick_labels_with_area
 
     subroutine draw_pdf_title_and_labels(ctx, title, xlabel, ylabel, &


### PR DESCRIPTION
## Summary
- remove the duplicated y tick label gap subtraction in the PDF backend so tick labels hug the axis again
- leave the overlap detection logic intact to keep spacing consistent with the raster backend

## Verification
- make test (`ALL TESTS PASSED (fpm test)`)
- make verify-artifacts (`Artifact verification passed.`; inspected `output/example/fortran/unicode_demo/unicode_demo.pdf`)
