### PR TITLE
fix: bug: .dat savefig uses PNG backend (fixes #1279)

### DIFF
--- a/src/utilities/fortplot_utils.f90
+++ b/src/utilities/fortplot_utils.f90
@@ -42,6 +42,8 @@ contains
                 backend_type = 'pdf'
             case ('txt')
                 backend_type = 'ascii'
+            case ('dat')
+                backend_type = 'ascii'
             case default
                 backend_type = 'png'  ! Default fallback
             end select

--- a/test/test_backend_extension_detection.f90
+++ b/test/test_backend_extension_detection.f90
@@ -1,0 +1,48 @@
+program test_backend_extension_detection
+    !! Verify get_backend_from_filename maps common extensions correctly
+
+    use fortplot_utils, only: get_backend_from_filename
+    implicit none
+
+    logical :: passed
+    character(len=20) :: backend
+
+    passed = .true.
+
+    backend = get_backend_from_filename('output.txt')
+    if (trim(backend) /= 'ascii') then
+        print *, 'FAIL: expected ascii for .txt, got', trim(backend)
+        passed = .false.
+    end if
+
+    backend = get_backend_from_filename('output.dat')
+    if (trim(backend) /= 'ascii') then
+        print *, 'FAIL: expected ascii for .dat, got', trim(backend)
+        passed = .false.
+    end if
+
+    backend = get_backend_from_filename('OUTPUT.DAT')
+    if (trim(backend) /= 'ascii') then
+        print *, 'FAIL: expected ascii for uppercase .DAT, got', trim(backend)
+        passed = .false.
+    end if
+
+    backend = get_backend_from_filename('plot.png')
+    if (trim(backend) /= 'png') then
+        print *, 'FAIL: expected png for .png, got', trim(backend)
+        passed = .false.
+    end if
+
+    backend = get_backend_from_filename('plot.pdf')
+    if (trim(backend) /= 'pdf') then
+        print *, 'FAIL: expected pdf for .pdf, got', trim(backend)
+        passed = .false.
+    end if
+
+    if (.not. passed) then
+        stop 1
+    else
+        print *, 'Backend extension detection tests passed'
+    end if
+
+end program test_backend_extension_detection

--- a/test/test_backend_extension_detection.f90
+++ b/test/test_backend_extension_detection.f90
@@ -5,44 +5,35 @@ program test_backend_extension_detection
     implicit none
 
     logical :: passed
-    character(len=20) :: backend
 
     passed = .true.
 
-    backend = get_backend_from_filename('output.txt')
-    if (trim(backend) /= 'ascii') then
-        print *, 'FAIL: expected ascii for .txt, got', trim(backend)
-        passed = .false.
-    end if
-
-    backend = get_backend_from_filename('output.dat')
-    if (trim(backend) /= 'ascii') then
-        print *, 'FAIL: expected ascii for .dat, got', trim(backend)
-        passed = .false.
-    end if
-
-    backend = get_backend_from_filename('OUTPUT.DAT')
-    if (trim(backend) /= 'ascii') then
-        print *, 'FAIL: expected ascii for uppercase .DAT, got', trim(backend)
-        passed = .false.
-    end if
-
-    backend = get_backend_from_filename('plot.png')
-    if (trim(backend) /= 'png') then
-        print *, 'FAIL: expected png for .png, got', trim(backend)
-        passed = .false.
-    end if
-
-    backend = get_backend_from_filename('plot.pdf')
-    if (trim(backend) /= 'pdf') then
-        print *, 'FAIL: expected pdf for .pdf, got', trim(backend)
-        passed = .false.
-    end if
+    call expect_backend('output.txt', 'ascii')
+    call expect_backend('output.dat', 'ascii')
+    call expect_backend('OUTPUT.DAT', 'ascii')
+    call expect_backend('plot.png', 'png')
+    call expect_backend('plot.pdf', 'pdf')
+    call expect_backend('plot', 'png')
+    call expect_backend('plot.unknown', 'png')
 
     if (.not. passed) then
-        stop 1
+        error stop 'backend extension detection regression'
     else
         print *, 'Backend extension detection tests passed'
     end if
+
+contains
+
+    subroutine expect_backend(filename, expected)
+        character(len=*), intent(in) :: filename
+        character(len=*), intent(in) :: expected
+        character(len=20) :: backend
+
+        backend = get_backend_from_filename(filename)
+        if (trim(backend) /= trim(expected)) then
+            print *, 'FAIL:', trim(filename), 'expected', trim(expected), 'got', trim(backend)
+            passed = .false.
+        end if
+    end subroutine expect_backend
 
 end program test_backend_extension_detection


### PR DESCRIPTION
## Summary
- map `.dat` extensions to the ASCII backend so savefig honors documentation
- add a regression test that exercises backend detection for `.dat`, `.txt`, and raster/vector outputs

## Verification
- `fpm test --target test_backend_extension_detection`
- `fpm test`
