### PR TITLE
fix: Refine Python bridge workflows and dual-backend example comparisons (fixes #1284)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ FPM_FLAGS_LIB = --flag -fPIC
 FPM_FLAGS_TEST =
 FPM_FLAGS_DEFAULT = $(FPM_FLAGS_LIB)
 
-.PHONY: all build example debug test clean help matplotlib example_python example_matplotlib doc create_build_dirs create_test_dirs validate-output test-docs verify-functionality verify-setup verify-with-evidence verify-size-compliance verify-complexity issue-branch issue-open-pr pr-merge pr-cleanup issue-loop issue-loop-dry test-python-bridge-example git-prune verify-warnings
+.PHONY: all build example debug test clean help matplotlib example_python example_matplotlib example_python_dual doc create_build_dirs create_test_dirs validate-output test-docs verify-functionality verify-setup verify-with-evidence verify-size-compliance verify-complexity issue-branch issue-open-pr pr-merge pr-cleanup issue-loop issue-loop-dry test-python-bridge-example git-prune verify-warnings
 
 # Default target
 all: build
@@ -120,6 +120,19 @@ example_matplotlib:
 		fi; \
 	done
 	@echo "Matplotlib comparison plots generated!"
+
+# Run Python examples in both modes and consolidate outputs
+example_python_dual:
+	@echo "Running Python examples in both modes (fortplot + matplotlib)..."
+	@for dir in example/python/*/; do \
+		if ls "$$dir"*.py >/dev/null 2>&1; then \
+			echo "[fortplot] $$dir"; \
+			cd "$$dir" && python3 *.py && cd - > /dev/null; \
+			echo "[matplotlib] $$dir"; \
+			cd "$$dir" && python3 *.py --matplotlib && cd - > /dev/null; \
+		fi; \
+	done
+	@echo "Dual-mode Python example runs completed!"
 
 # Legacy matplotlib target (deprecated, use example_matplotlib)
 matplotlib: example_matplotlib
@@ -324,6 +337,7 @@ help:
 	@echo "  example          - Build and run all Fortran examples"
 	@echo "  example_python   - Run Python examples with fortplot"
 	@echo "  example_matplotlib - Run Python examples with matplotlib (comparison)"
+	@echo "  example_python_dual - Run Python examples with both backends and consolidate outputs"
 	@echo "  debug            - Build and run apps for debugging"
 	@echo "  test             - Run all tests"
 	@echo "  test-ci          - Run CI-optimized tests (skip heavy I/O, MPEG tests)"

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ call savefig("log_plot.pdf")
 
 - Build: `make build` or `fpm build`
 - Tests: `make test` (full) or `make test-ci` (fast subset)
-- Examples: `make example` (Fortran), `make example_python`, `make example_matplotlib`
+- Examples: `make example` (Fortran), `make example_python`, `make example_matplotlib`, `make example_python_dual`
 
 ### Artifact Verification (required for rendering changes)
 
@@ -200,6 +200,21 @@ Dependencies for verification tools:
 - macOS (Homebrew): `brew install poppler ghostscript`
 
 In PRs and issues for output-affecting fixes, include the exact commands run, artifact paths, and short excerpts from tools (e.g., `pdftotext`) as evidence.
+
+### Python Example Outputs
+
+- All Python examples now accept an optional `--outdir` to override output location.
+- By default, outputs are consolidated under:
+  - `output/example/python/fortplot/<example>/` for fortplot backend
+  - `output/example/python/pyplot/<example>/` for matplotlib backend
+- Run both backends back-to-back for quick comparisons:
+
+```bash
+make example_python_dual
+# or per-example
+python3 example/python/basic_plots/basic_plots.py              # fortplot
+python3 example/python/basic_plots/basic_plots.py --matplotlib # matplotlib
+```
 
 #### Text annotations with coordinate systems
 ```fortran

--- a/example/python/basic_plots/basic_plots.py
+++ b/example/python/basic_plots/basic_plots.py
@@ -5,6 +5,7 @@ Equivalent to basic_plots.f90 for visual comparison
 """
 
 import sys
+from pathlib import Path
 import numpy as np
 
 # Dual-mode import: --matplotlib uses matplotlib, default uses fortplot
@@ -14,6 +15,36 @@ if "--matplotlib" in sys.argv:
 else:
     import fortplot.fortplot as plt
     backend = "fortplot"
+
+# Determine output directory (default to repo_root/output/example/python/<backend>/<example>/)
+# Support optional --outdir <path> or --outdir=<path>
+def _parse_outdir() -> Path:
+    args = sys.argv[:]
+    outdir_arg: str | None = None
+    # consume --outdir forms
+    for i, a in enumerate(list(args)):
+        if a.startswith("--outdir="):
+            outdir_arg = a.split("=", 1)[1]
+            sys.argv.pop(i)
+            break
+        if a == "--outdir" and i + 1 < len(args):
+            outdir_arg = args[i + 1]
+            # remove both
+            del sys.argv[i:i+2]
+            break
+    if outdir_arg:
+        p = Path(outdir_arg).expanduser().resolve()
+    else:
+        repo_root = Path(__file__).resolve().parents[3]
+        example_name = Path(__file__).resolve().parent.name
+        backend_dir = "pyplot" if backend == "matplotlib" else "fortplot"
+        p = repo_root / "output" / "example" / "python" / backend_dir / example_name
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+_OUTDIR = _parse_outdir()
+def out(name: str) -> str:
+    return str((_OUTDIR / name))
 
 def simple_plots():
     """Simple plot - equivalent to Fortran functional API"""
@@ -29,12 +60,12 @@ def simple_plots():
     plt.title('Simple Sine Wave')
     plt.xlabel('x')
     plt.ylabel('sin(x)')
-    plt.savefig('simple_plot.png')
-    plt.savefig('simple_plot.pdf')
+    plt.savefig(out('simple_plot.png'))
+    plt.savefig(out('simple_plot.pdf'))
     
     # Save TXT for fortplot only
     if backend == "fortplot":
-        plt.savefig('simple_plot.txt')
+        plt.savefig(out('simple_plot.txt'))
     
     if backend == "matplotlib":
         plt.close()
@@ -56,12 +87,12 @@ def multi_line_plot():
     plt.plot(x, sx, label="sin(x)")
     plt.plot(x, cx, label="cos(x)")
     plt.legend()
-    plt.savefig('multi_line.png')
-    plt.savefig('multi_line.pdf')
+    plt.savefig(out('multi_line.png'))
+    plt.savefig(out('multi_line.pdf'))
     
     # Save TXT for fortplot only
     if backend == "fortplot":
-        plt.savefig('multi_line.txt')
+        plt.savefig(out('multi_line.txt'))
     
     if backend == "matplotlib":
         plt.close()

--- a/example/python/basic_plots/basic_plots.py
+++ b/example/python/basic_plots/basic_plots.py
@@ -6,6 +6,7 @@ Equivalent to basic_plots.f90 for visual comparison
 
 import sys
 from pathlib import Path
+from typing import Optional
 import numpy as np
 
 # Dual-mode import: --matplotlib uses matplotlib, default uses fortplot
@@ -20,7 +21,7 @@ else:
 # Support optional --outdir <path> or --outdir=<path>
 def _parse_outdir() -> Path:
     args = sys.argv[:]
-    outdir_arg: str | None = None
+    outdir_arg: Optional[str] = None
     # consume --outdir forms
     for i, a in enumerate(list(args)):
         if a.startswith("--outdir="):

--- a/example/python/colored_contours/colored_contours.py
+++ b/example/python/colored_contours/colored_contours.py
@@ -2,6 +2,7 @@
 """Demonstrates colored contour plots with different colormaps - Dual mode: fortplot or matplotlib"""
 
 import sys
+from pathlib import Path
 import numpy as np
 
 # Dual-mode import: --matplotlib uses matplotlib, default uses fortplot
@@ -11,6 +12,32 @@ if "--matplotlib" in sys.argv:
 else:
     import fortplot.fortplot as plt
     backend = "fortplot"
+
+def _parse_outdir() -> Path:
+    args = sys.argv[:]
+    outdir_arg: str | None = None
+    for i, a in enumerate(list(args)):
+        if a.startswith("--outdir="):
+            outdir_arg = a.split("=", 1)[1]
+            sys.argv.pop(i)
+            break
+        if a == "--outdir" and i + 1 < len(args):
+            outdir_arg = args[i + 1]
+            del sys.argv[i:i+2]
+            break
+    if outdir_arg:
+        p = Path(outdir_arg).expanduser().resolve()
+    else:
+        repo_root = Path(__file__).resolve().parents[3]
+        example_name = Path(__file__).resolve().parent.name
+        backend_dir = "pyplot" if backend == "matplotlib" else "fortplot"
+        p = repo_root / "output" / "example" / "python" / backend_dir / example_name
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+_OUTDIR = _parse_outdir()
+def out(name: str) -> str:
+    return str((_OUTDIR / name))
 
 def default_gaussian_example():
     """Default colorblind-safe Gaussian example"""
@@ -32,12 +59,12 @@ def default_gaussian_example():
     # Use contourf for filled contours
     plt.contourf(X, Y, Z)
     
-    plt.savefig('gaussian_default.png')
-    plt.savefig('gaussian_default.pdf')
+    plt.savefig(out('gaussian_default.png'))
+    plt.savefig(out('gaussian_default.pdf'))
     
     # Save TXT for fortplot only
     if backend == "fortplot":
-        plt.savefig('gaussian_default.txt')
+        plt.savefig(out('gaussian_default.txt'))
     
     if backend == "matplotlib":
         plt.close()
@@ -67,12 +94,12 @@ def plasma_saddle_example():
     # Custom contour levels
     plt.contourf(X, Y, Z, custom_levels)
     
-    plt.savefig('saddle_plasma.png')
-    plt.savefig('saddle_plasma.pdf')
+    plt.savefig(out('saddle_plasma.png'))
+    plt.savefig(out('saddle_plasma.pdf'))
     
     # Save TXT for fortplot only
     if backend == "fortplot":
-        plt.savefig('saddle_plasma.txt')
+        plt.savefig(out('saddle_plasma.txt'))
     
     if backend == "matplotlib":
         plt.close()
@@ -97,12 +124,12 @@ def mixed_colormap_comparison():
     plt.ylabel("y")
     plt.title("Ripple Function - Inferno Colormap")
     plt.contourf(X, Y, Z)
-    plt.savefig('ripple_inferno.png')
-    plt.savefig('ripple_inferno.pdf')
+    plt.savefig(out('ripple_inferno.png'))
+    plt.savefig(out('ripple_inferno.pdf'))
     
     # Save TXT for fortplot only
     if backend == "fortplot":
-        plt.savefig('ripple_inferno.txt')
+        plt.savefig(out('ripple_inferno.txt'))
     
     if backend == "matplotlib":
         plt.close()
@@ -113,12 +140,12 @@ def mixed_colormap_comparison():
     plt.ylabel("y")
     plt.title("Ripple Function - Coolwarm Colormap")
     plt.contourf(X, Y, Z)
-    plt.savefig('ripple_coolwarm.png')
-    plt.savefig('ripple_coolwarm.pdf')
+    plt.savefig(out('ripple_coolwarm.png'))
+    plt.savefig(out('ripple_coolwarm.pdf'))
     
     # Save TXT for fortplot only
     if backend == "fortplot":
-        plt.savefig('ripple_coolwarm.txt')
+        plt.savefig(out('ripple_coolwarm.txt'))
     
     if backend == "matplotlib":
         plt.close()
@@ -129,12 +156,12 @@ def mixed_colormap_comparison():
     plt.ylabel("y")
     plt.title("Ripple Function - Jet Colormap")
     plt.contourf(X, Y, Z)
-    plt.savefig('ripple_jet.png')
-    plt.savefig('ripple_jet.pdf')
+    plt.savefig(out('ripple_jet.png'))
+    plt.savefig(out('ripple_jet.pdf'))
     
     # Save TXT for fortplot only
     if backend == "fortplot":
-        plt.savefig('ripple_jet.txt')
+        plt.savefig(out('ripple_jet.txt'))
     
     if backend == "matplotlib":
         plt.close()

--- a/example/python/colored_contours/colored_contours.py
+++ b/example/python/colored_contours/colored_contours.py
@@ -3,6 +3,7 @@
 
 import sys
 from pathlib import Path
+from typing import Optional
 import numpy as np
 
 # Dual-mode import: --matplotlib uses matplotlib, default uses fortplot
@@ -15,7 +16,7 @@ else:
 
 def _parse_outdir() -> Path:
     args = sys.argv[:]
-    outdir_arg: str | None = None
+    outdir_arg: Optional[str] = None
     for i, a in enumerate(list(args)):
         if a.startswith("--outdir="):
             outdir_arg = a.split("=", 1)[1]

--- a/example/python/contour_demo/contour_demo.py
+++ b/example/python/contour_demo/contour_demo.py
@@ -6,6 +6,7 @@ Equivalent to contour_demo.f90 for visual comparison
 
 import sys
 from pathlib import Path
+from typing import Optional
 import numpy as np
 
 # Dual-mode import: --matplotlib uses matplotlib, default uses fortplot
@@ -18,7 +19,7 @@ else:
 
 def _parse_outdir() -> Path:
     args = sys.argv[:]
-    outdir_arg: str | None = None
+    outdir_arg: Optional[str] = None
     for i, a in enumerate(list(args)):
         if a.startswith("--outdir="):
             outdir_arg = a.split("=", 1)[1]

--- a/example/python/contour_demo/contour_demo.py
+++ b/example/python/contour_demo/contour_demo.py
@@ -5,6 +5,7 @@ Equivalent to contour_demo.f90 for visual comparison
 """
 
 import sys
+from pathlib import Path
 import numpy as np
 
 # Dual-mode import: --matplotlib uses matplotlib, default uses fortplot
@@ -14,6 +15,32 @@ if "--matplotlib" in sys.argv:
 else:
     import fortplot.fortplot as plt
     backend = "fortplot"
+
+def _parse_outdir() -> Path:
+    args = sys.argv[:]
+    outdir_arg: str | None = None
+    for i, a in enumerate(list(args)):
+        if a.startswith("--outdir="):
+            outdir_arg = a.split("=", 1)[1]
+            sys.argv.pop(i)
+            break
+        if a == "--outdir" and i + 1 < len(args):
+            outdir_arg = args[i + 1]
+            del sys.argv[i:i+2]
+            break
+    if outdir_arg:
+        p = Path(outdir_arg).expanduser().resolve()
+    else:
+        repo_root = Path(__file__).resolve().parents[3]
+        example_name = Path(__file__).resolve().parent.name
+        backend_dir = "pyplot" if backend == "matplotlib" else "fortplot"
+        p = repo_root / "output" / "example" / "python" / backend_dir / example_name
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+_OUTDIR = _parse_outdir()
+def out(name: str) -> str:
+    return str((_OUTDIR / name))
 
 def gaussian_contours():
     """Gaussian contour demonstration - equivalent to Fortran version"""
@@ -35,12 +62,12 @@ def gaussian_contours():
     # Create contour plot
     plt.contour(X, Y, Z)
     
-    plt.savefig('contour_gaussian.png')
-    plt.savefig('contour_gaussian.pdf')
+    plt.savefig(out('contour_gaussian.png'))
+    plt.savefig(out('contour_gaussian.pdf'))
     
     # Save TXT for fortplot only
     if backend == "fortplot":
-        plt.savefig('contour_gaussian.txt')
+        plt.savefig(out('contour_gaussian.txt'))
     
     if backend == "matplotlib":
         plt.close()
@@ -71,12 +98,12 @@ def mixed_contour_line_plot():
     
     plt.legend()
     
-    plt.savefig('mixed_plot.png')
-    plt.savefig('mixed_plot.pdf')
+    plt.savefig(out('mixed_plot.png'))
+    plt.savefig(out('mixed_plot.pdf'))
     
     # Save TXT for fortplot only
     if backend == "fortplot":
-        plt.savefig('mixed_plot.txt')
+        plt.savefig(out('mixed_plot.txt'))
     
     if backend == "matplotlib":
         plt.close()

--- a/example/python/format_string_demo/format_string_demo.py
+++ b/example/python/format_string_demo/format_string_demo.py
@@ -2,6 +2,7 @@
 """Demonstrate matplotlib-style format strings - Dual mode: fortplot or matplotlib"""
 
 import sys
+from pathlib import Path
 import numpy as np
 
 # Dual-mode import: --matplotlib uses matplotlib, default uses fortplot
@@ -11,6 +12,32 @@ if "--matplotlib" in sys.argv:
 else:
     import fortplot.fortplot as plt
     backend = "fortplot"
+
+def _parse_outdir() -> Path:
+    args = sys.argv[:]
+    outdir_arg: str | None = None
+    for i, a in enumerate(list(args)):
+        if a.startswith("--outdir="):
+            outdir_arg = a.split("=", 1)[1]
+            sys.argv.pop(i)
+            break
+        if a == "--outdir" and i + 1 < len(args):
+            outdir_arg = args[i + 1]
+            del sys.argv[i:i+2]
+            break
+    if outdir_arg:
+        p = Path(outdir_arg).expanduser().resolve()
+    else:
+        repo_root = Path(__file__).resolve().parents[3]
+        example_name = Path(__file__).resolve().parent.name
+        backend_dir = "pyplot" if backend == "matplotlib" else "fortplot"
+        p = repo_root / "output" / "example" / "python" / backend_dir / example_name
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+_OUTDIR = _parse_outdir()
+def out(name: str) -> str:
+    return str((_OUTDIR / name))
 
 def main():
     print(f"=== Format String Demo ({backend}) ===")
@@ -35,12 +62,12 @@ def main():
     plt.plot(x, y4, linestyle='-.', label='cos(x/2) - dash-dot')
     
     plt.legend()
-    plt.savefig('format_string_demo.png')
-    plt.savefig('format_string_demo.pdf')
+    plt.savefig(out('format_string_demo.png'))
+    plt.savefig(out('format_string_demo.pdf'))
     
     # Save TXT for fortplot only
     if backend == "fortplot":
-        plt.savefig('format_string_demo.txt')
+        plt.savefig(out('format_string_demo.txt'))
     
     if backend == "matplotlib":
         plt.close()

--- a/example/python/format_string_demo/format_string_demo.py
+++ b/example/python/format_string_demo/format_string_demo.py
@@ -3,6 +3,7 @@
 
 import sys
 from pathlib import Path
+from typing import Optional
 import numpy as np
 
 # Dual-mode import: --matplotlib uses matplotlib, default uses fortplot
@@ -15,7 +16,7 @@ else:
 
 def _parse_outdir() -> Path:
     args = sys.argv[:]
-    outdir_arg: str | None = None
+    outdir_arg: Optional[str] = None
     for i, a in enumerate(list(args)):
         if a.startswith("--outdir="):
             outdir_arg = a.split("=", 1)[1]

--- a/example/python/legend_demo/legend_demo.py
+++ b/example/python/legend_demo/legend_demo.py
@@ -3,6 +3,7 @@
 Shows legend positioning, labeling, and rendering across all backends - Dual mode: fortplot or matplotlib"""
 
 import sys
+from pathlib import Path
 import numpy as np
 
 # Dual-mode import: --matplotlib uses matplotlib, default uses fortplot
@@ -12,6 +13,32 @@ if "--matplotlib" in sys.argv:
 else:
     import fortplot.fortplot as plt
     backend = "fortplot"
+
+def _parse_outdir() -> Path:
+    args = sys.argv[:]
+    outdir_arg: str | None = None
+    for i, a in enumerate(list(args)):
+        if a.startswith("--outdir="):
+            outdir_arg = a.split("=", 1)[1]
+            sys.argv.pop(i)
+            break
+        if a == "--outdir" and i + 1 < len(args):
+            outdir_arg = args[i + 1]
+            del sys.argv[i:i+2]
+            break
+    if outdir_arg:
+        p = Path(outdir_arg).expanduser().resolve()
+    else:
+        repo_root = Path(__file__).resolve().parents[3]
+        example_name = Path(__file__).resolve().parent.name
+        backend_dir = "pyplot" if backend == "matplotlib" else "fortplot"
+        p = repo_root / "output" / "example" / "python" / backend_dir / example_name
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+_OUTDIR = _parse_outdir()
+def out(name: str) -> str:
+    return str((_OUTDIR / name))
 
 def basic_legend_example():
     """Basic legend usage with labeled plots"""
@@ -34,12 +61,12 @@ def basic_legend_example():
     # Add legend with default position (upper right)
     plt.legend()
     
-    plt.savefig('basic_legend.png')
-    plt.savefig('basic_legend.pdf')
+    plt.savefig(out('basic_legend.png'))
+    plt.savefig(out('basic_legend.pdf'))
     
     # Save TXT for fortplot only
     if backend == "fortplot":
-        plt.savefig('basic_legend.txt')
+        plt.savefig(out('basic_legend.txt'))
     
     if backend == "matplotlib":
         plt.close()
@@ -64,12 +91,12 @@ def positioned_legend_example():
     plt.plot(x, y2, linestyle="--", label="log(x)")
     plt.legend()
     
-    plt.savefig('legend_positioning.png')
-    plt.savefig('legend_positioning.pdf')
+    plt.savefig(out('legend_positioning.png'))
+    plt.savefig(out('legend_positioning.pdf'))
     
     # Save TXT for fortplot only
     if backend == "fortplot":
-        plt.savefig('legend_positioning.txt')
+        plt.savefig(out('legend_positioning.txt'))
     
     if backend == "matplotlib":
         plt.close()
@@ -102,12 +129,12 @@ def multi_function_legend_example():
     # Add legend
     plt.legend()
     
-    plt.savefig('multi_function_legend.png')
-    plt.savefig('multi_function_legend.pdf')
+    plt.savefig(out('multi_function_legend.png'))
+    plt.savefig(out('multi_function_legend.pdf'))
     
     # Save TXT for fortplot only
     if backend == "fortplot":
-        plt.savefig('multi_function_legend.txt')
+        plt.savefig(out('multi_function_legend.txt'))
     
     if backend == "matplotlib":
         plt.close()

--- a/example/python/legend_demo/legend_demo.py
+++ b/example/python/legend_demo/legend_demo.py
@@ -4,6 +4,7 @@ Shows legend positioning, labeling, and rendering across all backends - Dual mod
 
 import sys
 from pathlib import Path
+from typing import Optional
 import numpy as np
 
 # Dual-mode import: --matplotlib uses matplotlib, default uses fortplot
@@ -16,7 +17,7 @@ else:
 
 def _parse_outdir() -> Path:
     args = sys.argv[:]
-    outdir_arg: str | None = None
+    outdir_arg: Optional[str] = None
     for i, a in enumerate(list(args)):
         if a.startswith("--outdir="):
             outdir_arg = a.split("=", 1)[1]

--- a/example/python/line_styles/line_styles.py
+++ b/example/python/line_styles/line_styles.py
@@ -6,6 +6,7 @@ Equivalent to line_styles.f90 for visual comparison
 
 import sys
 from pathlib import Path
+from typing import Optional
 import numpy as np
 
 # Dual-mode import: --matplotlib uses matplotlib, default uses fortplot
@@ -18,7 +19,7 @@ else:
 
 def _parse_outdir() -> Path:
     args = sys.argv[:]
-    outdir_arg: str | None = None
+    outdir_arg: Optional[str] = None
     for i, a in enumerate(list(args)):
         if a.startswith("--outdir="):
             outdir_arg = a.split("=", 1)[1]

--- a/example/python/line_styles/line_styles.py
+++ b/example/python/line_styles/line_styles.py
@@ -5,6 +5,7 @@ Equivalent to line_styles.f90 for visual comparison
 """
 
 import sys
+from pathlib import Path
 import numpy as np
 
 # Dual-mode import: --matplotlib uses matplotlib, default uses fortplot
@@ -14,6 +15,32 @@ if "--matplotlib" in sys.argv:
 else:
     import fortplot.fortplot as plt
     backend = "fortplot"
+
+def _parse_outdir() -> Path:
+    args = sys.argv[:]
+    outdir_arg: str | None = None
+    for i, a in enumerate(list(args)):
+        if a.startswith("--outdir="):
+            outdir_arg = a.split("=", 1)[1]
+            sys.argv.pop(i)
+            break
+        if a == "--outdir" and i + 1 < len(args):
+            outdir_arg = args[i + 1]
+            del sys.argv[i:i+2]
+            break
+    if outdir_arg:
+        p = Path(outdir_arg).expanduser().resolve()
+    else:
+        repo_root = Path(__file__).resolve().parents[3]
+        example_name = Path(__file__).resolve().parent.name
+        backend_dir = "pyplot" if backend == "matplotlib" else "fortplot"
+        p = repo_root / "output" / "example" / "python" / backend_dir / example_name
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+_OUTDIR = _parse_outdir()
+def out(name: str) -> str:
+    return str((_OUTDIR / name))
 
 def main():
     print(f"=== Line Style Examples ({backend}) ===")
@@ -38,12 +65,12 @@ def main():
     plt.ylabel('Y values')
     plt.legend()
     
-    plt.savefig('line_styles.png')
-    plt.savefig('line_styles.pdf')
+    plt.savefig(out('line_styles.png'))
+    plt.savefig(out('line_styles.pdf'))
     
     # Save TXT for fortplot only
     if backend == "fortplot":
-        plt.savefig('line_styles.txt')
+        plt.savefig(out('line_styles.txt'))
     
     if backend == "matplotlib":
         plt.close()

--- a/example/python/marker_demo/marker_demo.py
+++ b/example/python/marker_demo/marker_demo.py
@@ -3,6 +3,7 @@
 
 import sys
 from pathlib import Path
+from typing import Optional
 import numpy as np
 
 # Dual-mode import: --matplotlib uses matplotlib, default uses fortplot
@@ -16,7 +17,7 @@ else:
 # Determine output directory and helper
 def _parse_outdir() -> Path:
     args = sys.argv[:]
-    outdir_arg: str | None = None
+    outdir_arg: Optional[str] = None
     for i, a in enumerate(list(args)):
         if a.startswith("--outdir="):
             outdir_arg = a.split("=", 1)[1]

--- a/example/python/marker_demo/marker_demo.py
+++ b/example/python/marker_demo/marker_demo.py
@@ -2,6 +2,7 @@
 """Demonstrates different marker types and styles - Dual mode: fortplot or matplotlib"""
 
 import sys
+from pathlib import Path
 import numpy as np
 
 # Dual-mode import: --matplotlib uses matplotlib, default uses fortplot
@@ -11,6 +12,33 @@ if "--matplotlib" in sys.argv:
 else:
     import fortplot.fortplot as plt
     backend = "fortplot"
+
+# Determine output directory and helper
+def _parse_outdir() -> Path:
+    args = sys.argv[:]
+    outdir_arg: str | None = None
+    for i, a in enumerate(list(args)):
+        if a.startswith("--outdir="):
+            outdir_arg = a.split("=", 1)[1]
+            sys.argv.pop(i)
+            break
+        if a == "--outdir" and i + 1 < len(args):
+            outdir_arg = args[i + 1]
+            del sys.argv[i:i+2]
+            break
+    if outdir_arg:
+        p = Path(outdir_arg).expanduser().resolve()
+    else:
+        repo_root = Path(__file__).resolve().parents[3]
+        example_name = Path(__file__).resolve().parent.name
+        backend_dir = "pyplot" if backend == "matplotlib" else "fortplot"
+        p = repo_root / "output" / "example" / "python" / backend_dir / example_name
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+_OUTDIR = _parse_outdir()
+def out(name: str) -> str:
+    return str((_OUTDIR / name))
 
 def demo_scatter_plot():
     """Creates a scatter plot to demonstrate markers in practical use"""
@@ -30,12 +58,12 @@ def demo_scatter_plot():
     plt.plot(x, np.sin(x), linestyle="-", label='Sin(x) Reference')
     
     plt.legend()
-    plt.savefig('scatter_plot.png')
-    plt.savefig('scatter_plot.pdf')
+    plt.savefig(out('scatter_plot.png'))
+    plt.savefig(out('scatter_plot.pdf'))
     
     # Save TXT for fortplot only
     if backend == "fortplot":
-        plt.savefig('scatter_plot.txt')
+        plt.savefig(out('scatter_plot.txt'))
     
     if backend == "matplotlib":
         plt.close()
@@ -63,8 +91,8 @@ def demo_all_marker_types():
     ax.plot(x, y4, 'x', label='Cross')
     
     ax.legend()
-    plt.savefig('all_marker_types.png', dpi=100)
-    plt.savefig('all_marker_types.pdf')
+    plt.savefig(out('all_marker_types.png'), dpi=100)
+    plt.savefig(out('all_marker_types.pdf'))
     plt.close()
 
 def demo_marker_colors():
@@ -86,8 +114,8 @@ def demo_marker_colors():
     ax.plot(x, y3, 'D', label='Orange diamonds')
     
     ax.legend()
-    plt.savefig('marker_colors.png', dpi=100)
-    plt.savefig('marker_colors.pdf')
+    plt.savefig(out('marker_colors.png'), dpi=100)
+    plt.savefig(out('marker_colors.pdf'))
     plt.close()
 
 if __name__ == "__main__":

--- a/example/python/pcolormesh_demo/pcolormesh_demo.py
+++ b/example/python/pcolormesh_demo/pcolormesh_demo.py
@@ -3,6 +3,7 @@
 
 import sys
 from pathlib import Path
+from typing import Optional
 import numpy as np
 
 # Dual-mode import: --matplotlib uses matplotlib, default uses fortplot
@@ -15,7 +16,7 @@ else:
 
 def _parse_outdir() -> Path:
     args = sys.argv[:]
-    outdir_arg: str | None = None
+    outdir_arg: Optional[str] = None
     for i, a in enumerate(list(args)):
         if a.startswith("--outdir="):
             outdir_arg = a.split("=", 1)[1]

--- a/example/python/pcolormesh_demo/pcolormesh_demo.py
+++ b/example/python/pcolormesh_demo/pcolormesh_demo.py
@@ -2,6 +2,7 @@
 """Demonstrates pcolormesh functionality with different colormaps - Dual mode: fortplot or matplotlib"""
 
 import sys
+from pathlib import Path
 import numpy as np
 
 # Dual-mode import: --matplotlib uses matplotlib, default uses fortplot
@@ -11,6 +12,32 @@ if "--matplotlib" in sys.argv:
 else:
     import fortplot.fortplot as plt
     backend = "fortplot"
+
+def _parse_outdir() -> Path:
+    args = sys.argv[:]
+    outdir_arg: str | None = None
+    for i, a in enumerate(list(args)):
+        if a.startswith("--outdir="):
+            outdir_arg = a.split("=", 1)[1]
+            sys.argv.pop(i)
+            break
+        if a == "--outdir" and i + 1 < len(args):
+            outdir_arg = args[i + 1]
+            del sys.argv[i:i+2]
+            break
+    if outdir_arg:
+        p = Path(outdir_arg).expanduser().resolve()
+    else:
+        repo_root = Path(__file__).resolve().parents[3]
+        example_name = Path(__file__).resolve().parent.name
+        backend_dir = "pyplot" if backend == "matplotlib" else "fortplot"
+        p = repo_root / "output" / "example" / "python" / backend_dir / example_name
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+_OUTDIR = _parse_outdir()
+def out(name: str) -> str:
+    return str((_OUTDIR / name))
 
 def demo_basic_gradient():
     """Basic pcolormesh with simple gradient"""
@@ -35,12 +62,12 @@ def demo_basic_gradient():
     plt.ylabel('Y coordinate')
     plt.pcolormesh(x, y, C, cmap='viridis')
     
-    plt.savefig('pcolormesh_basic.png')
-    plt.savefig('pcolormesh_basic.pdf')
+    plt.savefig(out('pcolormesh_basic.png'))
+    plt.savefig(out('pcolormesh_basic.pdf'))
     
     # Save TXT for fortplot only
     if backend == "fortplot":
-        plt.savefig('pcolormesh_basic.txt')
+        plt.savefig(out('pcolormesh_basic.txt'))
     
     if backend == "matplotlib":
         plt.close()
@@ -69,12 +96,12 @@ def demo_sinusoidal_pattern():
     plt.ylabel('Y coordinate')
     plt.pcolormesh(x, y, C, cmap='coolwarm')
     
-    plt.savefig('pcolormesh_sinusoidal.png')
-    plt.savefig('pcolormesh_sinusoidal.pdf')
+    plt.savefig(out('pcolormesh_sinusoidal.png'))
+    plt.savefig(out('pcolormesh_sinusoidal.pdf'))
     
     # Save TXT for fortplot only
     if backend == "fortplot":
-        plt.savefig('pcolormesh_sinusoidal.txt')
+        plt.savefig(out('pcolormesh_sinusoidal.txt'))
     
     if backend == "matplotlib":
         plt.close()
@@ -102,12 +129,12 @@ def demo_different_colormaps():
     plt.ylabel('Y coordinate')
     plt.pcolormesh(x, y, C, cmap='plasma')
     
-    plt.savefig('pcolormesh_plasma.png')
-    plt.savefig('pcolormesh_plasma.pdf')
+    plt.savefig(out('pcolormesh_plasma.png'))
+    plt.savefig(out('pcolormesh_plasma.pdf'))
     
     # Save TXT for fortplot only
     if backend == "fortplot":
-        plt.savefig('pcolormesh_plasma.txt')
+        plt.savefig(out('pcolormesh_plasma.txt'))
     
     if backend == "matplotlib":
         plt.close()

--- a/example/python/scale_examples/scale_examples.py
+++ b/example/python/scale_examples/scale_examples.py
@@ -5,6 +5,7 @@ Equivalent to scale_examples.f90 for visual comparison
 """
 
 import sys
+from pathlib import Path
 import numpy as np
 
 # Dual-mode import: --matplotlib uses matplotlib, default uses fortplot
@@ -14,6 +15,32 @@ if "--matplotlib" in sys.argv:
 else:
     import fortplot.fortplot as plt
     backend = "fortplot"
+
+def _parse_outdir() -> Path:
+    args = sys.argv[:]
+    outdir_arg: str | None = None
+    for i, a in enumerate(list(args)):
+        if a.startswith("--outdir="):
+            outdir_arg = a.split("=", 1)[1]
+            sys.argv.pop(i)
+            break
+        if a == "--outdir" and i + 1 < len(args):
+            outdir_arg = args[i + 1]
+            del sys.argv[i:i+2]
+            break
+    if outdir_arg:
+        p = Path(outdir_arg).expanduser().resolve()
+    else:
+        repo_root = Path(__file__).resolve().parents[3]
+        example_name = Path(__file__).resolve().parent.name
+        backend_dir = "pyplot" if backend == "matplotlib" else "fortplot"
+        p = repo_root / "output" / "example" / "python" / backend_dir / example_name
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+_OUTDIR = _parse_outdir()
+def out(name: str) -> str:
+    return str((_OUTDIR / name))
 
 def log_scale_demo():
     """Log scale demonstration - equivalent to Fortran version"""
@@ -29,12 +56,12 @@ def log_scale_demo():
     plt.title('Log Scale Example')
     plt.xlabel('x')
     plt.ylabel('exp(0.2x)')
-    plt.savefig('log_scale.png')
-    plt.savefig('log_scale.pdf')
+    plt.savefig(out('log_scale.png'))
+    plt.savefig(out('log_scale.pdf'))
     
     # Save TXT for fortplot only
     if backend == "fortplot":
-        plt.savefig('log_scale.txt')
+        plt.savefig(out('log_scale.txt'))
     
     if backend == "matplotlib":
         plt.close()
@@ -55,12 +82,12 @@ def symlog_scale_demo():
     plt.title('Symlog Scale Example')
     plt.xlabel('x')
     plt.ylabel('x^3 - 50x')
-    plt.savefig('symlog_scale.png')
-    plt.savefig('symlog_scale.pdf')
+    plt.savefig(out('symlog_scale.png'))
+    plt.savefig(out('symlog_scale.pdf'))
     
     # Save TXT for fortplot only
     if backend == "fortplot":
-        plt.savefig('symlog_scale.txt')
+        plt.savefig(out('symlog_scale.txt'))
     
     if backend == "matplotlib":
         plt.close()

--- a/example/python/scale_examples/scale_examples.py
+++ b/example/python/scale_examples/scale_examples.py
@@ -6,6 +6,7 @@ Equivalent to scale_examples.f90 for visual comparison
 
 import sys
 from pathlib import Path
+from typing import Optional
 import numpy as np
 
 # Dual-mode import: --matplotlib uses matplotlib, default uses fortplot
@@ -18,7 +19,7 @@ else:
 
 def _parse_outdir() -> Path:
     args = sys.argv[:]
-    outdir_arg: str | None = None
+    outdir_arg: Optional[str] = None
     for i, a in enumerate(list(args)):
         if a.startswith("--outdir="):
             outdir_arg = a.split("=", 1)[1]

--- a/example/python/scatter3d_demo/scatter3d_demo.py
+++ b/example/python/scatter3d_demo/scatter3d_demo.py
@@ -6,9 +6,22 @@ Equivalent to fortplotlib's scatter3d_demo.f90
 This shows the matplotlib approach for comparison with fortplotlib's cleaner API.
 """
 
+from pathlib import Path
 import numpy as np
 import matplotlib.pyplot as plt
 from mpl_toolkits.mplot3d import Axes3D
+
+# Standardize output location under repo_root/output/example/python/pyplot/<example>
+backend = "matplotlib"
+def _default_outdir() -> Path:
+    repo_root = Path(__file__).resolve().parents[3]
+    example_name = Path(__file__).resolve().parent.name
+    p = repo_root / "output" / "example" / "python" / "pyplot" / example_name
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+_OUTDIR = _default_outdir()
+def out(name: str) -> str:
+    return str(_OUTDIR / name)
 
 # Generate the same data as fortplotlib example
 n = 100
@@ -29,7 +42,7 @@ ax.set_ylabel('Y Label')
 ax.set_zlabel('Z Label')
 ax.set_title('3D Scatter Plot')
 ax.legend()
-plt.savefig('scatter3d_demo.png', dpi=100)
+plt.savefig(out('scatter3d_demo.png'), dpi=100)
 plt.close()
 
 # Multiple scatter plots
@@ -50,7 +63,7 @@ ax.set_ylabel('Y')
 ax.set_zlabel('Z')
 ax.set_title('Multiple 3D Scatter Plots')
 ax.legend()
-plt.savefig('scatter3d_multi.png', dpi=100)
+plt.savefig(out('scatter3d_multi.png'), dpi=100)
 plt.close()
 
 # Parametric curve with scatter points
@@ -76,7 +89,7 @@ ax.set_ylabel('Y')
 ax.set_zlabel('Z')
 ax.set_title('Parametric Curve with Points')
 ax.legend()
-plt.savefig('scatter3d_curve.png', dpi=100)
+plt.savefig(out('scatter3d_curve.png'), dpi=100)
 plt.close()
 
 print("3D scatter plot demos complete!")

--- a/example/python/scatter_demo/scatter_demo.py
+++ b/example/python/scatter_demo/scatter_demo.py
@@ -6,8 +6,21 @@ Equivalent to fortplotlib's scatter_demo.f90
 This shows the matplotlib approach for comparison with fortplotlib's cleaner API.
 """
 
+from pathlib import Path
 import numpy as np
 import matplotlib.pyplot as plt
+
+# Standardize output location under repo_root/output/example/python/pyplot/<example>
+backend = "matplotlib"
+def _default_outdir() -> Path:
+    repo_root = Path(__file__).resolve().parents[3]
+    example_name = Path(__file__).resolve().parent.name
+    p = repo_root / "output" / "example" / "python" / "pyplot" / example_name
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+_OUTDIR = _default_outdir()
+def out(name: str) -> str:
+    return str(_OUTDIR / name)
 
 # Basic 2D scatter plot
 n = 50
@@ -21,7 +34,7 @@ plt.ylabel('Y')
 plt.title('Basic Scatter Plot')
 plt.legend()
 plt.grid(True, alpha=0.3)
-plt.savefig('scatter_basic.png', dpi=100)
+plt.savefig(out('scatter_basic.png'), dpi=100)
 plt.close()
 
 # Multiple scatter plots with different colors and sizes
@@ -48,7 +61,7 @@ plt.ylabel('Y')
 plt.title('Multiple Scatter Plots')
 plt.legend()
 plt.grid(True, alpha=0.3)
-plt.savefig('scatter_multi.png', dpi=100)
+plt.savefig(out('scatter_multi.png'), dpi=100)
 plt.close()
 
 # Gaussian distribution scatter
@@ -68,7 +81,7 @@ plt.ylabel('Y')
 plt.title('Gaussian Distribution')
 plt.grid(True, alpha=0.3)
 plt.axis('equal')
-plt.savefig('scatter_gaussian.png', dpi=100)
+plt.savefig(out('scatter_gaussian.png'), dpi=100)
 plt.close()
 
 print("2D scatter plot demos complete!")

--- a/example/python/streamplot_demo/streamplot_demo.py
+++ b/example/python/streamplot_demo/streamplot_demo.py
@@ -3,6 +3,7 @@
 
 import numpy as np
 import sys
+from pathlib import Path
 
 if "--matplotlib" in sys.argv:
     import matplotlib.pyplot as plt
@@ -10,6 +11,32 @@ if "--matplotlib" in sys.argv:
 else:
     import fortplot.fortplot as plt
     backend = "fortplot"
+
+def _parse_outdir() -> Path:
+    args = sys.argv[:]
+    outdir_arg: str | None = None
+    for i, a in enumerate(list(args)):
+        if a.startswith("--outdir="):
+            outdir_arg = a.split("=", 1)[1]
+            sys.argv.pop(i)
+            break
+        if a == "--outdir" and i + 1 < len(args):
+            outdir_arg = args[i + 1]
+            del sys.argv[i:i+2]
+            break
+    if outdir_arg:
+        p = Path(outdir_arg).expanduser().resolve()
+    else:
+        repo_root = Path(__file__).resolve().parents[3]
+        example_name = Path(__file__).resolve().parent.name
+        backend_dir = "pyplot" if backend == "matplotlib" else "fortplot"
+        p = repo_root / "output" / "example" / "python" / backend_dir / example_name
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+_OUTDIR = _parse_outdir()
+def out(name: str) -> str:
+    return str((_OUTDIR / name))
 
 def main():
     nx, ny = 20, 20
@@ -29,12 +56,12 @@ def main():
     plt.xlabel('X')
     plt.ylabel('Y')
     plt.title('Streamline Plot Demo - Circular Flow')
-    plt.savefig('streamplot_demo.png')
-    plt.savefig('streamplot_demo.pdf')
+    plt.savefig(out('streamplot_demo.png'))
+    plt.savefig(out('streamplot_demo.pdf'))
 
     # Export TXT for fortplot mode
     if backend == "fortplot":
-        with open('streamplot_demo.txt', 'w') as f:
+        with open(out('streamplot_demo.txt'), 'w') as f:
             f.write("Streamline Plot Demo - Circular Flow\n")
             f.write("=====================================\n\n")
             f.write("Grid size: {}x{}\n".format(nx, ny))

--- a/example/python/streamplot_demo/streamplot_demo.py
+++ b/example/python/streamplot_demo/streamplot_demo.py
@@ -4,6 +4,7 @@
 import numpy as np
 import sys
 from pathlib import Path
+from typing import Optional
 
 if "--matplotlib" in sys.argv:
     import matplotlib.pyplot as plt
@@ -14,7 +15,7 @@ else:
 
 def _parse_outdir() -> Path:
     args = sys.argv[:]
-    outdir_arg: str | None = None
+    outdir_arg: Optional[str] = None
     for i, a in enumerate(list(args)):
         if a.startswith("--outdir="):
             outdir_arg = a.split("=", 1)[1]

--- a/scripts/test_python_bridge_example.sh
+++ b/scripts/test_python_bridge_example.sh
@@ -11,6 +11,13 @@ OUT_FILE="$ROOT_DIR/output/python_bridge_demo.png"
 # Ensure output dir exists
 mkdir -p "$ROOT_DIR/output"
 
+# Guard: ensure command file exists with a clear error (Issue #1284)
+if [ ! -f "$CMD_FILE" ]; then
+  echo "Required command file missing: $CMD_FILE" >&2
+  echo "Please restore or ensure it is packaged. See example/python_bridge/commands_basic.txt" >&2
+  exit 4
+fi
+
 # Locate bridge executable via the Python helper (avoids hardcoding build paths)
 # Use PYTHONPATH to include the repo's python/ directory (robust when running from stdin)
 BRIDGE_EXE=$(PYTHONPATH="$ROOT_DIR/python${PYTHONPATH+:$PYTHONPATH}" python3 - <<'PY'


### PR DESCRIPTION
fix: Refine Python bridge workflows and dual-backend example comparisons (fixes #1284)

Summary
- Consolidate Python example artifacts under output/example/python/<backend>/<example>/
- Add make target example_python_dual to run both fortplot and matplotlib back-to-back
- Harden bridge example by guarding missing commands_basic.txt with a clear error

Changes
- Update all dual-mode Python examples to accept optional --outdir and default to:
  - output/example/python/fortplot/<example>/ for fortplot
  - output/example/python/pyplot/<example>/ for matplotlib
- Add Makefile target example_python_dual to orchestrate both runs per example
- Add guard in scripts/test_python_bridge_example.sh for missing example/python_bridge/commands_basic.txt

Verification
Commands run locally from repo root:
- make test-ci
  - All CI-fast tests passed (see snippets below)
  - Python bridge example: "✓ Python bridge example produced output/python_bridge_demo.png (... bytes)"
  - Fortplot Python examples executed via scripts/test_python_examples.py
- make example_python_dual
  - Produced consolidated outputs under:
    - output/example/python/fortplot/*/
    - output/example/python/pyplot/*/

Evidence excerpts
- After make example_python_dual:
  - output/example/python/fortplot/basic_plots: simple_plot.png/pdf/txt, multi_line.png/pdf/txt
  - output/example/python/pyplot/basic_plots: simple_plot.png/pdf, multi_line.png/pdf
  - output/example/python/fortplot/legend_demo: basic_legend.png/pdf/txt, legend_positioning.png/pdf/txt, multi_function_legend.png/pdf/txt
  - output/example/python/pyplot/legend_demo: basic_legend.png/pdf, legend_positioning.png/pdf, multi_function_legend.png/pdf

Notes
- No changes made to CI matrix; this PR keeps matplotlib runs opt-in via make example_python_dual to avoid introducing new CI dependencies. A follow-up can integrate a lightweight matplotlib smoke test if desired.



---

Reviewer validation (Codex CLI)
- Ran: make test-ci (all passing)
- Ran: make example_python_dual (both backends ran; outputs under output/example/python/{fortplot,pyplot}/...)
- Ran: make verify-artifacts (strict checks passed; see log)
- Minor improvements pushed:
  - Replace Python 3.10 union syntax with typing.Optional for broader compatibility
  - README: document consolidated Python output dirs and example_python_dual target

Key artifacts (examples):
- output/example/python/fortplot/basic_plots/simple_plot.png/pdf/txt
- output/example/python/pyplot/basic_plots/simple_plot.png/pdf
- output/example/python/fortplot/legend_demo/multi_function_legend.png/pdf/txt
- output/example/python/pyplot/legend_demo/multi_function_legend.png/pdf

Logs excerpt:

