### PR TITLE
fix: Superscript wrong in last example of https://lazy-fortran.github (fixes #1288)

### DIFF
--- a/example/fortran/legend_demo/legend_demo.f90
+++ b/example/fortran/legend_demo/legend_demo.f90
@@ -122,10 +122,11 @@ contains
         call ylabel("f(x)")
         
         ! Add multiple labeled functions
-        call add_plot(x, y1, label="e^(-x/2)cos(x)")
-        call add_plot(x, y2, label="xe^(-x/3)")
+        ! Use mathtext with braces for multi-character superscripts
+        call add_plot(x, y1, label="e^{-x/2}cos(x)")
+        call add_plot(x, y2, label="xe^{-x/3}")
         call add_plot(x, y3, label="sin(x)/x")
-        call add_plot(x, y4, label="x²e^(-x)")
+        call add_plot(x, y4, label="x^{2}e^{-x}")
         
         ! Add legend
         call legend()

--- a/example/python/legend_demo/legend_demo.py
+++ b/example/python/legend_demo/legend_demo.py
@@ -122,10 +122,11 @@ def multi_function_legend_example():
     plt.ylabel("f(x)")
     
     # Add multiple labeled functions
-    plt.plot(x, y1, linestyle="-", label="e^(-x/2)cos(x)")
-    plt.plot(x, y2, linestyle="--", label="xe^(-x/3)")
+    # Use mathtext with braces for multi-character superscripts
+    plt.plot(x, y1, linestyle="-", label="e^{-x/2}cos(x)")
+    plt.plot(x, y2, linestyle="--", label="xe^{-x/3}")
     plt.plot(x, y3, linestyle=":", label="sin(x)/x")
-    plt.plot(x, y4, linestyle="-.", label="x^2*exp(-x)")
+    plt.plot(x, y4, linestyle="-.", label="x^{2}e^{-x}")
     
     # Add legend
     plt.legend()


### PR DESCRIPTION
fix: Superscript wrong in last example of legend demo (fixes #1288)

Summary
- Correct legend labels in the multi-function legend example to use proper mathtext braces so multi-character superscripts render correctly across backends.
- Updated both Fortran and Python examples.

Changes
- example/fortran/legend_demo/legend_demo.f90: use e^{-x/2}, xe^{-x/3}, x^{2}e^{-x}
- example/python/legend_demo/legend_demo.py: same labels updated

Verification
- Baseline tests: make test-ci
  Excerpts:
  - "CI essential test suite completed successfully"
  - Backend switching, histogram, PDF tests all passed.
- Example artifacts regenerated:
  - Fortran: output/example/fortran/legend_demo/multi_function_legend.png
  - Python:  output/example/python/fortplot/legend_demo/multi_function_legend.png
- Visual check: legend shows labels as
  - e^{-x/2}cos(x)
  - xe^{-x/3}
  - sin(x)/x
  - x^{2}e^{-x}

No other code changes.
