### PR TITLE
fix: sqrt symbol showing as '?' in pdf (fixes #1296)

### DIFF
--- a/src/backends/vector/fortplot_pdf_text_escape.f90
+++ b/src/backends/vector/fortplot_pdf_text_escape.f90
@@ -49,6 +49,13 @@ contains
         esc = ''
         found = .false.
 
+        ! Common math symbols supported by Symbol font
+        ! U+221A (square root) maps to octal \214 in Symbol encoding
+        if (unicode_codepoint == 8730) then
+            symbol_char = achar(92)//'214'
+            return
+        end if
+
         call lookup_lowercase_greek(unicode_codepoint, esc, found)
         if (.not. found) call lookup_uppercase_greek(unicode_codepoint, esc, found)
 

--- a/test/test_pdf_unicode_sqrt.f90
+++ b/test/test_pdf_unicode_sqrt.f90
@@ -38,5 +38,11 @@ program test_pdf_unicode_sqrt
         stop 1
     end if
 
+    ! Ensure the character following the radical (here 'x') renders as a normal text segment
+    if (index(stream_text, '(x) Tj') == 0) then
+        print *, 'FAIL: Expected following text segment for x not found'
+        stop 1
+    end if
+
     print *, 'PASS: Unicode square root renders in PDF without fallback'
 end program test_pdf_unicode_sqrt

--- a/test/test_pdf_unicode_sqrt.f90
+++ b/test/test_pdf_unicode_sqrt.f90
@@ -1,0 +1,42 @@
+program test_pdf_unicode_sqrt
+    use fortplot
+    use test_pdf_utils, only: extract_pdf_stream_text
+    use fortplot_validation, only: validation_result_t, validate_file_exists
+    implicit none
+
+    character(len=:), allocatable :: stream_text
+    integer :: status
+    type(validation_result_t) :: val
+    character(len=*), parameter :: outfile = 'test/output/test_pdf_sqrt.pdf'
+
+    call figure()
+    call plot([0.0d0, 1.0d0], [0.0d0, 1.0d0])
+    ! Include the Unicode square root symbol directly
+    call title('PDF sqrt: √x')
+    call savefig(outfile)
+
+    val = validate_file_exists(outfile)
+    if (.not. val%passed) then
+        print *, 'FAIL: PDF file not created for sqrt test'
+        stop 1
+    end if
+
+    call extract_pdf_stream_text(outfile, stream_text, status)
+    if (status /= 0) then
+        print *, 'FAIL: Could not extract PDF stream text'
+        stop 1
+    end if
+
+    if (index(stream_text, '?') > 0) then
+        print *, 'FAIL: Found fallback ? in PDF stream (sqrt not mapped)'
+        stop 1
+    end if
+
+    ! Heuristic: ensure the Symbol octal escape for radical (\214) is present
+    if (index(stream_text, '\214') == 0) then
+        print *, 'FAIL: Expected Symbol escape \\214 for sqrt not found'
+        stop 1
+    end if
+
+    print *, 'PASS: Unicode square root renders in PDF without fallback'
+end program test_pdf_unicode_sqrt


### PR DESCRIPTION
fix: sqrt symbol showing as '?' in pdf (fixes #1296)

Summary
- Map Unicode square root (U+221A) to the PDF Symbol font (octal \214) so it renders correctly instead of falling back to '?'.
- Add a focused FPM test that generates a PDF with "√x" in the title and asserts the PDF content contains the Symbol escape and no '?' fallback.

Changes
- src/backends/vector/fortplot_pdf_text_escape.f90
  - Add mapping in unicode_to_symbol_char for U+221A -> "\214" (Symbol encoding), switching to /Symbol for the glyph.
- test/test_pdf_unicode_sqrt.f90
  - New test that saves a PDF with a Unicode sqrt and validates stream text via test_pdf_utils.

Verification
- Baseline tests (before change):
  - make test
  - ALL TESTS PASSED
- After changes:
  - make test
  - ALL TESTS PASSED, including new test: "PASS: Unicode square root renders in PDF without fallback"
- PDF stream evidence (decompressed):
  - Shows Symbol font switch and octal escape for radical, then returns to Helvetica for the following text:
    BT
    /F5 14.0 Tf
    ...
    (PDF sqrt: ) Tj
    /F6 14.0 Tf
    (\214) Tj
    /F5 14.0 Tf
    (x) Tj
    ET
- Artifact verification for output-affecting change:
  - make verify-artifacts
  - Artifact verification passed (no regressions); example PDFs/PNGs validated, including unicode_demo.

Repro commands
- make test
- ./build/gfortran_*/test/test_pdf_unicode_sqrt
- python - <<PY
import re,zlib
p='test/output/test_pdf_sqrt.pdf'
with open(p,'rb') as f:
    d=f.read()
for m in re.finditer(rb'stream\r?\n',d):
    start=m.end(); end=d.find(b'endstream',start)
    chunk=d[start:end]
    try:
        txt=zlib.decompress(chunk)
        if b"(\\214) Tj" in txt: print("Found \\214 in stream")
    except Exception:
        pass
PY

Notes
- pdftotext may not emit the radical character from Symbol; the test asserts presence of the correct Symbol escape in the PDF stream and absence of '?' fallback to ensure rendering is correct.



Additional verification
- Strengthened test to also assert the following text segment '(x) Tj' appears after the radical, confirming Helvetica switch and proper sequencing.