### PR TITLE
fix: Error bar plots not working (fixes #1299)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,6 +164,8 @@ doc:
 	# Generate streamplot and pcolormesh demos so images are available in docs
 	$(MAKE) example ARGS="streamplot_demo" >/dev/null
 	$(MAKE) example ARGS="pcolormesh_demo" >/dev/null
+	# Generate errorbar demo so example page has images (fixes #1299)
+	$(MAKE) example ARGS="errorbar_demo" >/dev/null
 	# Generate marker demo so marker images (including all_marker_types.png) are present (fixes #1109)
 	$(MAKE) example ARGS="marker_demo" >/dev/null
 	# Generate animation demo so MP4 is available for docs (fixes #1085)

--- a/scripts/verify_artifacts.sh
+++ b/scripts/verify_artifacts.sh
@@ -7,6 +7,7 @@ fpm run --example pcolormesh_demo >/dev/null
 fpm run --example pcolormesh_negative >/dev/null
 fpm run --example marker_demo >/dev/null
 fpm run --example line_styles >/dev/null
+fpm run --example errorbar_demo >/dev/null
 
 # Additional visual regression examples (ylabel spacing, PDF scale, subplots, unicode, show viewer)
 fpm run --example label_positioning_demo >/dev/null
@@ -213,6 +214,22 @@ for f in \
       echo "ERROR: $f has too few unique colors ($c) — contours may be missing" >&2
       exit 1
     fi
+  fi
+done
+
+# Errorbar demo outputs should exist and be non-trivial
+for f in \
+  output/example/fortran/errorbar_demo/errorbar_basic_y.png \
+  output/example/fortran/errorbar_demo/errorbar_basic_x.png \
+  output/example/fortran/errorbar_demo/errorbar_combined.png \
+  output/example/fortran/errorbar_demo/errorbar_asymmetric.png \
+  output/example/fortran/errorbar_demo/errorbar_scientific.png
+  do
+  if [[ -f "$f" ]]; then
+    check_png_size "$f" 4000
+  else
+    echo "ERROR: Missing errorbar demo artifact $f" >&2
+    exit 1
   fi
 done
 


### PR DESCRIPTION
Summary
- Generate errorbar demo artifacts during `make doc` so the docs page has images.
- Add errorbar demo checks to `scripts/verify_artifacts.sh` to guard regressions.

Verification
- Baseline tests:
  - Command: make test
  - Result: ALL TESTS PASSED (fpm test)
- Artifact verification:
  - Command: make verify-artifacts
  - Key excerpts:
    - Created artifacts during example run:
      - output/example/fortran/errorbar_demo/errorbar_basic_y.png
      - output/example/fortran/errorbar_demo/errorbar_basic_x.png
      - output/example/fortran/errorbar_demo/errorbar_combined.png
      - output/example/fortran/errorbar_demo/errorbar_asymmetric.png
      - output/example/fortran/errorbar_demo/errorbar_scientific.png
    - Size checks:
      - [png] errorbar_basic_y.png size≈22k
      - [png] errorbar_basic_x.png size≈22k
      - [png] errorbar_combined.png size≈22k
      - [png] errorbar_asymmetric.png size≈26k
      - [png] errorbar_scientific.png size≈23k
    - PDF/text checks for other demos all OK; artifact verification passed.

Repro
- Regenerate docs and media:
  - make doc
- Or run the example directly:
  - make example ARGS="errorbar_demo"

Notes
- This ensures the hosted docs page for Errorbar Demo has up-to-date images without requiring a manual example run.
