### PR TITLE
fix: 3D plotting not working (fixes #1300)

### DIFF
--- a/test/test_3d_plot_data_storage.f90
+++ b/test/test_3d_plot_data_storage.f90
@@ -22,26 +22,27 @@ contains
         real(wp), dimension(5) :: y = [2.0_wp, 4.0_wp, 6.0_wp, 8.0_wp, 10.0_wp]
         real(wp), dimension(5) :: z = [0.5_wp, 1.0_wp, 1.5_wp, 2.0_wp, 2.5_wp]
         
-        ! Act - Store 3D data
         plot_data%plot_type = PLOT_TYPE_LINE
         plot_data%x = x
         plot_data%y = y
-        ! Note: This test verifies current 2D plot_data_t structure
-        ! 3D support (z field) is not yet implemented - this is expected behavior
-        plot_data%label = "2D test data (3D support pending)"
-        
-        ! Test current implementation: verify x and y data are stored correctly
-        if (.not. allocated(plot_data%x) .or. .not. allocated(plot_data%y)) then
-            error stop "plot_data_t should support x and y coordinate allocation"
+        plot_data%z = z
+        plot_data%label = "3D test data"
+
+        if (.not. allocated(plot_data%x) .or. .not. allocated(plot_data%y) .or. &
+            .not. allocated(plot_data%z)) then
+            error stop "plot_data_t should allocate x, y, and z for 3D data"
         end if
-        
-        if (size(plot_data%x) /= 5 .or. size(plot_data%y) /= 5) then
-            error stop "x or y array size mismatch"
+
+        if (size(plot_data%x) /= 5 .or. size(plot_data%y) /= 5 .or. &
+            size(plot_data%z) /= 5) then
+            error stop "Coordinate array size mismatch"
         end if
-        
-        ! Current working assertions with platform-safe tolerance
+
         if (abs(plot_data%x(3) - 3.0_wp) > get_windows_safe_tolerance(1e-10_wp)) then
             error stop "x coordinate value mismatch"
+        end if
+        if (abs(plot_data%z(2) - 1.0_wp) > get_windows_safe_tolerance(1e-10_wp)) then
+            error stop "z coordinate value mismatch"
         end if
         
     end subroutine test_3d_line_plot_storage
@@ -58,9 +59,11 @@ contains
         plot_data%y = y
         ! Don't allocate z for 2D plots
         
-        ! Test current 2D-only implementation: z field not yet supported
         if (.not. allocated(plot_data%x) .or. .not. allocated(plot_data%y)) then
             error stop "2D plots should have x and y allocated"
+        end if
+        if (allocated(plot_data%z)) then
+            error stop "Z array should remain unallocated for 2D data"
         end if
         
     end subroutine test_2d_plot_no_z_allocation
@@ -70,14 +73,17 @@ contains
         !! Enable when plot_data_t has z field and is_3d() method
         type(plot_data_t) :: plot_data
         
-        ! Test current 2D plot implementation
-        allocate(plot_data%x(3), plot_data%y(3))
-        
-        ! Verify basic allocation works (3D detection not yet implemented)
-        if (.not. allocated(plot_data%x) .or. .not. allocated(plot_data%y)) then
-            error stop "plot_data_t should support basic x and y allocation"
+        allocate(plot_data%x(3), plot_data%y(3), plot_data%z(3))
+
+        if (.not. plot_data%is_3d()) then
+            error stop "plot_data_t should report 3D when z is allocated"
         end if
-        
+
+        deallocate(plot_data%z)
+        if (plot_data%is_3d()) then
+            error stop "plot_data_t should report 2D after z deallocation"
+        end if
+
     end subroutine test_3d_plot_type_detection
 
 end program test_3d_plot_data_storage

--- a/test/test_3d_projection.f90
+++ b/test/test_3d_projection.f90
@@ -1,0 +1,103 @@
+program test_3d_projection
+    !! Validate that 3D plotting utilities project data to 2D as expected
+
+    use iso_fortran_env, only: wp => real64
+    use fortplot_figure_core, only: figure_t
+    use fortplot_3d_plots, only: add_3d_plot
+    use fortplot_scatter_plots, only: add_scatter_plot_data
+    use fortplot_projection, only: get_default_view_angles, project_3d_to_2d
+    use fortplot_windows_test_helper, only: get_windows_safe_tolerance
+    implicit none
+
+    call test_line_projection()
+    call test_scatter_projection()
+
+    print *, 'All 3D projection tests passed!'
+
+contains
+
+    subroutine test_line_projection()
+        type(figure_t) :: fig
+        real(wp) :: x(4), y(4), z(4)
+        real(wp) :: x_expected(4), y_expected(4)
+        real(wp) :: tol, azim, elev, dist
+        integer :: plot_idx
+
+        call fig%initialize()
+
+        x = [0.0_wp, 1.0_wp, -1.0_wp, 0.5_wp]
+        y = [0.0_wp, 0.5_wp, 0.5_wp, -0.5_wp]
+        z = [0.0_wp, 0.5_wp, 0.5_wp, 1.0_wp]
+
+        call get_default_view_angles(azim, elev, dist)
+        call project_3d_to_2d(x, y, z, azim, elev, dist, x_expected, y_expected)
+
+        call add_3d_plot(fig, x, y, z)
+
+        plot_idx = fig%plot_count
+        tol = get_windows_safe_tolerance(1.0e-12_wp)
+
+        if (plot_idx /= 1) then
+            error stop 'Expected one plot in figure after add_3d_plot'
+        end if
+
+        if (.not. allocated(fig%plots(plot_idx)%z)) then
+            error stop '3D line plot should retain original z samples'
+        end if
+
+        if (any(abs(fig%plots(plot_idx)%x - x_expected) > tol)) then
+            error stop 'Projected x coordinates mismatch for 3D line plot'
+        end if
+
+        if (any(abs(fig%plots(plot_idx)%y - y_expected) > tol)) then
+            error stop 'Projected y coordinates mismatch for 3D line plot'
+        end if
+
+        if (any(abs(fig%plots(plot_idx)%z - z) > tol)) then
+            error stop 'Stored z coordinates mismatch for 3D line plot'
+        end if
+    end subroutine test_line_projection
+
+    subroutine test_scatter_projection()
+        type(figure_t) :: fig
+        real(wp) :: x(3), y(3), z(3)
+        real(wp) :: x_expected(3), y_expected(3)
+        real(wp) :: tol, azim, elev, dist
+        integer :: plot_idx
+
+        call fig%initialize()
+
+        x = [0.0_wp, 0.5_wp, -0.5_wp]
+        y = [0.0_wp, -0.25_wp, 0.75_wp]
+        z = [0.0_wp, 0.8_wp, 0.4_wp]
+
+        call get_default_view_angles(azim, elev, dist)
+        call project_3d_to_2d(x, y, z, azim, elev, dist, x_expected, y_expected)
+
+        call add_scatter_plot_data(fig, x, y, z=z)
+
+        plot_idx = fig%plot_count
+        tol = get_windows_safe_tolerance(1.0e-12_wp)
+
+        if (plot_idx /= 1) then
+            error stop 'Expected one scatter plot in figure after add_scatter_plot_data'
+        end if
+
+        if (.not. allocated(fig%plots(plot_idx)%z)) then
+            error stop '3D scatter plot should retain original z samples'
+        end if
+
+        if (any(abs(fig%plots(plot_idx)%x - x_expected) > tol)) then
+            error stop 'Projected x coordinates mismatch for 3D scatter plot'
+        end if
+
+        if (any(abs(fig%plots(plot_idx)%y - y_expected) > tol)) then
+            error stop 'Projected y coordinates mismatch for 3D scatter plot'
+        end if
+
+        if (any(abs(fig%plots(plot_idx)%z - z) > tol)) then
+            error stop 'Stored z coordinates mismatch for 3D scatter plot'
+        end if
+    end subroutine test_scatter_projection
+
+end program test_3d_projection


### PR DESCRIPTION
## Summary
- project 3D line and scatter data using the default projection before rendering
- keep original z samples on plots and update storage tests to cover 3D allocation
- add regression coverage that compares stored coordinates to the projection utilities

## Verification
- make test
- make example ARGS="3d_plotting"
