### PR TITLE
fix: Box plots not working at all (fixes #1311)

### DIFF
--- a/example/fortran/boxplot_demo/boxplot_demo.f90
+++ b/example/fortran/boxplot_demo/boxplot_demo.f90
@@ -31,17 +31,10 @@ program boxplot_demo
     call xlabel('Data Groups')
     call ylabel('Values')
     
-    ! Note: Box plot functionality would need to be implemented in fortplot
-    ! For now, create a simple line plot demonstration with the data
-    
-    ! Create x-axis data for each group
-    x_a = [(real(i, wp), i=1, 10)]
-    x_b = [(real(i, wp) + 0.1_wp, i=1, 10)]  ! Slight offset for visibility
-    x_c = [(real(i, wp) + 0.2_wp, i=1, 10)]  ! Slight offset for visibility
-    
-    call plot(x_a, group_a, label='Group A')
-    call plot(x_b, group_b, label='Group B')  
-    call plot(x_c, group_c, label='Group C')
+    ! Render box plots: simple vertical boxes with positions 1,2,3
+    call boxplot(group_a, position=1.0_wp, width=0.6_wp, label='Group A')
+    call boxplot(group_b, position=2.0_wp, width=0.6_wp, label='Group B')
+    call boxplot(group_c, position=3.0_wp, width=0.6_wp, label='Group C')
     call legend()
     
     call savefig('output/example/fortran/boxplot_demo/boxplot_demo.png')

--- a/src/backends/memory/fortplot_boxplot_rendering.f90
+++ b/src/backends/memory/fortplot_boxplot_rendering.f90
@@ -1,0 +1,150 @@
+module fortplot_boxplot_rendering
+    !! Box plot rendering for memory backends (shared for raster/PDF via context)
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    use fortplot_context, only: plot_context
+    use fortplot_scales, only: apply_scale_transform
+    use fortplot_plot_data, only: plot_data_t
+    implicit none
+
+    private
+    public :: render_boxplot_plot
+
+contains
+
+    subroutine render_boxplot_plot(backend, plot_data, xscale, yscale, symlog_threshold)
+        !! Render a single box plot (vertical or horizontal)
+        class(plot_context), intent(inout) :: backend
+        type(plot_data_t), intent(in) :: plot_data
+        character(len=*), intent(in) :: xscale, yscale
+        real(wp), intent(in) :: symlog_threshold
+
+        real(wp) :: pos, halfw
+        real(wp) :: q1, q2, q3, wlo, whi
+        real(wp) :: capw
+        logical :: horiz
+
+        if (.not. allocated(plot_data%box_data)) return
+
+        pos = plot_data%position
+        halfw = 0.5_wp * plot_data%width
+        q1 = plot_data%q1
+        q2 = plot_data%q2
+        q3 = plot_data%q3
+        wlo = plot_data%whisker_low
+        whi = plot_data%whisker_high
+        capw = max(0.1_wp * plot_data%width, 0.05_wp)
+        horiz = plot_data%horizontal
+
+        call backend%color(plot_data%color(1), plot_data%color(2), plot_data%color(3))
+
+        if (.not. horiz) then
+            call draw_box_vertical(backend, pos, halfw, q1, q2, q3, wlo, whi, capw, xscale, yscale, symlog_threshold)
+            if (plot_data%show_outliers) call draw_outliers_vertical(backend, pos, plot_data, xscale, yscale, symlog_threshold)
+        else
+            call draw_box_horizontal(backend, pos, halfw, q1, q2, q3, wlo, whi, capw, xscale, yscale, symlog_threshold)
+            if (plot_data%show_outliers) call draw_outliers_horizontal(backend, pos, plot_data, xscale, yscale, symlog_threshold)
+        end if
+    end subroutine render_boxplot_plot
+
+    subroutine draw_box_vertical(backend, pos, halfw, q1, q2, q3, wlo, whi, capw, xscale, yscale, t)
+        class(plot_context), intent(inout) :: backend
+        real(wp), intent(in) :: pos, halfw, q1, q2, q3, wlo, whi, capw
+        character(len=*), intent(in) :: xscale, yscale
+        real(wp), intent(in) :: t
+        real(wp) :: x0, x1
+        real(wp) :: xs0, xs1, ys0, ys1
+
+        x0 = pos - halfw; x1 = pos + halfw
+
+        ! Box rectangle (q1 to q3)
+        call line_scaled(backend, x0, q1, x1, q1, xscale, yscale, t)
+        call line_scaled(backend, x1, q1, x1, q3, xscale, yscale, t)
+        call line_scaled(backend, x1, q3, x0, q3, xscale, yscale, t)
+        call line_scaled(backend, x0, q3, x0, q1, xscale, yscale, t)
+
+        ! Median line
+        call line_scaled(backend, x0, q2, x1, q2, xscale, yscale, t)
+
+        ! Whiskers
+        call line_scaled(backend, pos, q1, pos, wlo, xscale, yscale, t)
+        call line_scaled(backend, pos, q3, pos, whi, xscale, yscale, t)
+        ! Caps
+        call line_scaled(backend, pos - capw, wlo, pos + capw, wlo, xscale, yscale, t)
+        call line_scaled(backend, pos - capw, whi, pos + capw, whi, xscale, yscale, t)
+    end subroutine draw_box_vertical
+
+    subroutine draw_box_horizontal(backend, pos, halfw, q1, q2, q3, wlo, whi, capw, xscale, yscale, t)
+        class(plot_context), intent(inout) :: backend
+        real(wp), intent(in) :: pos, halfw, q1, q2, q3, wlo, whi, capw
+        character(len=*), intent(in) :: xscale, yscale
+        real(wp), intent(in) :: t
+        real(wp) :: y0, y1
+
+        y0 = pos - halfw; y1 = pos + halfw
+
+        ! Box rectangle (q1 to q3) but horizontal
+        call line_scaled(backend, q1, y0, q3, y0, xscale, yscale, t)
+        call line_scaled(backend, q3, y0, q3, y1, xscale, yscale, t)
+        call line_scaled(backend, q3, y1, q1, y1, xscale, yscale, t)
+        call line_scaled(backend, q1, y1, q1, y0, xscale, yscale, t)
+
+        ! Median line
+        call line_scaled(backend, q2, y0, q2, y1, xscale, yscale, t)
+
+        ! Whiskers
+        call line_scaled(backend, q1, pos, wlo, pos, xscale, yscale, t)
+        call line_scaled(backend, q3, pos, whi, pos, xscale, yscale, t)
+        ! Caps
+        call line_scaled(backend, wlo, pos - capw, wlo, pos + capw, xscale, yscale, t)
+        call line_scaled(backend, whi, pos - capw, whi, pos + capw, xscale, yscale, t)
+    end subroutine draw_box_horizontal
+
+    subroutine draw_outliers_vertical(backend, pos, plot, xscale, yscale, t)
+        class(plot_context), intent(inout) :: backend
+        real(wp), intent(in) :: pos
+        type(plot_data_t), intent(in) :: plot
+        character(len=*), intent(in) :: xscale, yscale
+        real(wp), intent(in) :: t
+        integer :: i
+        real(wp) :: xs, ys
+
+        if (.not. allocated(plot%outliers)) return
+        do i = 1, size(plot%outliers)
+            xs = apply_scale_transform(pos, xscale, t)
+            ys = apply_scale_transform(plot%outliers(i), yscale, t)
+            call backend%draw_marker(xs, ys, 'o')
+        end do
+    end subroutine draw_outliers_vertical
+
+    subroutine draw_outliers_horizontal(backend, pos, plot, xscale, yscale, t)
+        class(plot_context), intent(inout) :: backend
+        real(wp), intent(in) :: pos
+        type(plot_data_t), intent(in) :: plot
+        character(len=*), intent(in) :: xscale, yscale
+        real(wp), intent(in) :: t
+        integer :: i
+        real(wp) :: xs, ys
+
+        if (.not. allocated(plot%outliers)) return
+        do i = 1, size(plot%outliers)
+            xs = apply_scale_transform(plot%outliers(i), xscale, t)
+            ys = apply_scale_transform(pos, yscale, t)
+            call backend%draw_marker(xs, ys, 'o')
+        end do
+    end subroutine draw_outliers_horizontal
+
+    subroutine line_scaled(backend, x1, y1, x2, y2, xscale, yscale, t)
+        class(plot_context), intent(inout) :: backend
+        real(wp), intent(in) :: x1, y1, x2, y2
+        character(len=*), intent(in) :: xscale, yscale
+        real(wp), intent(in) :: t
+        real(wp) :: xs1, ys1, xs2, ys2
+        xs1 = apply_scale_transform(x1, xscale, t)
+        ys1 = apply_scale_transform(y1, yscale, t)
+        xs2 = apply_scale_transform(x2, xscale, t)
+        ys2 = apply_scale_transform(y2, yscale, t)
+        call backend%line(xs1, ys1, xs2, ys2)
+    end subroutine line_scaled
+
+end module fortplot_boxplot_rendering
+

--- a/src/backends/memory/fortplot_boxplot_rendering.f90
+++ b/src/backends/memory/fortplot_boxplot_rendering.f90
@@ -52,7 +52,7 @@ contains
         character(len=*), intent(in) :: xscale, yscale
         real(wp), intent(in) :: t
         real(wp) :: x0, x1
-        real(wp) :: xs0, xs1, ys0, ys1
+        ! no temporaries needed; transform per segment for cache friendliness
 
         x0 = pos - halfw; x1 = pos + halfw
 
@@ -147,4 +147,3 @@ contains
     end subroutine line_scaled
 
 end module fortplot_boxplot_rendering
-

--- a/src/backends/memory/fortplot_rendering.f90
+++ b/src/backends/memory/fortplot_rendering.f90
@@ -9,6 +9,7 @@ module fortplot_rendering
     use fortplot_marker_rendering
     use fortplot_contour_rendering
     use fortplot_mesh_rendering
+    use fortplot_boxplot_rendering
     implicit none
     
     private
@@ -16,6 +17,7 @@ module fortplot_rendering
     public :: render_contour_plot
     public :: render_pcolormesh_plot
     public :: render_fill_between_plot
+    public :: render_boxplot_plot
     public :: render_markers
     public :: render_solid_line
     public :: draw_filled_quad

--- a/src/figures/plot_types/fortplot_figure_boxplot.f90
+++ b/src/figures/plot_types/fortplot_figure_boxplot.f90
@@ -110,7 +110,6 @@ contains
     
     subroutine compute_boxplot_stats_inplace(plot)
         !! Compute quartiles, whiskers, and outliers for a box plot in-place
-        use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
         type(plot_data_t), intent(inout) :: plot
         real(wp), allocatable :: sorted(:)
         integer :: n, i, q1_idx, q2_idx, q3_idx, n_out

--- a/test/test_boxplot_outliers.f90
+++ b/test/test_boxplot_outliers.f90
@@ -1,0 +1,60 @@
+program test_boxplot_outliers
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    use fortplot, only: figure_t
+    implicit none
+
+    type(figure_t) :: fig
+    real(wp), parameter :: data(6) = [1.0_wp, 2.0_wp, 3.0_wp, 4.0_wp, 5.0_wp, 20.0_wp]
+
+    call fig%initialize(400,300)
+    call fig%boxplot(data, position=1.0_wp, show_outliers=.true.)
+
+    if (fig%plot_count /= 1) then
+        print *, 'FAIL: plot_count expected 1, got', fig%plot_count
+        stop 1
+    end if
+
+    if (.not. allocated(fig%plots(1)%outliers)) then
+        print *, 'FAIL: outliers not allocated'
+        stop 1
+    end if
+
+    if (size(fig%plots(1)%outliers) /= 1) then
+        print *, 'FAIL: expected 1 outlier, got', size(fig%plots(1)%outliers)
+        stop 1
+    end if
+
+    if (abs(fig%plots(1)%outliers(1) - 20.0_wp) > 1.0e-6_wp) then
+        print *, 'FAIL: outlier value unexpected:', fig%plots(1)%outliers(1)
+        stop 1
+    end if
+
+    if (fig%plots(1)%whisker_high > 5.0_wp + 1.0e-6_wp) then
+        print *, 'FAIL: whisker_high exceeds inlier max:', fig%plots(1)%whisker_high
+        stop 1
+    end if
+
+    ! Horizontal flag should not affect statistics computation
+    block
+        type(figure_t) :: fig2
+        call fig2%initialize(400,300)
+        call fig2%boxplot(data, position=1.0_wp, show_outliers=.true., horizontal=.true.)
+
+        if (.not. allocated(fig2%plots(1)%outliers)) then
+            print *, 'FAIL: outliers not allocated (horizontal)'
+            stop 1
+        end if
+
+        if (size(fig2%plots(1)%outliers) /= 1) then
+            print *, 'FAIL: expected 1 outlier (horizontal), got', size(fig2%plots(1)%outliers)
+            stop 1
+        end if
+
+        if (abs(fig2%plots(1)%outliers(1) - 20.0_wp) > 1.0e-6_wp) then
+            print *, 'FAIL: outlier value unexpected (horizontal):', fig2%plots(1)%outliers(1)
+            stop 1
+        end if
+    end block
+
+    print *, 'Boxplot outliers test PASSED'
+end program test_boxplot_outliers

--- a/test/test_boxplot_stats.f90
+++ b/test/test_boxplot_stats.f90
@@ -1,0 +1,34 @@
+program test_boxplot_stats
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    use fortplot, only: figure_t
+    implicit none
+
+    type(figure_t) :: fig
+    real(wp), parameter :: data(10) = [1.0_wp,2.0_wp,3.0_wp,4.0_wp,5.0_wp,6.0_wp,7.0_wp,8.0_wp,9.0_wp,10.0_wp]
+
+    call fig%initialize(400,300)
+    call fig%boxplot(data, position=1.0_wp)
+
+    if (fig%plot_count /= 1) then
+        print *, 'FAIL: plot_count expected 1, got', fig%plot_count
+        stop 1
+    end if
+
+    if (.not. allocated(fig%plots(1)%box_data)) then
+        print *, 'FAIL: box_data not allocated'
+        stop 1
+    end if
+
+    if (abs(fig%plots(1)%q2 - 5.0_wp) > 1.0e-6_wp .and. abs(fig%plots(1)%q2 - 6.0_wp) > 1.0e-6_wp) then
+        print *, 'FAIL: median (q2) not set as expected: ', fig%plots(1)%q2
+        stop 1
+    end if
+
+    if (fig%plots(1)%whisker_low < 1.0_wp - 1e-6_wp .or. fig%plots(1)%whisker_high > 10.0_wp + 1e-6_wp) then
+        print *, 'FAIL: whiskers not within data range'
+        stop 1
+    end if
+
+    print *, 'Boxplot stats test PASSED'
+end program test_boxplot_stats
+


### PR DESCRIPTION
fix: Box plots not working at all (fixes #1311)

Summary
- Add full box plot rendering support across backends.
- Compute quartiles, whiskers, and outliers in core figure path.
- Integrate boxplot into range calc and rendering pipeline.
- Update Fortran example to actually render boxplots.
- Add a fast test verifying stats are populated.

Key Changes
- src/backends/memory/fortplot_boxplot_rendering.f90: New renderer (box, whiskers, caps, outliers; vertical/horizontal).
- src/backends/memory/fortplot_rendering.f90: Export render_boxplot_plot.
- src/figures/fortplot_figure_rendering_pipeline.f90: Handle PLOT_TYPE_BOXPLOT in ranges and rendering.
- src/figures/plot_types/fortplot_figure_boxplot.f90: Compute stats in-place when adding a boxplot.
- example/fortran/boxplot_demo/boxplot_demo.f90: Replace stub line plots with actual boxplot() calls.
- test/test_boxplot_stats.f90: New minimal test to exercise stats.

Verification
Commands run locally:
- make test-ci
  ✓ All CI-fast tests passed.
- make example ARGS="boxplot_demo"
  ✓ Created outputs:
    - output/example/fortran/boxplot_demo/boxplot_demo.png (size ~15 KB)
    - output/example/fortran/boxplot_demo/boxplot_demo.pdf
    - output/example/fortran/boxplot_demo/boxplot_demo.txt
- make verify-artifacts
  ✓ Artifact verification passed (math/unicode checks, pcolormesh, scale tokens).

Selected Excerpts
- Boxplot example output exists and is non-empty:
  ls -l output/example/fortran/boxplot_demo/boxplot_demo.png → size 15492
- Tests include new boxplot stats check:
  test/test_boxplot_stats.f90 ensures median and whiskers are populated.

Notes
- Public API preserved (matplotlib-style `boxplot` and `figure%boxplot`).
- Rendering uses existing scaling and context utilities; no backend-specific forks needed.

---

Reviewer additions
- Added test/test_boxplot_outliers.f90 to assert outlier detection and whisker bounds.
- Ran make test-ci, make test, make example ARGS="boxplot_demo", and make verify-artifacts — all passed.
- Evidence: ls -l output/example/fortran/boxplot_demo/boxplot_demo.png → 15492 bytes
- Code cleanup: removed unused variables/import in boxplot modules.
