### PR TITLE
fix: Mathtext doesnt work everywhere (fixes #1315)

### DIFF
--- a/src/backends/raster/fortplot_raster_labels.f90
+++ b/src/backends/raster/fortplot_raster_labels.f90
@@ -7,6 +7,7 @@ module fortplot_raster_labels
                                         render_text_with_size, TITLE_FONT_SIZE
     use fortplot_latex_parser, only: process_latex_in_text
     use fortplot_unicode, only: escape_unicode_for_raster
+    use fortplot_text_helpers, only: prepare_mathtext_if_needed
     use fortplot_margins, only: plot_area_t
     use fortplot_raster_core, only: raster_image_t
     use fortplot_bitmap, only: render_text_to_bitmap, rotate_bitmap_90_ccw, composite_bitmap_to_raster
@@ -33,8 +34,10 @@ contains
         integer, intent(in) :: width, height
         type(plot_area_t), intent(in) :: plot_area
         character(len=*), intent(in) :: title, xlabel, ylabel
-        character(len=500) :: processed_text, escaped_text
-        integer :: label_x, label_y, processed_len
+        character(len=500) :: processed_text
+        character(len=600) :: math_ready
+        character(len=600) :: escaped_text
+        integer :: label_x, label_y, processed_len, math_len
         integer :: label_width, label_height
 
         ! Title at top
@@ -45,7 +48,8 @@ contains
         ! X label at bottom
         if (len_trim(xlabel) > 0) then
             call process_latex_in_text(trim(xlabel), processed_text, processed_len)
-            call escape_unicode_for_raster(processed_text(1:processed_len), escaped_text)
+            call prepare_mathtext_if_needed(processed_text(1:processed_len), math_ready, math_len)
+            call escape_unicode_for_raster(math_ready(1:math_len), escaped_text)
             label_width = calculate_text_width(trim(escaped_text))
             label_height = calculate_text_height(trim(escaped_text))
             label_x = plot_area%left + plot_area%width/2 - label_width/2
@@ -67,8 +71,10 @@ contains
         integer, intent(in) :: width, height
         type(plot_area_t), intent(in) :: plot_area
         character(len=*), intent(in) :: ylabel
-        character(len=500) :: processed_text, escaped_text
-        integer :: processed_len
+        character(len=500) :: processed_text
+        character(len=600) :: math_ready
+        character(len=600) :: escaped_text
+        integer :: processed_len, math_len
         integer(1), allocatable :: text_bitmap(:,:,:), rotated_bitmap(:,:,:)
         integer :: text_width, text_height, text_descent
         integer :: rotated_width, rotated_height
@@ -79,7 +85,8 @@ contains
 
         ! Process LaTeX
         call process_latex_in_text(trim(ylabel), processed_text, processed_len)
-        call escape_unicode_for_raster(processed_text(1:processed_len), escaped_text)
+        call prepare_mathtext_if_needed(processed_text(1:processed_len), math_ready, math_len)
+        call escape_unicode_for_raster(math_ready(1:math_len), escaped_text)
 
         ! Calculate text dimensions
         text_width = calculate_text_width(trim(escaped_text))
@@ -155,8 +162,10 @@ contains
         integer, intent(in) :: width, height
         type(plot_area_t), intent(in) :: plot_area
         character(len=*), intent(in) :: title_text
-        character(len=500) :: processed_text, escaped_text
-        integer :: processed_len
+        character(len=500) :: processed_text
+        character(len=600) :: math_ready
+        character(len=600) :: escaped_text
+        integer :: processed_len, math_len
         integer :: title_px, title_py
         real(wp) :: title_px_real, title_py_real
 
@@ -181,9 +190,12 @@ contains
         integer, intent(out) :: processed_len
         real(wp), intent(out) :: title_px, title_py
         integer :: title_width
+        character(len=600) :: math_ready
+        integer :: math_len
 
         call process_latex_in_text(trim(title_text), processed_text, processed_len)
-        call escape_unicode_for_raster(processed_text(1:processed_len), escaped_text)
+        call prepare_mathtext_if_needed(processed_text(1:processed_len), math_ready, math_len)
+        call escape_unicode_for_raster(math_ready(1:math_len), escaped_text)
 
         ! Calculate text width using the larger title font size
         title_width = calculate_text_width_with_size(trim(escaped_text), real(TITLE_FONT_SIZE, wp))

--- a/src/backends/raster/fortplot_raster_ticks.f90
+++ b/src/backends/raster/fortplot_raster_ticks.f90
@@ -5,6 +5,7 @@ module fortplot_raster_ticks
     use fortplot_text_rendering, only: render_text_to_image, calculate_text_width, calculate_text_height
     use fortplot_latex_parser, only: process_latex_in_text
     use fortplot_unicode, only: escape_unicode_for_raster
+    use fortplot_text_helpers, only: prepare_mathtext_if_needed
     use fortplot_margins, only: plot_area_t
     use fortplot_raster_line_styles, only: draw_styled_line
     use fortplot_raster_core, only: raster_image_t
@@ -174,8 +175,10 @@ contains
         integer :: tick_x, label_x, label_y, j
         integer :: label_width, label_height
         real(wp) :: min_t, max_t, tick_t
-        character(len=500) :: processed_text, escaped_text
-        integer :: processed_len
+        character(len=500) :: processed_text
+        character(len=600) :: math_ready
+        character(len=600) :: escaped_text
+        integer :: processed_len, math_len
 
         ! Draw x-axis tick labels with overlap prevention
         min_t = apply_scale_transform(x_min, xscale, symlog_threshold)
@@ -197,7 +200,8 @@ contains
 
             ! Process LaTeX (allocation handled internally)
             call process_latex_in_text(trim(xtick_labels(j)), processed_text, processed_len)
-            call escape_unicode_for_raster(processed_text(1:processed_len), escaped_text)
+            call prepare_mathtext_if_needed(processed_text(1:processed_len), math_ready, math_len)
+            call escape_unicode_for_raster(math_ready(1:math_len), escaped_text)
 
             label_width = calculate_text_width(trim(escaped_text))
             label_height = calculate_text_height(trim(escaped_text))
@@ -224,8 +228,10 @@ contains
         integer :: tick_y, label_x, label_y, j
         integer :: label_width, label_height
         real(wp) :: min_t, max_t, tick_t
-        character(len=500) :: processed_text, escaped_text
-        integer :: processed_len
+        character(len=500) :: processed_text
+        character(len=600) :: math_ready
+        character(len=600) :: escaped_text
+        integer :: processed_len, math_len
 
         ! Draw y-axis tick labels
         min_t = apply_scale_transform(y_min, yscale, symlog_threshold)
@@ -242,7 +248,8 @@ contains
 
             ! Process LaTeX (allocation handled internally)
             call process_latex_in_text(trim(ytick_labels(j)), processed_text, processed_len)
-            call escape_unicode_for_raster(processed_text(1:processed_len), escaped_text)
+            call prepare_mathtext_if_needed(processed_text(1:processed_len), math_ready, math_len)
+            call escape_unicode_for_raster(math_ready(1:math_len), escaped_text)
 
             label_width = calculate_text_width(trim(escaped_text))
             label_height = calculate_text_height(trim(escaped_text))

--- a/src/text/fortplot_text_helpers.f90
+++ b/src/text/fortplot_text_helpers.f90
@@ -1,0 +1,51 @@
+module fortplot_text_helpers
+    !! Small helpers for preparing text for backends
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    use fortplot_text_layout, only: has_mathtext
+    implicit none
+
+    private
+    public :: prepare_mathtext_if_needed
+
+contains
+
+    subroutine prepare_mathtext_if_needed(input_text, output_text, out_len)
+        !! If text contains ^ or _ but no $...$, wrap with $ delimiters
+        !! so downstream mathtext-aware renderers parse superscripts/subscripts.
+        character(len=*), intent(in) :: input_text
+        character(len=*), intent(out) :: output_text
+        integer, intent(out) :: out_len
+        character(len=:), allocatable :: trimmed
+        integer :: n
+
+        trimmed = trim(input_text)
+        n = len_trim(trimmed)
+
+        if (n <= 0) then
+            output_text = ''
+            out_len = 0
+            return
+        end if
+
+        if (has_mathtext(trimmed)) then
+            ! Already mathtext-delimited
+            output_text = trimmed
+            out_len = n
+        else if (index(trimmed, '^') > 0 .or. index(trimmed, '_') > 0) then
+            ! Add $ delimiters to engage mathtext pipeline in raster layout/renderers
+            if (len(output_text) >= n + 2) then
+                output_text = '$' // trimmed(1:n) // '$'
+                out_len = n + 2
+            else
+                ! Fallback: truncate safely if caller provided too-small buffer
+                output_text = '$' // trimmed(1:min(n, max(0, len(output_text)-2))) // '$'
+                out_len = min(n, max(0, len(output_text)-2)) + 2
+            end if
+        else
+            output_text = trimmed
+            out_len = n
+        end if
+    end subroutine prepare_mathtext_if_needed
+
+end module fortplot_text_helpers
+

--- a/test/test_text_helpers_mathtext_wrap.f90
+++ b/test/test_text_helpers_mathtext_wrap.f90
@@ -1,0 +1,34 @@
+program test_text_helpers_mathtext_wrap
+    use fortplot_text_helpers, only: prepare_mathtext_if_needed
+    implicit none
+
+    character(len=256) :: out
+    integer :: n
+
+    call prepare_mathtext_if_needed('x^3', out, n)
+    if (out(1:n) /= '$x^3$') then
+        print *, 'FAIL: x^3 should wrap to $x^3$'
+        stop 1
+    end if
+
+    call prepare_mathtext_if_needed('x_1', out, n)
+    if (out(1:n) /= '$x_1$') then
+        print *, 'FAIL: x_1 should wrap to $x_1$'
+        stop 1
+    end if
+
+    call prepare_mathtext_if_needed('$x^3$', out, n)
+    if (out(1:n) /= '$x^3$') then
+        print *, 'FAIL: $x^3$ should remain unchanged'
+        stop 1
+    end if
+
+    call prepare_mathtext_if_needed('hello', out, n)
+    if (out(1:n) /= 'hello') then
+        print *, 'FAIL: plain text should remain unchanged'
+        stop 1
+    end if
+
+    print *, 'PASS: prepare_mathtext_if_needed wraps as expected'
+end program test_text_helpers_mathtext_wrap
+


### PR DESCRIPTION
fix: Mathtext doesnt work everywhere (fixes #1315)

Verification:
- Baseline CI-fast: make test-ci (all green)
- Full test run: make test (all green)
- Full artifact check: make verify-artifacts (all green)
- Key excerpts:
  - [ok] symlog ylabel shows superscript three (unicode)
  - PNG/PDF examples generated without errors; raster text now parses ^/_

Commands:
- make test-ci
- make test
- make verify-artifacts

Reviewer updates:
- Added targeted unit test for helper logic: test/test_text_helpers_mathtext_wrap.f90
  - Verifies wrapping behavior: "x^3" -> "$x^3$", "x_1" -> "$x_1$"; leaves "$x^3$" and "hello" unchanged.
- Confirmed all tests and artifact checks pass locally.

Evidence snippets:
- verify-artifacts: [ok] symlog ylabel shows superscript three (unicode)
- unit test: PASS: prepare_mathtext_if_needed wraps as expected
