### PR TITLE
fix: Grid works only sometimes (fixes #1326)

### DIFF
--- a/doc/examples/grid_demo.md
+++ b/doc/examples/grid_demo.md
@@ -8,7 +8,7 @@ Source: [grid_demo.f90](https://github.com/lazy-fortran/fortplot/blob/main/examp
 Demonstrates grid functionality for enhanced plot readability.
 
 - `grid_demo.f90` - Source code
-- `grid_plot.png/pdf/txt` - Example outputs
+- `grid_demo.png/pdf/txt` - Example outputs
 
 - **Grid lines**: Major and minor grid lines
 - **Grid customization**: Line styles, colors, transparency
@@ -42,4 +42,3 @@ ASCII output:
 [Download ASCII](../../media/examples/grid_demo/grid_demo.txt)
 
 [Download PDF](../../media/examples/grid_demo/grid_demo.pdf)
-

--- a/example/fortran/grid_demo/README.md
+++ b/example/fortran/grid_demo/README.md
@@ -8,7 +8,7 @@ Demonstrates grid functionality for enhanced plot readability.
 ## Files
 
 - `grid_demo.f90` - Source code
-- `grid_plot.png/pdf/txt` - Example outputs
+- `grid_demo.png/pdf/txt` - Example outputs
 
 ## Running
 

--- a/example/fortran/grid_demo/grid_demo.f90
+++ b/example/fortran/grid_demo/grid_demo.f90
@@ -23,7 +23,11 @@ program grid_demo
     call title('Basic Plot - Grid Demo')
     call xlabel('Time (s)')
     call ylabel('Amplitude')
-    ! Note: Grid functionality is not available in current API
+    
+    ! Enable grid lines to demonstrate the feature
+    ! Default: major grid on both axes
+    call grid(.true.)
+
     call savefig('output/example/fortran/grid_demo/grid_demo.png')
     call savefig('output/example/fortran/grid_demo/grid_demo.pdf')
     call savefig('output/example/fortran/grid_demo/grid_demo.txt')

--- a/scripts/verify_artifacts.sh
+++ b/scripts/verify_artifacts.sh
@@ -17,6 +17,7 @@ fpm run --example test_pdf_scale_regression >/dev/null
 fpm run --example subplots_grid_demo >/dev/null
 fpm run --example unicode_demo >/dev/null
 fpm run --example show_viewer_demo >/dev/null || true
+fpm run --example grid_demo >/dev/null
 
 check_pdf_ok() {
   local pdf=$1
@@ -169,6 +170,22 @@ for pdf in \
     exit 1
   fi
 done
+
+# Grid demo: ensure outputs exist and ASCII export shows grid structure
+if [[ -f output/example/fortran/grid_demo/grid_demo.png ]]; then
+  check_png_size output/example/fortran/grid_demo/grid_demo.png 4000
+fi
+if [[ -f output/example/fortran/grid_demo/grid_demo.pdf ]]; then
+  check_pdf_ok output/example/fortran/grid_demo/grid_demo.pdf
+  check_pdftotext_has output/example/fortran/grid_demo/grid_demo.pdf "Basic Plot - Grid Demo"
+fi
+if [[ -f output/example/fortran/grid_demo/grid_demo.txt ]]; then
+  # Heuristic: ASCII grid should contain repeated separators and vertical bars
+  if ! grep -Eq "#:#:#:#|\|\s+\|" output/example/fortran/grid_demo/grid_demo.txt; then
+    echo "ERROR: grid_demo.txt does not appear to contain grid lines" >&2
+    exit 1
+  fi
+fi
 
 # A couple PNG size checks as non-empty proxy
 check_png_size output/example/fortran/marker_demo/all_marker_types.png 8000


### PR DESCRIPTION
Verification

Commands run:
- make test-ci
- make verify-artifacts
- make example ARGS="grid_demo"

Key outputs:
- CI-fast tests: all passed (core, backends, histogram, PDF checks)
- verify-artifacts: now runs grid_demo and asserts ASCII grid presence
  - [png] output/example/fortran/grid_demo/grid_demo.png size=42643
  - [pdftotext] asserting needle=Basic Plot - Grid Demo in output/example/fortran/grid_demo/grid_demo.pdf
  - grid_demo.txt contains repeated grid separators (e.g., '#:#:#:#' and vertical bars)

Artifacts:
- output/example/fortran/grid_demo/grid_demo.png
- output/example/fortran/grid_demo/grid_demo.pdf
- output/example/fortran/grid_demo/grid_demo.txt

Additional changes in this PR:
- test: verify grid_demo artifacts in scripts/verify_artifacts.sh
- docs: fix example names to grid_demo.png/pdf/txt in docs/READMEs
