### PR TITLE
fix: sqrt symbol not rendered at all in PDF (fixes #1324)

### DIFF
--- a/src/backends/vector/fortplot_pdf_mathtext_render.f90
+++ b/src/backends/vector/fortplot_pdf_mathtext_render.f90
@@ -1,8 +1,8 @@
 module fortplot_pdf_mathtext_render
     !! PDF mathtext rendering utilities
 
-    use iso_fortran_env, only: wp => real64
-    use fortplot_mathtext, only: mathtext_element_t, parse_mathtext
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    use fortplot_mathtext, only: mathtext_element_t, parse_mathtext, ELEMENT_SQRT
     use fortplot_latex_parser, only: process_latex_in_text
     use fortplot_pdf_core, only: pdf_context_core, PDF_LABEL_SIZE
     use fortplot_pdf_text_render, only: draw_mixed_font_text
@@ -57,7 +57,7 @@ contains
         elem_y = baseline_y + element%vertical_offset * base_font_size
 
         ! Handle square root specially by drawing the radical (check mark + overbar)
-        if (element%element_type == 3) then
+        if (element%element_type == ELEMENT_SQRT) then
             ! Width of radical symbol and radicand
             sym_w = 0.6_wp * elem_font_size
             rad_width = estimate_pdf_text_width(element%text, elem_font_size)
@@ -129,15 +129,6 @@ contains
         x_pos = x_pos + char_width
     end subroutine render_mathtext_element_pdf
 
-    subroutine render_text_with_unicode_superscripts(this, x, y, text, font_size)
-        class(pdf_context_core), intent(inout) :: this
-        real(wp), intent(in) :: x, y
-        character(len=*), intent(in) :: text
-        real(wp), intent(in) :: font_size
-
-        call draw_mixed_font_text(this, x, y, text, font_size)
-    end subroutine render_text_with_unicode_superscripts
-
     subroutine render_mathtext_with_unicode_superscripts(this, x, y, text, font_size)
         class(pdf_context_core), intent(inout) :: this
         real(wp), intent(in) :: x, y
@@ -158,7 +149,6 @@ contains
     end subroutine render_mathtext_with_unicode_superscripts
 
     pure function to_move_cmd(x, y) result(cmd)
-        use iso_fortran_env, only: wp => real64
         real(wp), intent(in) :: x, y
         character(len=64) :: cmd
         write(cmd, '(F0.3,1X,F0.3,1X,A)') x, y, 'm'
@@ -166,7 +156,6 @@ contains
     end function to_move_cmd
 
     pure function to_line_cmd(x, y) result(cmd)
-        use iso_fortran_env, only: wp => real64
         real(wp), intent(in) :: x, y
         character(len=64) :: cmd
         write(cmd, '(F0.3,1X,F0.3,1X,A)') x, y, 'l'

--- a/src/backends/vector/fortplot_pdf_mathtext_render.f90
+++ b/src/backends/vector/fortplot_pdf_mathtext_render.f90
@@ -9,6 +9,7 @@ module fortplot_pdf_mathtext_render
     use fortplot_pdf_text_segments, only: render_mixed_font_at_position
     use fortplot_unicode, only: utf8_to_codepoint, utf8_char_length
     use fortplot_text_layout, only: preprocess_math_text
+    use fortplot_pdf_text_metrics, only: estimate_pdf_text_width
     implicit none
     private
 
@@ -50,9 +51,49 @@ contains
         real(wp) :: elem_font_size, elem_y
         real(wp) :: char_width
         integer :: i, codepoint, char_len
+        real(wp) :: sym_w, rad_width, top_y
 
         elem_font_size = base_font_size * element%font_size_ratio
         elem_y = baseline_y + element%vertical_offset * base_font_size
+
+        ! Handle square root specially by drawing the radical (check mark + overbar)
+        if (element%element_type == 3) then
+            ! Width of radical symbol and radicand
+            sym_w = 0.6_wp * elem_font_size
+            rad_width = estimate_pdf_text_width(element%text, elem_font_size)
+
+            ! Place overbar slightly above baseline by approximately one font size
+            top_y = baseline_y + elem_font_size
+
+            ! Exit text object, draw path for radical, then re-enter text object
+            this%stream_data = this%stream_data // 'ET' // new_line('a')
+
+            ! Use current stroke settings; draw the two slanted ticks and horizontal bar
+            block
+                character(len=64) :: cmd
+                cmd = to_move_cmd(x_pos, baseline_y)
+                this%stream_data = this%stream_data // trim(adjustl(cmd)) // new_line('a')
+
+                cmd = to_line_cmd(x_pos + sym_w/2.0_wp, baseline_y + sym_w/2.0_wp)
+                this%stream_data = this%stream_data // trim(adjustl(cmd)) // new_line('a')
+
+                cmd = to_line_cmd(x_pos + sym_w, top_y)
+                this%stream_data = this%stream_data // trim(adjustl(cmd)) // new_line('a')
+
+                cmd = to_line_cmd(x_pos + sym_w + rad_width, top_y)
+                this%stream_data = this%stream_data // trim(adjustl(cmd)) // new_line('a')
+
+                this%stream_data = this%stream_data // 'S' // new_line('a')
+            end block
+
+            ! Re-enter text mode for the radicand
+            this%stream_data = this%stream_data // 'BT' // new_line('a')
+            call render_mixed_font_at_position(this, x_pos + sym_w, elem_y, &
+                 element%text, elem_font_size)
+
+            x_pos = x_pos + sym_w + rad_width
+            return
+        end if
 
         call render_mixed_font_at_position(this, x_pos, elem_y, element%text, &
             elem_font_size)
@@ -116,4 +157,19 @@ contains
         this%stream_data = this%stream_data // 'ET' // new_line('a')
     end subroutine render_mathtext_with_unicode_superscripts
 
+    pure function to_move_cmd(x, y) result(cmd)
+        use iso_fortran_env, only: wp => real64
+        real(wp), intent(in) :: x, y
+        character(len=64) :: cmd
+        write(cmd, '(F0.3,1X,F0.3,1X,A)') x, y, 'm'
+        cmd = trim(adjustl(cmd))
+    end function to_move_cmd
+
+    pure function to_line_cmd(x, y) result(cmd)
+        use iso_fortran_env, only: wp => real64
+        real(wp), intent(in) :: x, y
+        character(len=64) :: cmd
+        write(cmd, '(F0.3,1X,F0.3,1X,A)') x, y, 'l'
+        cmd = trim(adjustl(cmd))
+    end function to_line_cmd
 end module fortplot_pdf_mathtext_render

--- a/src/backends/vector/fortplot_pdf_text_metrics.f90
+++ b/src/backends/vector/fortplot_pdf_text_metrics.f90
@@ -1,8 +1,8 @@
 module fortplot_pdf_text_metrics
     !! PDF text measurement helpers
 
-    use iso_fortran_env, only: wp => real64
-    use fortplot_mathtext, only: mathtext_element_t, parse_mathtext
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    use fortplot_mathtext, only: mathtext_element_t, parse_mathtext, ELEMENT_SQRT
     use fortplot_text_layout, only: has_mathtext, preprocess_math_text
     use fortplot_pdf_core, only: PDF_LABEL_SIZE
     use fortplot_unicode, only: utf8_to_codepoint, utf8_char_length, check_utf8_sequence
@@ -101,7 +101,7 @@ contains
         elem_font_size = base_font_size * element%font_size_ratio
 
         ! Include radical head width for sqrt elements, then measure radicand recursively
-        if (element%element_type == 3) then
+        if (element%element_type == ELEMENT_SQRT) then
             w = w + 0.6_wp * elem_font_size
             w = w + estimate_mathtext_width(element%text, elem_font_size)
             return

--- a/src/backends/vector/fortplot_pdf_text_metrics.f90
+++ b/src/backends/vector/fortplot_pdf_text_metrics.f90
@@ -99,6 +99,14 @@ contains
 
         w = 0.0_wp
         elem_font_size = base_font_size * element%font_size_ratio
+
+        ! Include radical head width for sqrt elements, then measure radicand recursively
+        if (element%element_type == 3) then
+            w = w + 0.6_wp * elem_font_size
+            w = w + estimate_mathtext_width(element%text, elem_font_size)
+            return
+        end if
+
         i = 1
         do while (i <= len_trim(element%text))
             char_len = utf8_char_length(element%text(i:i))

--- a/src/text/fortplot_mathtext.f90
+++ b/src/text/fortplot_mathtext.f90
@@ -8,6 +8,7 @@ module fortplot_mathtext
     private
     public :: mathtext_element_t, parse_mathtext, render_mathtext_elements
     public :: calculate_mathtext_width, calculate_mathtext_height
+    public :: ELEMENT_NORMAL, ELEMENT_SUPERSCRIPT, ELEMENT_SUBSCRIPT, ELEMENT_SQRT
 
     ! Mathematical text element types
     integer, parameter :: ELEMENT_NORMAL = 0

--- a/test/test_pdf_mathtext_sqrt_rendering.f90
+++ b/test/test_pdf_mathtext_sqrt_rendering.f90
@@ -1,0 +1,53 @@
+program test_pdf_mathtext_sqrt_rendering
+    !! Verify that LaTeX-style \sqrt{} renders in PDF (radical shape + radicand)
+    use fortplot
+    use test_pdf_utils, only: extract_pdf_stream_text
+    use fortplot_validation, only: validation_result_t, validate_file_exists
+    implicit none
+
+    character(len=:), allocatable :: stream_text
+    integer :: status
+    type(validation_result_t) :: val
+    character(len=*), parameter :: outfile = 'test/output/test_pdf_math_sqrt.pdf'
+
+    call figure()
+    call plot([0.0d0, 1.0d0], [0.0d0, 1.0d0])
+    ! Use LaTeX-style sqrt so it goes through mathtext parser
+    call title('PDF math sqrt: \sqrt{x}')
+    call legend()
+    call savefig(outfile)
+
+    val = validate_file_exists(outfile)
+    if (.not. val%passed) then
+        print *, 'FAIL: PDF file not created for math sqrt test'
+        stop 1
+    end if
+
+    call extract_pdf_stream_text(outfile, stream_text, status)
+    if (status /= 0) then
+        print *, 'FAIL: Could not extract PDF stream for math sqrt test'
+        stop 1
+    end if
+
+    ! Ensure the raw command string "\\sqrt" is not emitted to the PDF text stream
+    if (index(stream_text, '\\sqrt') > 0) then
+        print *, 'FAIL: Literal \\sqrt found in PDF stream (mathtext not applied)'
+        stop 1
+    end if
+
+    ! Ensure radicand 'x' is present as a text segment
+    if (index(stream_text, '(x) Tj') == 0) then
+        print *, 'FAIL: Expected radicand text segment (x) not found'
+        stop 1
+    end if
+
+    ! Heuristic: stream should contain at least one stroke command associated
+    ! with the radical path drawing near the text section.
+    if (index(stream_text, ' S') == 0 .and. index(stream_text, '\nS\n') == 0) then
+        print *, 'FAIL: Expected stroke command for radical not found'
+        stop 1
+    end if
+
+    print *, 'PASS: LaTeX-style \\sqrt{} renders in PDF (no literal fallback)'
+end program test_pdf_mathtext_sqrt_rendering
+

--- a/test/test_pdf_text_sqrt_width.f90
+++ b/test/test_pdf_text_sqrt_width.f90
@@ -1,0 +1,25 @@
+program test_pdf_text_sqrt_width
+    !! Verify PDF text width accounts for sqrt radical head
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    use fortplot_pdf_text, only: estimate_pdf_text_width
+    implicit none
+
+    real(wp) :: w_x, w_sqrt
+    real(wp), parameter :: fs = 12.0_wp
+
+    w_x = estimate_pdf_text_width('x', fs)
+    w_sqrt = estimate_pdf_text_width('\\sqrt{x}', fs)
+
+    if (w_x <= 0.0_wp .or. w_sqrt <= 0.0_wp) then
+        print *, 'FAIL: expected positive widths (x=', w_x, ', sqrt=', w_sqrt, ')'
+        stop 1
+    end if
+
+    if (w_sqrt <= w_x) then
+        print *, 'FAIL: sqrt width (', w_sqrt, ') not greater than radicand width (', w_x, ')'
+        stop 1
+    end if
+
+    print *, 'PASS: sqrt width exceeds radicand width (metrics include radical head)'
+end program test_pdf_text_sqrt_width
+


### PR DESCRIPTION
fix: sqrt symbol not rendered at all in PDF (fixes #1324)

Summary
- Implement PDF mathtext rendering for LaTeX-style \sqrt{...} by drawing the radical (check mark + overbar) and then rendering the radicand at the correct baseline.
- Improve PDF text width estimation to include the radical head width for sqrt elements so legend/layout sizing is accurate.
- Add unit test test/test_pdf_mathtext_sqrt_rendering.f90 to verify that \sqrt{} strings are parsed (no literal "\\sqrt" in the content stream) and that the radicand is emitted as a text segment.

Details
- Vector backend: src/backends/vector/fortplot_pdf_mathtext_render.f90
  - Special-cases ELEMENT_SQRT: temporarily closes BT, draws the radical path using m/l/S commands, re-enters BT, renders the radicand, and advances x_pos by the combined width.
  - Uses a simple, readable sizing heuristic consistent with raster backend: radical head width = 0.6 * font size; bar height ~ one font size above baseline.
- Metrics: src/backends/vector/fortplot_pdf_text_metrics.f90
  - sqrt width now includes the radical head plus recursive width of the radicand string. This mirrors raster mathtext width logic and improves legend/layout computations.
- Tests: test/test_pdf_mathtext_sqrt_rendering.f90
  - Creates a small PDF with a title containing \sqrt{x}, saves it, extracts the PDF stream, and asserts:
    - no literal "\\sqrt" appears (parsed by mathtext),
    - the radicand '(x) Tj' is present,
    - a stroke operator is present (heuristic for the drawn radical path).

Verification
Commands run locally:
- Baseline: make test-ci
- Full: make test
- Artifacts: make verify-artifacts

Key outputs/excerpts:
- make test-ci: CI essential suite passed; PDF text/axes tests OK.
- make test: All tests passed, including new test:
  PASS: LaTeX-style \\sqrt{} renders in PDF (no literal fallback)
- verify-artifacts: All example artifact checks passed; no regressions flagged.

Artifacts to review:
- Unit test output PDF: test/output/test_pdf_math_sqrt.pdf
- Legend/title examples under output/example/fortran/* where mathtext may appear.

This change addresses #1324 by ensuring \sqrt{} is rendered correctly in PDF output and by making width estimates consistent for layout.



## Additional Tests
- Added  to verify PDF text metrics include radical head width.
- Evidence:





## Additional Tests
- Added `test/test_pdf_text_sqrt_width.f90` to verify PDF text metrics include radical head width.
- Evidence:

```
$ fpm test --target test_pdf_text_sqrt_width
PASS: sqrt width exceeds radicand width (metrics include radical head)
```

