### PR TITLE
fix: 3D plot example still looks like 3D plotting doesnt work fully (fixes #1329)

### DIFF
--- a/src/testing/fortplot_plot_data.f90
+++ b/src/testing/fortplot_plot_data.f90
@@ -144,10 +144,12 @@ module fortplot_plot_data
 contains
 
     logical function is_3d(self)
-        !! Check if plot data contains 3D information
-        !! Following KISS principle - simple check for z allocation
+        !! Check if plot represents true 3D data
+        !! A plot is 3D only when explicit 3D samples (x,y,z) are provided.
+        !! Contour/pcolormesh (z_grid over x/y grid) are 2D renderings and must not
+        !! trigger 3D axes.
         class(plot_data_t), intent(in) :: self
-        is_3d = allocated(self%z) .or. allocated(self%z_grid)
+        is_3d = allocated(self%z)
     end function is_3d
 
 end module fortplot_plot_data

--- a/src/testing/fortplot_plot_data.f90
+++ b/src/testing/fortplot_plot_data.f90
@@ -149,7 +149,15 @@ contains
         !! Contour/pcolormesh (z_grid over x/y grid) are 2D renderings and must not
         !! trigger 3D axes.
         class(plot_data_t), intent(in) :: self
-        is_3d = allocated(self%z)
+        if (allocated(self%z)) then
+            if (size(self%z) > 0) then
+                is_3d = .true.
+            else
+                is_3d = .false.
+            end if
+        else
+            is_3d = .false.
+        end if
     end function is_3d
 
 end module fortplot_plot_data

--- a/test/test_contour_is_not_3d.f90
+++ b/test/test_contour_is_not_3d.f90
@@ -1,0 +1,40 @@
+program test_contour_is_not_3d
+    !! Ensure contour/pcolormesh style data does not mark figure as 3D
+    use iso_fortran_env, only: wp => real64
+    use fortplot_plot_data, only: plot_data_t
+    implicit none
+
+    type(plot_data_t) :: plot
+
+    call setup_contour_like_plot(plot)
+
+    if (plot%is_3d()) then
+        print *, 'DEBUG: allocated(z)=', allocated(plot%z)
+        print *, 'DEBUG: allocated(z_grid)=', allocated(plot%z_grid)
+        error stop 'Contour-style plot must not be detected as 3D'
+    end if
+
+    print *, 'PASS: contour/pcolormesh data is treated as 2D'
+
+contains
+
+    subroutine setup_contour_like_plot(p)
+        type(plot_data_t), intent(inout) :: p
+        real(wp), allocatable :: x(:), y(:)
+        real(wp), allocatable :: z(:,:)
+
+        integer :: nx, ny, i, j
+
+        nx = 10; ny = 8
+        allocate(x(nx), y(ny), z(ny, nx))
+
+        x = [(real(i-1, wp), i=1,nx)]
+        y = [(real(j-1, wp), j=1,ny)]
+        z = 0.0_wp
+
+        p%x_grid = x
+        p%y_grid = y
+        p%z_grid = z
+    end subroutine setup_contour_like_plot
+
+end program test_contour_is_not_3d

--- a/test/test_is_3d_empty_allocation.f90
+++ b/test/test_is_3d_empty_allocation.f90
@@ -1,0 +1,17 @@
+program test_is_3d_empty_allocation
+    !! Ensure empty z allocation does not trigger 3D detection
+    use iso_fortran_env, only: wp => real64
+    use fortplot_figure_core, only: plot_data_t
+    implicit none
+
+    type(plot_data_t) :: plot
+
+    allocate(plot%z(0))
+    if (plot%is_3d()) then
+        error stop 'Empty z array must not be detected as 3D'
+    end if
+
+    print *, 'PASS: empty z allocation is not treated as 3D'
+
+end program test_is_3d_empty_allocation
+


### PR DESCRIPTION
fix: prevent 3D axes on 2D contour/pcolormesh (fixes #1329)

Root cause
- 3D detection used `allocated(z_grid)` which flagged 2D field plots (contour/pcolormesh) as 3D.
- Figure pipeline then rendered 3D axes and could overdraw 2D ticks/labels in the 3D example.

Changes
- plot_data_t%is_3d() now returns true only when vector `z` is allocated (true 3D samples).
- Added test `test/test_contour_is_not_3d.f90` to assert contour-like data is treated as 2D.

Verification
- Baseline fast tests:
  - make test-ci
  - All passed (core, axes, backend basics)
- Artifact checks:
  - make verify-artifacts
  - Passed; PNG/PDF structure and unicode/text excerpts validated
- Targeted test:
  - fpm test --target test_contour_is_not_3d
  - PASS: contour/pcolormesh data is treated as 2D

Artifacts
- Example outputs under `output/example/fortran/*` regenerated during CI-fast run.
  - No unintended 3D axes on contour outputs; 3D axes reserved for true 3D plots.

Notes
- Change is minimal/surgical and aligns with intent: 3D axes only when (x,y,z) samples exist.


---
Self-review updates (by Codex CLI)
- Tightened 3D detection: ignore zero-length z arrays in is_3d()
- Added test: test_is_3d_empty_allocation (PASS)
- Re-ran: make test-ci (PASS). Prior verify-artifacts run also passed locally.

Commands executed locally
- fpm test --target test_contour_is_not_3d
- fpm test --target test_is_3d_empty_allocation
- make test-ci
- make verify-artifacts
