### PR TITLE
fix: Silence SyntaxWarning in pdf_expect_token.py docstring (fixes #1339)

### DIFF
--- a/scripts/pdf_expect_token.py
+++ b/scripts/pdf_expect_token.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""
+r"""
 Search PDF content streams (handles Flate-compressed streams) for a given
 substring or regular expression. Returns 0 if pattern is found, 1 otherwise.
 
@@ -93,4 +93,3 @@ def main(argv):
 
 if __name__ == "__main__":
     sys.exit(main(sys.argv))
-


### PR DESCRIPTION
This PR silences a Python SyntaxWarning emitted during artifact verification by making the module docstring in `scripts/pdf_expect_token.py` a raw string. This avoids invalid escape sequence parsing in the example patterns.

Verification
- Baseline warning reproduction:
  - Command: `make verify-artifacts`
  - Excerpt (before fix):
    - `SyntaxWarning: invalid escape sequence '\\('`
    - `scripts/pdf_expect_token.py:11: SyntaxWarning`
- After fix:
  - Commands run (local):
    - `make test-ci`
    - `make verify-artifacts | tee /tmp/verify_artifacts_output.txt`
    - `python3 -Wall -c "import sys; sys.path.insert(0, '.'); import scripts.pdf_expect_token as m; print('OK:', bool(m))" > /tmp/wall_import_output.txt 2>&1`
  - Results:
    - No `SyntaxWarning` occurrences in `/tmp/verify_artifacts_output.txt` (checked via `rg -i SyntaxWarning`).
    - No warnings on import with `-Wall` (content of `/tmp/wall_import_output.txt` is `OK: True`).
    - Example path exercised by the verifier: `output/example/fortran/scale_examples/symlog_scale.pdf` (see `[ok] symlog ylabel shows superscript three (unicode)`).

Artifacts
- Script touched: `scripts/pdf_expect_token.py`
- No output artifacts changed; verification suite still passes.
