### PR TITLE
fix: Remove committed __pycache__ and guard against Python bytecode (fixes #1341)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,8 @@ test-fast: create_test_dirs
 test-ci:
 	$(call _timeout_notice)
 	@echo "Running CI-optimized test suite (essential tests only)$(if $(TIMEOUT_PREFIX), with timeout $(TEST_TIMEOUT),)..."
+	@# Guard: ensure no Python bytecode is tracked
+	@$(TIMEOUT_PREFIX) bash scripts/test_no_tracked_python_bytecode.sh || exit 1
 	@echo "Testing core functionality, axes, backend basics"
 	@$(TIMEOUT_PREFIX) fpm test $(FPM_FLAGS_TEST) --target test_public_api || exit 1
 	@$(TIMEOUT_PREFIX) fpm test $(FPM_FLAGS_TEST) --target test_simple_validation || exit 1

--- a/scripts/test_no_tracked_python_bytecode.sh
+++ b/scripts/test_no_tracked_python_bytecode.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Guard against Python bytecode being tracked in git
+# Fails if any '*.pyc' files or '__pycache__' directories are tracked.
+
+tracked=$(git ls-files -z | tr '\0' '\n' | rg -n '(^|/)__pycache__\/|\.pyc$' || true)
+
+if [[ -n "$tracked" ]]; then
+  echo "ERROR: Tracked Python bytecode detected:" >&2
+  echo "$tracked" >&2
+  echo "Please remove these files from git history and working tree." >&2
+  exit 1
+fi
+
+echo "OK: No tracked Python bytecode (pyc/__pycache__)"
+

--- a/scripts/test_no_tracked_python_bytecode.sh
+++ b/scripts/test_no_tracked_python_bytecode.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # Guard against Python bytecode being tracked in git
 # Fails if any '*.pyc' files or '__pycache__' directories are tracked.
 
-tracked=$(git ls-files -z | tr '\0' '\n' | rg -n '(^|/)__pycache__\/|\.pyc$' || true)
+tracked=$(git ls-files -z | tr '\0' '\n' | grep -En '(^|/)__pycache__/|\.pyc$' || true)
 
 if [[ -n "$tracked" ]]; then
   echo "ERROR: Tracked Python bytecode detected:" >&2


### PR DESCRIPTION
Summary
- Add CI guard script to prevent tracked Python bytecode (*.pyc, __pycache__/).
- Wire guard into test-ci; no functional changes to Fortran code.

Rationale
- Prevents accidental commits of transient Python artifacts.
- Keeps repository clean and avoids stale bytecode issues.

Changes
- scripts/test_no_tracked_python_bytecode.sh: new guard script (executable).
- Makefile: run guard early in `test-ci`.
- Portability: guard script uses `grep -E` (no ripgrep dependency).

Verification
- CI-optimized tests:
  Command: `make test-ci`
  Key excerpts:
  - "OK: No tracked Python bytecode (pyc/__pycache__)"
  - "CI essential test suite completed successfully"

- Bytecode guard (standalone):
  Command: `scripts/test_no_tracked_python_bytecode.sh`
  Output:
  - "OK: No tracked Python bytecode (pyc/__pycache__)"

Notes
- .gitignore already ignores these patterns; this adds a CI assertion to prevent regressions.

\n---\nLocal verification (maintainer)\n- Ran: `make test-ci` on Linux x86_64\n- Key excerpts: \n  - "OK: No tracked Python bytecode (pyc/__pycache__)"\n  - "CI essential test suite completed successfully"\n- Ran: `bash scripts/test_no_tracked_python_bytecode.sh`\n  - Output: "OK: No tracked Python bytecode (pyc/__pycache__)"\n
