### PR TITLE
fix: Mark get_log_level() pure for consistency (fixes #1347)

### DIFF
--- a/src/external/fortplot_logging.f90
+++ b/src/external/fortplot_logging.f90
@@ -47,7 +47,7 @@ contains
         current_log_level = lvl
     end subroutine set_log_level
 
-    function get_log_level() result(level)
+    pure function get_log_level() result(level)
         !! Get the current global logging level
         !! Returns one of: LOG_LEVEL_SILENT, LOG_LEVEL_ERROR,
         !!                  LOG_LEVEL_WARNING, LOG_LEVEL_INFO, LOG_LEVEL_DEBUG


### PR DESCRIPTION
Summary
- Mark get_log_level() as pure since it reads a module variable without side effects.
- Clarifies intent, enables compiler optimizations, and aligns with project guidance to prefer purity when applicable.

Verification
Commands run locally:
- make test-ci
  - CI essential suite completed successfully
- make test
  - ALL TESTS PASSED (fpm test)

Key excerpts:
- CI essential: "CI essential test suite completed successfully"
- Full suite: "ALL TESTS PASSED (fpm test)"

No artifact/output differences, as expected (signature-only attribute change).