### PR TITLE
fix: Consistent wp usage in raster RGB extraction (fixes #1349)

### DIFF
--- a/src/animation/fortplot_animation_rendering.f90
+++ b/src/animation/fortplot_animation_rendering.f90
@@ -1,5 +1,5 @@
 module fortplot_animation_rendering
-    use iso_fortran_env, only: real64, wp => real64
+    use iso_fortran_env, only: wp => real64
     use fortplot_figure_core, only: figure_t, plot_data_t
     use fortplot_utils, only: initialize_backend
     implicit none
@@ -14,7 +14,7 @@ contains
 
     subroutine extract_frame_rgb_data(fig, rgb_data, status)
         type(figure_t), intent(inout) :: fig
-        real(real64), intent(out) :: rgb_data(:,:,:)
+        real(wp), intent(out) :: rgb_data(:,:,:)
         integer, intent(out) :: status
         
         status = 0

--- a/src/backends/ascii/fortplot_ascii.f90
+++ b/src/backends/ascii/fortplot_ascii.f90
@@ -374,16 +374,15 @@ contains
 
     subroutine ascii_extract_rgb_data(this, width, height, rgb_data)
         !! Extract RGB data from ASCII backend (not supported - dummy data)
-        use, intrinsic :: iso_fortran_env, only: real64
         class(ascii_context), intent(in) :: this
         integer, intent(in) :: width, height
-        real(real64), intent(out) :: rgb_data(width, height, 3)
+        real(wp), intent(out) :: rgb_data(width, height, 3)
         
         ! Reference otherwise-unused member without unreachable branch
         associate(unused_w => this%width); end associate
         
         ! ASCII backend doesn't have RGB data for animation - fill with dummy data
-        rgb_data = 0.0_real64  ! Black background
+        rgb_data = 0.0_wp  ! Black background
     end subroutine ascii_extract_rgb_data
 
     subroutine ascii_get_png_data(this, width, height, png_data, status)

--- a/src/backends/ascii/fortplot_ascii_backend_support.f90
+++ b/src/backends/ascii/fortplot_ascii_backend_support.f90
@@ -7,7 +7,7 @@ module fortplot_ascii_backend_support
     !! Author: fortplot contributors
     
     use fortplot_plot_data, only: plot_data_t
-    use, intrinsic :: iso_fortran_env, only: wp => real64, real64
+    use, intrinsic :: iso_fortran_env, only: wp => real64
     implicit none
     
     private
@@ -19,10 +19,10 @@ contains
     subroutine extract_ascii_rgb_data(width, height, rgb_data)
         !! Extract RGB data from ASCII backend (not supported - dummy data)
         integer, intent(in) :: width, height
-        real(real64), intent(out) :: rgb_data(width, height, 3)
+        real(wp), intent(out) :: rgb_data(width, height, 3)
         
         ! ASCII backend doesn't have RGB data for animation - fill with dummy data
-        rgb_data = 0.0_real64  ! Black background
+        rgb_data = 0.0_wp  ! Black background
     end subroutine extract_ascii_rgb_data
 
     subroutine get_ascii_png_data(width, height, png_data, status)

--- a/src/backends/raster/fortplot_raster.f90
+++ b/src/backends/raster/fortplot_raster.f90
@@ -411,10 +411,9 @@ contains
     end subroutine raster_calculate_legend_position_context
 
     subroutine raster_extract_rgb_data_context(this, width, height, rgb_data)
-        use, intrinsic :: iso_fortran_env, only: real64
         class(raster_context), intent(in) :: this
         integer, intent(in) :: width, height
-        real(real64), intent(out) :: rgb_data(width, height, 3)
+        real(wp), intent(out) :: rgb_data(width, height, 3)
         
         call raster_extract_rgb_data(this%raster, width, height, rgb_data)
     end subroutine raster_extract_rgb_data_context

--- a/src/backends/raster/fortplot_raster_rendering.f90
+++ b/src/backends/raster/fortplot_raster_rendering.f90
@@ -256,10 +256,9 @@ contains
 
     subroutine raster_extract_rgb_data(raster, width, height, rgb_data)
         !! Extract RGB data from PNG backend
-        use, intrinsic :: iso_fortran_env, only: real64
         type(raster_image_t), intent(in) :: raster
         integer, intent(in) :: width, height
-        real(real64), intent(out) :: rgb_data(width, height, 3)
+        real(wp), intent(out) :: rgb_data(width, height, 3)
         integer :: x, y, idx_base
         
         do y = 1, height
@@ -269,9 +268,9 @@ contains
                 idx_base = ((y-1) * width + (x-1)) * 3
                 
                 ! Extract RGB values (normalized to 0-1)
-                rgb_data(x, y, 1) = real(raster%image_data(idx_base + 1), real64) / 255.0_real64
-                rgb_data(x, y, 2) = real(raster%image_data(idx_base + 2), real64) / 255.0_real64
-                rgb_data(x, y, 3) = real(raster%image_data(idx_base + 3), real64) / 255.0_real64
+                rgb_data(x, y, 1) = real(raster%image_data(idx_base + 1), wp) / 255.0_wp
+                rgb_data(x, y, 2) = real(raster%image_data(idx_base + 2), wp) / 255.0_wp
+                rgb_data(x, y, 3) = real(raster%image_data(idx_base + 3), wp) / 255.0_wp
             end do
         end do
     end subroutine raster_extract_rgb_data


### PR DESCRIPTION
fix: Consistent wp usage in raster RGB extraction (fixes #1349)

Summary
- Replace real(real64) with real(wp) and remove redundant local iso_fortran_env imports in raster RGB extraction routines.
- Aligns with repo style and avoids kind mismatches if wp changes.

Changes
- src/backends/raster/fortplot_raster_rendering.f90: use wp in raster_extract_rgb_data
- src/backends/raster/fortplot_raster.f90: use wp in raster_extract_rgb_data_context

Verification
Commands run:
- make build
- make test-ci
- make verify-artifacts

Key outputs:
- ALL TESTS PASSED (fpm test)
- CI essential test suite completed successfully
- Artifact verification passed (examples under output/example/fortran/*)
  - e.g., output/example/fortran/pcolormesh_demo/pcolormesh_basic.pdf contains RGB Image XObject
  - ylabel stripe checks passed for output/example/fortran/ylabel_left/*.png

No functional changes observed; this is a consistency cleanup.


Reviewer updates
- Also aligned wp usage in animation extract API and ASCII backend support.
- Rebuilt, re-ran test-ci and verify-artifacts; all passed locally.

