### PR TITLE
fix: No example for bar charts on website. Are they even working? (fixes #1354)

### DIFF
--- a/doc/examples/bar_chart_demo.md
+++ b/doc/examples/bar_chart_demo.md
@@ -1,0 +1,51 @@
+title: Bar Chart Demo
+---
+
+# Bar Chart Demo
+
+Source: [bar_chart_demo.f90](https://github.com/lazy-fortran/fortplot/blob/main/example/fortran/bar_chart_demo/bar_chart_demo.f90)
+
+Grouped bar charts for categorical comparisons using both the pyplot-style
+stateful helpers and the `figure_t` object API.
+
+- **Stateful grouped bars**: `call bar(...)` renders side-by-side series for
+  quarterly revenue comparisons.
+- **Horizontal bars**: `call barh(...)` presents ranked completion percentages
+  for training modules.
+- **Object-oriented workflow**: `call bar_impl(fig, ...)` builds the same
+  grouped view without relying on the global figure state.
+- **Multi-format outputs**: Every scenario writes PNG, PDF, and ASCII artefacts
+  under `output/example/fortran/bar_chart_demo/`.
+
+## Stateful API Example
+
+```fortran
+call figure(figsize=[7.5d0, 5.0d0])
+call bar(positions_a, product_a, width=0.4d0, label='Product A')
+call bar(positions_b, product_b, width=0.4d0, label='Product B')
+call legend()
+```
+
+## Object API Example
+
+```fortran
+call fig%initialize()
+call bar_impl(fig, positions_baseline, baseline, width=0.32d0, label='Baseline')
+call bar_impl(fig, positions_projected, projected, width=0.32d0, label='Projected')
+call fig%legend()
+```
+
+## Running
+
+```bash
+make example ARGS="bar_chart_demo"
+```
+
+## Output Artefacts
+
+- `stateful_grouped.(png|pdf|txt)` – Vertical grouped bars comparing two series
+- `stateful_horizontal.(png|pdf|txt)` – Horizontal ranking chart
+- `oo_grouped.(png|pdf|txt)` – Object-oriented grouped comparison
+
+These outputs provide quick evidence that bar charts render correctly across
+fortplot's interfaces and export formats.

--- a/doc/examples/index.md
+++ b/doc/examples/index.md
@@ -15,6 +15,7 @@ listed here the next time the documentation is rebuilt.
 - [Animation](./animation.html) - Documentation for this example is auto-generated.
 - [Annotation Demo](./annotation_demo.html) - Documentation for this example is auto-generated.
 - [Ascii Heatmap](./ascii_heatmap.html) - Documentation for this example is auto-generated.
+- [Bar Chart Demo](./bar_chart_demo.html) - Grouped vertical and horizontal bar charts.
 - [Basic Plots](./basic_plots.html) - Documentation for this example is auto-generated.
 - [Boxplot Demo](./boxplot_demo.html) - Demonstrates box-and-whisker plots for statistical data visualization.
 - [Colored Contours](./colored_contours.html) - Documentation for this example is auto-generated.

--- a/doc/index.md
+++ b/doc/index.md
@@ -32,6 +32,7 @@ and links directly to the source code.
 - [Animation](./examples/animation.html) - Documentation for this example is auto-generated.
 - [Annotation Demo](./examples/annotation_demo.html) - Documentation for this example is auto-generated.
 - [Ascii Heatmap](./examples/ascii_heatmap.html) - Documentation for this example is auto-generated.
+- [Bar Chart Demo](./examples/bar_chart_demo.html) - Grouped vertical and horizontal bar charts.
 - [Basic Plots](./examples/basic_plots.html) - Documentation for this example is auto-generated.
 - [Boxplot Demo](./examples/boxplot_demo.html) - Demonstrates box-and-whisker plots for statistical data visualization.
 - [Colored Contours](./examples/colored_contours.html) - Documentation for this example is auto-generated.

--- a/example/fortran/README.md
+++ b/example/fortran/README.md
@@ -26,10 +26,7 @@ make example ARGS="example_name"
 ### Statistical and Categorical
 - [errorbar_demo](./errorbar_demo/) - Error bars for scientific data
 - [boxplot_demo](./boxplot_demo/) - Box-and-whisker plots
-  
-Note: Dedicated bar chart and histogram example programs are not yet included
-in the examples directory. See tests under `test/` exercising `bar`, `barh`,
-and `hist` functionality, and use the plotting APIs in your applications.
+- [bar_chart_demo](./bar_chart_demo/) - Grouped vertical and horizontal bars
 
 ### Advanced Plotting
 - [3d_plotting](./3d_plotting/) - 3D surface and line plots

--- a/example/fortran/bar_chart_demo/README.md
+++ b/example/fortran/bar_chart_demo/README.md
@@ -1,0 +1,35 @@
+title: Bar Chart Demo
+---
+
+# Bar Chart Demo
+
+Demonstrates grouped vertical and horizontal bar charts using both the stateful
+(pyplot-style) and object-oriented (`figure_t`) fortplot APIs.
+
+## Files
+
+- `bar_chart_demo.f90` - Source demonstrating grouped and horizontal bars
+- Generated outputs in `output/example/fortran/bar_chart_demo/`
+
+## Running
+
+```bash
+make example ARGS="bar_chart_demo"
+```
+
+## Features Demonstrated
+
+- **Grouped bars**: Compare multiple series per category
+- **Horizontal bars**: Present ranked metrics across categories
+- **OO workflow**: Call `bar_impl` with an explicit `figure_t` instance to avoid globals
+- **Multiple formats**: Save PNG, PDF, and ASCII outputs for each scenario
+
+## Output Summary
+
+Running the demo generates:
+- `stateful_grouped.(png|pdf|txt)` - Vertical grouped comparison
+- `stateful_horizontal.(png|pdf|txt)` - Horizontal completion chart
+- `oo_grouped.(png|pdf|txt)` - Object API grouped budget comparison
+
+Perfect for showcasing categorical comparisons and verifying bar chart support
+in fortplot.

--- a/example/fortran/bar_chart_demo/bar_chart_demo.f90
+++ b/example/fortran/bar_chart_demo/bar_chart_demo.f90
@@ -1,0 +1,134 @@
+program bar_chart_demo
+    !! Demonstrates vertical and horizontal bar charts using fortplot
+    !! Covers both pyplot-style and figure_t object workflows
+
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use fortplot, only: figure, bar, barh, xlabel, ylabel, title, legend
+    use fortplot, only: savefig_with_status, figure_t
+    use fortplot_plotting_advanced, only: bar_impl
+    use fortplot_errors, only: SUCCESS
+    implicit none
+
+    call demo_stateful_grouped()
+    call demo_stateful_horizontal()
+    call demo_object_grouped()
+
+contains
+
+    subroutine demo_stateful_grouped()
+        real(dp) :: centers(4)
+        real(dp) :: positions_a(4)
+        real(dp) :: positions_b(4)
+        real(dp) :: product_a(4)
+        real(dp) :: product_b(4)
+        real(dp) :: offset
+        integer :: status
+        logical :: ok
+
+        centers = [1.0d0, 2.0d0, 3.0d0, 4.0d0]
+        product_a = [4.5d0, 5.8d0, 6.1d0, 6.7d0]
+        product_b = [3.2d0, 4.6d0, 5.4d0, 6.0d0]
+        offset = 0.2d0
+        positions_a = centers - offset
+        positions_b = centers + offset
+
+        call figure(figsize=[7.5d0, 5.0d0])
+        call bar(positions_a, product_a, width=0.4d0, label='Product A')
+        call bar(positions_b, product_b, width=0.4d0, label='Product B')
+        call xlabel('Quarter')
+        call ylabel('Revenue (million $)')
+        call title('Stateful API - grouped bar chart')
+        call legend()
+
+        ok = .true.
+        call savefig_with_status('output/example/fortran/bar_chart_demo/' // &
+                                 'stateful_grouped.png', status)
+        if (status /= SUCCESS) ok = .false.
+        call savefig_with_status('output/example/fortran/bar_chart_demo/' // &
+                                 'stateful_grouped.pdf', status)
+        if (status /= SUCCESS) ok = .false.
+        call savefig_with_status('output/example/fortran/bar_chart_demo/' // &
+                                 'stateful_grouped.txt', status)
+        if (status /= SUCCESS) ok = .false.
+        if (.not. ok) then
+            print *, 'WARNING: failed to save stateful grouped bar outputs'
+        end if
+    end subroutine demo_stateful_grouped
+
+    subroutine demo_stateful_horizontal()
+        real(dp) :: employee_levels(4)
+        real(dp) :: proficiency(4)
+        integer :: status
+        logical :: ok
+
+        employee_levels = [1.0d0, 2.0d0, 3.0d0, 4.0d0]
+        proficiency = [72.0d0, 65.0d0, 84.0d0, 90.0d0]
+
+        call figure(figsize=[6.8d0, 4.6d0])
+        call barh(employee_levels, proficiency, height=0.6d0, &
+                  label='Certification completion')
+        call xlabel('Completion (%)')
+        call ylabel('Training module')
+        call title('Stateful API - horizontal bar chart')
+        call legend()
+
+        ok = .true.
+        call savefig_with_status('output/example/fortran/bar_chart_demo/' // &
+                                 'stateful_horizontal.png', status)
+        if (status /= SUCCESS) ok = .false.
+        call savefig_with_status('output/example/fortran/bar_chart_demo/' // &
+                                 'stateful_horizontal.pdf', status)
+        if (status /= SUCCESS) ok = .false.
+        call savefig_with_status('output/example/fortran/bar_chart_demo/' // &
+                                 'stateful_horizontal.txt', status)
+        if (status /= SUCCESS) ok = .false.
+        if (.not. ok) then
+            print *, 'WARNING: failed to save stateful horizontal bar outputs'
+        end if
+    end subroutine demo_stateful_horizontal
+
+    subroutine demo_object_grouped()
+        type(figure_t) :: fig
+        real(dp) :: centers(3)
+        real(dp) :: baseline(3)
+        real(dp) :: projected(3)
+        real(dp) :: offset
+        real(dp) :: positions_baseline(3)
+        real(dp) :: positions_projected(3)
+        integer :: status
+        logical :: ok
+
+        call fig%initialize()
+
+        centers = [1.0d0, 2.0d0, 3.0d0]
+        baseline = [2.8d0, 3.4d0, 3.9d0]
+        projected = [3.5d0, 3.8d0, 4.6d0]
+        offset = 0.18d0
+        positions_baseline = centers - offset
+        positions_projected = centers + offset
+
+        call fig%set_title('Object API - grouped budget comparison')
+        call fig%set_xlabel('Team')
+        call fig%set_ylabel('Quarterly budget (M$)')
+        call bar_impl(fig, positions_baseline, baseline, width=0.32d0, &
+                      label='Baseline')
+        call bar_impl(fig, positions_projected, projected, width=0.32d0, &
+                      label='Projected')
+        call fig%legend()
+
+        ok = .true.
+        call fig%savefig_with_status('output/example/fortran/bar_chart_demo/' // &
+                                     'oo_grouped.png', status)
+        if (status /= SUCCESS) ok = .false.
+        call fig%savefig_with_status('output/example/fortran/bar_chart_demo/' // &
+                                     'oo_grouped.pdf', status)
+        if (status /= SUCCESS) ok = .false.
+        call fig%savefig_with_status('output/example/fortran/bar_chart_demo/' // &
+                                     'oo_grouped.txt', status)
+        if (status /= SUCCESS) ok = .false.
+        if (.not. ok) then
+            print *, 'WARNING: failed to save OO grouped bar outputs'
+        end if
+    end subroutine demo_object_grouped
+
+end program bar_chart_demo

--- a/src/plotting/fortplot_plot_bars.f90
+++ b/src/plotting/fortplot_plot_bars.f90
@@ -95,6 +95,8 @@ contains
         if (present(label) .and. len_trim(label) > 0) then
             self%plots(plot_idx)%label = label
         end if
+
+        self%state%plot_count = self%plot_count
     end subroutine add_bar_plot_data
 
 end module fortplot_plot_bars

--- a/test/test_stateful_api_fast.f90
+++ b/test/test_stateful_api_fast.f90
@@ -160,31 +160,55 @@ contains
     
     subroutine test_bar_api()
         real(8) :: x(5), height(5)
+        type(figure_t), pointer :: fig
+        integer :: previous_count
         
         x = [1.0d0, 2.0d0, 3.0d0, 4.0d0, 5.0d0]
         height = [3.0d0, 7.0d0, 2.0d0, 5.0d0, 8.0d0]
-        
+
+        call figure()
         call bar(x, height)
         call check_result("bar basic call", .true.)
-        
+        fig => get_global_figure()
+        call check_result("bar syncs state count after first call", &
+                          fig%state%plot_count == fig%plot_count)
+
         call bar(x, height, width=0.5d0)
         call check_result("bar with width", .true.)
-        
-        ! Skip color test - requires RGB array
-        call check_result("bar with color", .true.)
+        fig => get_global_figure()
+        call check_result("bar syncs state count after width call", &
+                          fig%state%plot_count == fig%plot_count)
+
+        previous_count = fig%plot_count
+        call bar(x, height, label='Category A')
+        fig => get_global_figure()
+        call check_result("bar increments plot count", &
+                          fig%plot_count == previous_count + 1)
+        call check_result("bar keeps state and figure counts aligned", &
+                          fig%state%plot_count == fig%plot_count)
+        call check_result("bar stores legend label", &
+                          len_trim(fig%plots(fig%plot_count)%label) > 0)
     end subroutine test_bar_api
-    
+
     subroutine test_barh_api()
         real(8) :: y(5), width(5)
+        type(figure_t), pointer :: fig
         
         y = [1.0d0, 2.0d0, 3.0d0, 4.0d0, 5.0d0]
         width = [3.0d0, 7.0d0, 2.0d0, 5.0d0, 8.0d0]
-        
+
+        call figure()
         call barh(y, width)
         call check_result("barh basic call", .true.)
-        
+        fig => get_global_figure()
+        call check_result("barh syncs state count after first call", &
+                          fig%state%plot_count == fig%plot_count)
+
         call barh(y, width, height=0.5d0)
         call check_result("barh with height", .true.)
+        fig => get_global_figure()
+        call check_result("barh syncs state count after height call", &
+                          fig%state%plot_count == fig%plot_count)
     end subroutine test_barh_api
     
     subroutine test_histogram_api()


### PR DESCRIPTION
## Summary
- add a bar_chart_demo example showcasing vertical and horizontal bars for both APIs
- document the new example across the gallery and remove the stale placeholder note
- keep bar plot counters in sync so legends report stateful bar series correctly

## Verification
- `make test`
  - `ALL TESTS PASSED (fpm test)`
- `make verify-artifacts`
  - `Artifact verification passed (strict checks)`
- `make example ARGS="bar_chart_demo"`
  - `Project compiled successfully.`
