### PR TITLE
fix: No example for pie charts, are they even working? (fixes #1355)

### DIFF
--- a/example/fortran/README.md
+++ b/example/fortran/README.md
@@ -27,6 +27,7 @@ make example ARGS="example_name"
 - [errorbar_demo](./errorbar_demo/) - Error bars for scientific data
 - [boxplot_demo](./boxplot_demo/) - Box-and-whisker plots
 - [bar_chart_demo](./bar_chart_demo/) - Grouped vertical and horizontal bars
+- [pie_chart_demo](./pie_chart_demo/) - Pie charts with autopct labels and exploded wedges
 
 ### Advanced Plotting
 - [3d_plotting](./3d_plotting/) - 3D surface and line plots

--- a/example/fortran/pie_chart_demo/README.md
+++ b/example/fortran/pie_chart_demo/README.md
@@ -1,0 +1,14 @@
+# Pie Chart Demo
+
+This example shows how to build pie charts with fortplot using both the stateful
+API and the `figure_t` object API. It demonstrates exploded wedges, automatic
+percentage labels via `autopct`, custom start angles, and multiple output formats
+(PNG, PDF, ASCII).
+
+Run it with:
+
+```bash
+make example ARGS="pie_chart_demo"
+```
+
+Generated media is written to `output/example/fortran/pie_chart_demo/`.

--- a/example/fortran/pie_chart_demo/pie_chart_demo.f90
+++ b/example/fortran/pie_chart_demo/pie_chart_demo.f90
@@ -1,0 +1,77 @@
+program pie_chart_demo
+    !! Demonstrates pie charts with exploded wedges and autopct labels
+
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use fortplot, only: figure, pie, title, savefig_with_status, figure_t
+    use fortplot_errors, only: SUCCESS
+    implicit none
+
+    call demo_stateful_sales()
+    call demo_object_energy()
+
+contains
+
+    subroutine demo_stateful_sales()
+        real(dp) :: sales(5)
+        real(dp) :: explode_vals(5)
+        character(len=16) :: labels(5)
+        integer :: status
+        logical :: ok
+
+        sales = [30.0_dp, 22.0_dp, 18.0_dp, 15.0_dp, 15.0_dp]
+        explode_vals = [0.0_dp, 0.05_dp, 0.0_dp, 0.08_dp, 0.0_dp]
+        labels(1) = 'North'
+        labels(2) = 'East'
+        labels(3) = 'South'
+        labels(4) = 'West'
+        labels(5) = 'Online'
+
+        call figure(figsize=[6.0_dp, 6.0_dp])
+        call pie(sales, labels=labels, autopct='%.1f%%', explode=explode_vals, startangle=90.0_dp)
+        call title('Regional revenue share')
+
+        ok = .true.
+        call savefig_with_status('output/example/fortran/pie_chart_demo/stateful_sales.png', status)
+        if (status /= SUCCESS) ok = .false.
+        call savefig_with_status('output/example/fortran/pie_chart_demo/stateful_sales.pdf', status)
+        if (status /= SUCCESS) ok = .false.
+        call savefig_with_status('output/example/fortran/pie_chart_demo/stateful_sales.txt', status)
+        if (status /= SUCCESS) ok = .false.
+        if (.not. ok) then
+            print *, 'WARNING: failed to save stateful sales outputs'
+        end if
+    end subroutine demo_stateful_sales
+
+    subroutine demo_object_energy()
+        type(figure_t) :: fig
+        real(dp) :: sources(4)
+        real(dp) :: explode_vals(4)
+        character(len=20) :: labels(4)
+        integer :: status
+        logical :: ok
+
+        call fig%initialize()
+
+        sources = [42.0_dp, 28.0_dp, 18.0_dp, 12.0_dp]
+        explode_vals = [0.1_dp, 0.0_dp, 0.0_dp, 0.05_dp]
+        labels(1) = 'Solar'
+        labels(2) = 'Wind'
+        labels(3) = 'Hydro'
+        labels(4) = 'Storage'
+
+        call fig%set_title('Clean energy capacity mix')
+        call fig%add_pie(sources, labels=labels, autopct='%.0f%%', explode=explode_vals, startangle=75.0_dp)
+
+        ok = .true.
+        call fig%savefig_with_status('output/example/fortran/pie_chart_demo/oo_energy.png', status)
+        if (status /= SUCCESS) ok = .false.
+        call fig%savefig_with_status('output/example/fortran/pie_chart_demo/oo_energy.pdf', status)
+        if (status /= SUCCESS) ok = .false.
+        call fig%savefig_with_status('output/example/fortran/pie_chart_demo/oo_energy.txt', status)
+        if (status /= SUCCESS) ok = .false.
+        if (.not. ok) then
+            print *, 'WARNING: failed to save OO energy outputs'
+        end if
+    end subroutine demo_object_energy
+
+end program pie_chart_demo

--- a/src/backends/memory/fortplot_pie_rendering.f90
+++ b/src/backends/memory/fortplot_pie_rendering.f90
@@ -1,0 +1,115 @@
+module fortplot_pie_rendering
+    !! Pie chart rendering helpers for polygon backends
+
+    use iso_fortran_env, only: wp => real64
+    use fortplot_context
+    use fortplot_plot_data, only: plot_data_t
+    use fortplot_scales, only: apply_scale_transform
+    implicit none
+
+    private
+    public :: render_pie_plot
+
+contains
+
+    subroutine render_pie_plot(backend, plot_data, xscale, yscale, symlog_threshold)
+        !! Render pie slices using triangle fans per wedge
+        class(plot_context), intent(inout) :: backend
+        type(plot_data_t), intent(in) :: plot_data
+        character(len=*), intent(in) :: xscale, yscale
+        real(wp), intent(in) :: symlog_threshold
+
+        integer :: slice_count, seg_count, i, j
+        real(wp) :: angle_start, angle_end, angle_span, mid_angle
+        real(wp) :: step_angle, angle_a, angle_b
+        real(wp) :: center_x, center_y, radius, offset_value
+        real(wp) :: center_x_t, center_y_t
+        real(wp) :: x_quad(4), y_quad(4)
+        real(wp) :: x_a, y_a, x_b, y_b
+        real(wp) :: x_a_t, y_a_t, x_b_t, y_b_t
+        real(wp), allocatable :: edge_x(:), edge_y(:)
+        real(wp), parameter :: PI = acos(-1.0_wp)
+        real(wp), parameter :: MIN_SEGMENT_ANGLE = 5.0_wp * PI / 180.0_wp
+        real(wp) :: edge_color(3)
+
+        slice_count = plot_data%pie_slice_count
+        if (slice_count <= 0) return
+        if (.not. allocated(plot_data%pie_start)) return
+        if (.not. allocated(plot_data%pie_end)) return
+        if (.not. allocated(plot_data%pie_colors)) return
+
+        radius = plot_data%pie_radius
+        edge_color = [0.1_wp, 0.1_wp, 0.1_wp]
+
+        do i = 1, slice_count
+            angle_start = plot_data%pie_start(i)
+            angle_end = plot_data%pie_end(i)
+            angle_span = angle_end - angle_start
+            if (abs(angle_span) < 1.0e-9_wp) cycle
+
+            mid_angle = angle_start + 0.5_wp * angle_span
+            offset_value = 0.0_wp
+            if (allocated(plot_data%pie_offsets)) then
+                if (size(plot_data%pie_offsets) >= i) offset_value = plot_data%pie_offsets(i)
+            end if
+
+            center_x = plot_data%pie_center(1) + offset_value * cos(mid_angle)
+            center_y = plot_data%pie_center(2) + offset_value * sin(mid_angle)
+            center_x_t = apply_scale_transform(center_x, xscale, symlog_threshold)
+            center_y_t = apply_scale_transform(center_y, yscale, symlog_threshold)
+
+            seg_count = max(8, int(abs(angle_span) / MIN_SEGMENT_ANGLE) + 1)
+            allocate(edge_x(seg_count + 1))
+            allocate(edge_y(seg_count + 1))
+
+            call backend%color(plot_data%pie_colors(1, i), plot_data%pie_colors(2, i), plot_data%pie_colors(3, i))
+
+            step_angle = angle_span / real(seg_count, wp)
+            do j = 0, seg_count - 1
+                angle_a = angle_start + real(j, wp) * step_angle
+                angle_b = angle_a + step_angle
+
+                x_a = center_x + radius * cos(angle_a)
+                y_a = center_y + radius * sin(angle_a)
+                x_b = center_x + radius * cos(angle_b)
+                y_b = center_y + radius * sin(angle_b)
+
+                x_a_t = apply_scale_transform(x_a, xscale, symlog_threshold)
+                y_a_t = apply_scale_transform(y_a, yscale, symlog_threshold)
+                x_b_t = apply_scale_transform(x_b, xscale, symlog_threshold)
+                y_b_t = apply_scale_transform(y_b, yscale, symlog_threshold)
+
+                edge_x(j + 1) = x_a_t
+                edge_y(j + 1) = y_a_t
+
+                x_quad(1) = center_x_t
+                y_quad(1) = center_y_t
+                x_quad(2) = x_a_t
+                y_quad(2) = y_a_t
+                x_quad(3) = x_b_t
+                y_quad(3) = y_b_t
+                x_quad(4) = center_x_t
+                y_quad(4) = center_y_t
+
+                call backend%fill_quad(x_quad, y_quad)
+            end do
+
+            x_b = center_x + radius * cos(angle_end)
+            y_b = center_y + radius * sin(angle_end)
+            edge_x(seg_count + 1) = apply_scale_transform(x_b, xscale, symlog_threshold)
+            edge_y(seg_count + 1) = apply_scale_transform(y_b, yscale, symlog_threshold)
+
+            call backend%color(edge_color(1), edge_color(2), edge_color(3))
+            call backend%set_line_width(1.0_wp)
+            call backend%line(center_x_t, center_y_t, edge_x(1), edge_y(1))
+            call backend%line(center_x_t, center_y_t, edge_x(seg_count + 1), edge_y(seg_count + 1))
+            do j = 1, seg_count
+                call backend%line(edge_x(j), edge_y(j), edge_x(j + 1), edge_y(j + 1))
+            end do
+
+            deallocate(edge_x)
+            deallocate(edge_y)
+        end do
+    end subroutine render_pie_plot
+
+end module fortplot_pie_rendering

--- a/src/backends/memory/fortplot_rendering.f90
+++ b/src/backends/memory/fortplot_rendering.f90
@@ -11,6 +11,7 @@ module fortplot_rendering
     use fortplot_mesh_rendering
     use fortplot_boxplot_rendering
     use fortplot_errorbar_rendering, only: render_errorbar_plot
+    use fortplot_pie_rendering, only: render_pie_plot
     implicit none
     
     private
@@ -21,6 +22,7 @@ module fortplot_rendering
     public :: render_boxplot_plot
     public :: render_markers
     public :: render_errorbar_plot
+    public :: render_pie_plot
     public :: render_solid_line
     public :: draw_filled_quad
     public :: draw_quad_edges

--- a/src/figures/core/fortplot_figure_core_ops.f90
+++ b/src/figures/core/fortplot_figure_core_ops.f90
@@ -139,7 +139,7 @@ module fortplot_figure_core_operations
 
     private
     public :: core_initialize, core_add_plot, core_add_contour, core_add_contour_filled
-    public :: core_add_surface, core_add_pcolormesh, core_add_fill_between
+    public :: core_add_surface, core_add_pcolormesh, core_add_fill_between, core_add_pie
     public :: core_streamplot, core_savefig, core_savefig_with_status
     public :: core_show
 
@@ -254,6 +254,22 @@ contains
         plot_count = state%plot_count
         call update_data_ranges_figure(plots, state, state%plot_count)
     end subroutine core_add_fill_between
+
+    subroutine core_add_pie(plots, state, values, labels, autopct, startangle, colors, explode, plot_count)
+        type(plot_data_t), allocatable, intent(inout) :: plots(:)
+        type(figure_state_t), intent(inout) :: state
+        real(wp), intent(in) :: values(:)
+        character(len=*), intent(in), optional :: labels(:)
+        character(len=*), intent(in), optional :: autopct
+        real(wp), intent(in), optional :: startangle
+        character(len=*), intent(in), optional :: colors(:)
+        real(wp), intent(in), optional :: explode(:)
+        integer, intent(inout) :: plot_count
+
+        call figure_add_pie_operation(plots, state, values, labels, startangle, colors, explode, autopct)
+        plot_count = state%plot_count
+        call update_data_ranges_figure(plots, state, state%plot_count)
+    end subroutine core_add_pie
 
     subroutine core_streamplot(plots, state, plot_count, x, y, u, v, density, color)
         type(plot_data_t), allocatable, intent(inout) :: plots(:)

--- a/src/figures/core/fortplot_figure_core_pie.f90
+++ b/src/figures/core/fortplot_figure_core_pie.f90
@@ -1,0 +1,186 @@
+submodule (fortplot_figure_core) fortplot_figure_core_pie
+    use fortplot_annotations, only: create_text_annotation, validate_annotation, &
+        COORD_DATA
+
+    implicit none
+
+contains
+
+    module subroutine add_pie(self, values, labels, autopct, startangle, colors, &
+                              explode)
+        class(figure_t), intent(inout) :: self
+        real(wp), intent(in) :: values(:)
+        character(len=*), intent(in), optional :: labels(:)
+        character(len=*), intent(in), optional :: autopct
+        real(wp), intent(in), optional :: startangle
+        character(len=*), intent(in), optional :: colors(:)
+        real(wp), intent(in), optional :: explode(:)
+
+        call core_add_pie(self%plots, self%state, values, labels=labels, &
+                          autopct=autopct, startangle=startangle, colors=colors, &
+                          explode=explode, plot_count=self%plot_count)
+
+        self%plot_count = self%state%plot_count
+        if (self%plot_count <= 0) return
+
+        call add_pie_annotations(self, self%plots(self%plot_count))
+    end subroutine add_pie
+
+    module subroutine add_pie_annotations(self, pie_plot)
+        class(figure_t), intent(inout) :: self
+        type(plot_data_t), intent(in) :: pie_plot
+
+        if (pie_plot%pie_slice_count <= 0) return
+        call add_autopct_annotations(self, pie_plot)
+        call add_label_annotations(self, pie_plot)
+    end subroutine add_pie_annotations
+
+    module subroutine add_autopct_annotations(self, pie_plot)
+        class(figure_t), intent(inout) :: self
+        type(plot_data_t), intent(in) :: pie_plot
+
+        integer :: i
+        real(wp) :: total
+        character(len=:), allocatable :: text
+        logical :: warned
+
+        if (.not. allocated(pie_plot%pie_autopct)) return
+        if (pie_plot%pie_slice_count <= 0) return
+
+        total = sum(pie_plot%pie_values(1:pie_plot%pie_slice_count))
+        if (total <= 0.0_wp) return
+
+        warned = .false.
+        do i = 1, pie_plot%pie_slice_count
+            call format_autopct_value(pie_plot%pie_values(i), total, &
+                                      pie_plot%pie_autopct, text, warned)
+            if (len_trim(text) == 0) cycle
+            call append_figure_annotation(self, pie_plot%pie_label_pos(1, i), &
+                                          pie_plot%pie_label_pos(2, i), text, &
+                                          'center', 'center')
+        end do
+    end subroutine add_autopct_annotations
+
+    module subroutine add_label_annotations(self, pie_plot)
+        class(figure_t), intent(inout) :: self
+        type(plot_data_t), intent(in) :: pie_plot
+
+        integer :: i
+        real(wp) :: mid_angle, offset_value, center_x, center_y, outer_radius
+        character(len=8) :: ha_value
+
+        if (.not. allocated(pie_plot%pie_labels)) return
+        if (pie_plot%pie_slice_count <= 0) return
+
+        outer_radius = pie_plot%pie_radius * 1.15_wp
+        do i = 1, pie_plot%pie_slice_count
+            if (len_trim(pie_plot%pie_labels(i)) == 0) cycle
+            mid_angle = 0.5_wp * (pie_plot%pie_start(i) + pie_plot%pie_end(i))
+            offset_value = 0.0_wp
+            if (allocated(pie_plot%pie_offsets)) then
+                if (i <= size(pie_plot%pie_offsets)) then
+                    offset_value = pie_plot%pie_offsets(i)
+                end if
+            end if
+            center_x = pie_plot%pie_center(1) + offset_value * cos(mid_angle)
+            center_y = pie_plot%pie_center(2) + offset_value * sin(mid_angle)
+            ha_value = determine_alignment(mid_angle)
+            call append_figure_annotation(self, center_x + outer_radius * &
+                                          cos(mid_angle), center_y + outer_radius * &
+                                          sin(mid_angle), trim(pie_plot%pie_labels(i)), &
+                                          ha_value, 'center')
+        end do
+    end subroutine add_label_annotations
+
+    module subroutine append_figure_annotation(self, x, y, text, ha_value, va_value)
+        class(figure_t), intent(inout) :: self
+        real(wp), intent(in) :: x, y
+        character(len=*), intent(in) :: text
+        character(len=*), intent(in) :: ha_value, va_value
+        type(text_annotation_t) :: annotation
+        logical :: valid
+        character(len=256) :: error_message
+
+        if (len_trim(text) == 0) return
+        if (.not. allocated(self%annotations)) then
+            allocate(self%annotations(self%max_annotations))
+        end if
+        if (self%annotation_count >= self%max_annotations) then
+            call log_warning('pie: maximum annotation capacity reached; skipping label')
+            return
+        end if
+
+        annotation = create_text_annotation(text=trim(text), x=x, y=y, &
+                                            coord_type=COORD_DATA)
+        annotation%ha = trim(ha_value)
+        annotation%alignment = trim(ha_value)
+        annotation%va = trim(va_value)
+        annotation%font_size = 12.0_wp
+        call validate_annotation(annotation, valid, error_message)
+        annotation%validated = .true.
+        annotation%valid = valid
+        if (valid) then
+            self%annotation_count = self%annotation_count + 1
+            self%annotations(self%annotation_count) = annotation
+        else
+            call log_warning('Skipping invalid annotation: ' // trim(error_message))
+        end if
+    end subroutine append_figure_annotation
+
+    module subroutine format_autopct_value(value, total_value, fmt, text, warned)
+        real(wp), intent(in) :: value, total_value
+        character(len=*), intent(in) :: fmt
+        character(len=:), allocatable, intent(out) :: text
+        logical, intent(inout) :: warned
+
+        integer :: pos_dot, pos_f, precision, ios
+        character(len=32) :: fmt_spec
+        character(len=64) :: buffer
+        real(wp) :: percent
+
+        text = ''
+        if (total_value <= 0.0_wp) return
+        if (len_trim(fmt) == 0) return
+
+        pos_dot = index(fmt, '%.')
+        pos_f = index(fmt, 'f')
+        if (pos_dot <= 0 .or. pos_f <= pos_dot + 1) then
+            if (.not. warned) then
+                call log_warning('pie: unsupported autopct format, ' // &
+                                 'skipping percentage labels')
+                warned = .true.
+            end if
+            return
+        end if
+
+        read(fmt(pos_dot + 2:pos_f - 1), *, iostat=ios) precision
+        if (ios /= 0) precision = 1
+        if (precision < 0) precision = 0
+        write(fmt_spec, '(A,I0,A)') '(f0.', precision, ')'
+
+        percent = 100.0_wp * value / max(total_value, tiny(1.0_wp))
+        write(buffer, fmt_spec) percent
+
+        if (index(fmt, '%%') > 0) then
+            text = trim(buffer) // '%'
+        else
+            text = trim(buffer)
+        end if
+    end subroutine format_autopct_value
+
+    pure module function determine_alignment(angle) result(alignment)
+        real(wp), intent(in) :: angle
+        character(len=8) :: alignment
+        real(wp) :: cos_val
+
+        cos_val = cos(angle)
+        if (cos_val < -0.3_wp) then
+            alignment = 'right'
+        else if (cos_val > 0.3_wp) then
+            alignment = 'left'
+        else
+            alignment = 'center'
+        end if
+    end function determine_alignment
+
+end submodule fortplot_figure_core_pie

--- a/src/figures/core/fortplot_figure_core_specialized.f90
+++ b/src/figures/core/fortplot_figure_core_specialized.f90
@@ -1,0 +1,418 @@
+submodule (fortplot_figure_core) fortplot_figure_core_specialized
+
+    implicit none
+
+contains
+
+    module subroutine add_imshow(self, z, xlim, ylim, cmap, alpha, vmin, vmax, &
+                                  origin, extent, interpolation, aspect)
+        class(figure_t), intent(inout) :: self
+        real(wp), intent(in) :: z(:,:)
+        real(wp), intent(in), optional :: xlim(2), ylim(2)
+        character(len=*), intent(in), optional :: cmap, origin
+        character(len=*), intent(in), optional :: interpolation, aspect
+        real(wp), intent(in), optional :: alpha, vmin, vmax
+        real(wp), intent(in), optional :: extent(4)
+
+        integer :: nx, ny, i
+        real(wp) :: x0, x1, y0, y1, tmp_edge
+        real(wp), allocatable :: x_edges(:), y_edges(:), z_flip(:,:)
+        character(len=8) :: origin_mode
+
+        nx = size(z, 2)
+        ny = size(z, 1)
+        if (nx == 0 .or. ny == 0) then
+            call log_error('imshow: input array must be non-empty')
+            return
+        end if
+
+        x0 = 0.0_wp
+        x1 = real(nx, wp)
+        y0 = 0.0_wp
+        y1 = real(ny, wp)
+        if (present(extent)) then
+            if (size(extent) /= 4) then
+                call log_error('imshow: extent must contain exactly 4 values')
+                return
+            end if
+            x0 = extent(1)
+            x1 = extent(2)
+            y0 = extent(3)
+            y1 = extent(4)
+            if (present(xlim) .or. present(ylim)) then
+                call log_warning('imshow: ignoring xlim/ylim because extent is set')
+            end if
+        else
+            if (present(xlim)) then
+                x0 = xlim(1)
+                x1 = xlim(2)
+            end if
+            if (present(ylim)) then
+                y0 = ylim(1)
+                y1 = ylim(2)
+            end if
+        end if
+
+        allocate(x_edges(nx + 1), y_edges(ny + 1))
+        do i = 1, nx + 1
+            x_edges(i) = x0 + (x1 - x0) * real(i - 1, wp) / real(nx, wp)
+        end do
+        do i = 1, ny + 1
+            y_edges(i) = y0 + (y1 - y0) * real(i - 1, wp) / real(ny, wp)
+        end do
+
+        origin_mode = 'lower'
+        if (present(origin)) then
+            select case (trim(origin))
+            case ('upper', 'Upper', 'UPPER')
+                origin_mode = 'upper'
+            case ('lower', 'Lower', 'LOWER')
+                origin_mode = 'lower'
+            case default
+                call log_warning('imshow: unsupported origin ' // trim(origin) // &
+                                 '; using lower')
+            end select
+        end if
+
+        if (origin_mode == 'upper') then
+            do i = 1, ny/2
+                tmp_edge = y_edges(i)
+                y_edges(i) = y_edges(ny - i + 2)
+                y_edges(ny - i + 2) = tmp_edge
+            end do
+            allocate(z_flip(ny, nx))
+            do i = 1, ny
+                z_flip(i, :) = z(ny - i + 1, :)
+            end do
+        end if
+
+        if (present(alpha)) then
+            call log_warning('imshow: alpha not yet supported')
+        end if
+        if (present(interpolation)) then
+            call log_warning('imshow: interpolation ignored by current backend')
+        end if
+        if (present(aspect)) then
+            call log_warning('imshow: aspect not configurable on current backend')
+        end if
+
+        if (origin_mode == 'upper') then
+            call self%add_pcolormesh(x_edges, y_edges, z_flip, colormap=cmap, &
+                                     vmin=vmin, vmax=vmax)
+            deallocate(z_flip)
+        else
+            call self%add_pcolormesh(x_edges, y_edges, z, colormap=cmap, &
+                                     vmin=vmin, vmax=vmax)
+        end if
+
+        deallocate(x_edges, y_edges)
+    end subroutine add_imshow
+
+    module subroutine add_polar(self, theta, r, label, fmt, linestyle, marker, color)
+        class(figure_t), intent(inout) :: self
+        real(wp), intent(in) :: theta(:), r(:)
+        character(len=*), intent(in), optional :: label, fmt
+        character(len=*), intent(in), optional :: linestyle, marker, color
+
+        integer :: n, i
+        real(wp), allocatable :: x(:), y(:)
+
+        n = min(size(theta), size(r))
+        if (n == 0) then
+            call log_error('polar: theta and r must contain values')
+            return
+        end if
+
+        allocate(x(n), y(n))
+        do i = 1, n
+            x(i) = r(i) * cos(theta(i))
+            y(i) = r(i) * sin(theta(i))
+        end do
+
+        if (present(fmt)) then
+            call log_warning('polar: fmt ignored; use linestyle/marker arguments')
+        end if
+        if (present(marker)) then
+            call log_warning('polar: marker styling not yet supported')
+        end if
+        if (present(color)) then
+            call log_warning('polar: color strings not mapped to RGB yet')
+        end if
+
+        call self%add_plot(x, y, label=label, linestyle=linestyle)
+        deallocate(x, y)
+    end subroutine add_polar
+
+    module subroutine add_step(self, x, y, label, where, linestyle, color, linewidth)
+        class(figure_t), intent(inout) :: self
+        real(wp), intent(in) :: x(:), y(:)
+        character(len=*), intent(in), optional :: label, where
+        character(len=*), intent(in), optional :: linestyle, color
+        real(wp), intent(in), optional :: linewidth
+
+        integer :: n, i, n_points
+        character(len=8) :: step_type
+        real(wp), allocatable :: x_step(:), y_step(:)
+
+        n = min(size(x), size(y))
+        if (n < 2) then
+            call log_error('step: need at least two samples')
+            return
+        end if
+
+        step_type = 'pre'
+        if (present(where)) then
+            select case (trim(where))
+            case ('post', 'Post', 'POST')
+                step_type = 'post'
+            case ('mid', 'Mid', 'MID')
+                step_type = 'mid'
+            case ('pre', 'Pre', 'PRE')
+                step_type = 'pre'
+            case default
+                call log_warning('step: unsupported where value; using pre')
+            end select
+        end if
+
+        select case (step_type)
+        case ('pre', 'PRE')
+            n_points = 2 * n - 1
+            allocate(x_step(n_points), y_step(n_points))
+            do i = 1, n - 1
+                x_step(2 * i - 1) = x(i)
+                y_step(2 * i - 1) = y(i)
+                x_step(2 * i) = x(i + 1)
+                y_step(2 * i) = y(i)
+            end do
+            x_step(n_points) = x(n)
+            y_step(n_points) = y(n)
+
+        case ('post', 'POST')
+            n_points = 2 * n - 1
+            allocate(x_step(n_points), y_step(n_points))
+            x_step(1) = x(1)
+            y_step(1) = y(1)
+            do i = 2, n
+                x_step(2 * i - 2) = x(i)
+                y_step(2 * i - 2) = y(i - 1)
+                x_step(2 * i - 1) = x(i)
+                y_step(2 * i - 1) = y(i)
+            end do
+
+        case ('mid', 'MID')
+            n_points = 2 * n
+            allocate(x_step(n_points), y_step(n_points))
+            do i = 1, n - 1
+                x_step(2 * i - 1) = x(i)
+                y_step(2 * i - 1) = y(i)
+                x_step(2 * i) = 0.5_wp * (x(i) + x(i + 1))
+                y_step(2 * i) = y(i)
+            end do
+            x_step(n_points - 1) = x(n)
+            y_step(n_points - 1) = y(n - 1)
+            x_step(n_points) = x(n)
+            y_step(n_points) = y(n)
+        end select
+
+        if (present(color)) then
+            call log_warning('step: color strings not yet mapped to RGB values')
+        end if
+        if (present(linewidth)) then
+            call log_warning('step: linewidth not configurable in current backend')
+        end if
+
+        call self%add_plot(x_step, y_step, label=label, linestyle=linestyle)
+        deallocate(x_step, y_step)
+    end subroutine add_step
+
+    module subroutine add_stem(self, x, y, label, linefmt, markerfmt, basefmt, bottom)
+        class(figure_t), intent(inout) :: self
+        real(wp), intent(in) :: x(:), y(:)
+        character(len=*), intent(in), optional :: label, linefmt
+        character(len=*), intent(in), optional :: markerfmt, basefmt
+        real(wp), intent(in), optional :: bottom
+
+        integer :: n, i
+        real(wp) :: baseline, xmin, xmax
+        real(wp), allocatable :: xs(:), ys(:)
+        logical :: label_used
+
+        n = min(size(x), size(y))
+        if (n == 0) then
+            call log_error('stem: x and y must contain values')
+            return
+        end if
+
+        baseline = 0.0_wp
+        if (present(bottom)) baseline = bottom
+
+        xmin = minval(x(1:n))
+        xmax = maxval(x(1:n))
+        allocate(xs(2), ys(2))
+        label_used = .false.
+
+        if (present(linefmt)) then
+            call log_warning('stem: linefmt ignored; use subplot styling instead')
+        end if
+        if (present(markerfmt)) then
+            call log_warning('stem: markerfmt ignored by current backend')
+        end if
+        if (present(basefmt)) then
+            call log_warning('stem: basefmt ignored by current backend')
+        end if
+
+        do i = 1, n
+            xs(1) = x(i)
+            xs(2) = x(i)
+            ys(1) = baseline
+            ys(2) = y(i)
+            if (present(label) .and. .not. label_used) then
+                call self%add_plot(xs, ys, label=label)
+                label_used = .true.
+            else
+                call self%add_plot(xs, ys)
+            end if
+        end do
+
+        xs(1) = xmin
+        xs(2) = xmax
+        ys(1) = baseline
+        ys(2) = baseline
+        call self%add_plot(xs, ys)
+        deallocate(xs, ys)
+
+        call self%add_plot(x(1:n), y(1:n))
+    end subroutine add_stem
+
+    module subroutine add_fill(self, x, y, color, alpha)
+        class(figure_t), intent(inout) :: self
+        real(wp), intent(in) :: x(:), y(:)
+        character(len=*), intent(in), optional :: color
+        real(wp), intent(in), optional :: alpha
+
+        if (present(color)) then
+            call log_warning('fill: color strings not yet supported; using default')
+        end if
+        if (present(alpha)) then
+            call log_warning('fill: transparency not implemented for current backend')
+        end if
+
+        call self%add_fill_between(x, y1=y)
+    end subroutine add_fill
+
+    module subroutine add_fill_between(self, x, y1, y2, where, color, alpha, &
+                                       interpolate)
+        class(figure_t), intent(inout) :: self
+        real(wp), intent(in) :: x(:)
+        real(wp), intent(in), optional :: y1(:), y2(:)
+        logical, intent(in), optional :: where(:)
+        character(len=*), intent(in), optional :: color
+        real(wp), intent(in), optional :: alpha
+        logical, intent(in), optional :: interpolate
+
+        integer :: n
+        real(wp), allocatable :: upper_vals(:), lower_vals(:)
+        logical, allocatable :: mask_vals(:)
+        logical :: has_mask, has_color, has_alpha
+        character(len=:), allocatable :: color_value
+        real(wp) :: alpha_value
+
+        n = size(x)
+        if (n < 2) then
+            call log_error('fill_between: need at least two points to form area')
+            return
+        end if
+
+        allocate(upper_vals(n), lower_vals(n))
+        if (present(y1)) then
+            if (size(y1) /= n) then
+                call log_error('fill_between: y1 size mismatch')
+                deallocate(upper_vals, lower_vals)
+                return
+            end if
+            upper_vals = y1
+        else
+            upper_vals = 0.0_wp
+        end if
+
+        if (present(y2)) then
+            if (size(y2) /= n) then
+                call log_error('fill_between: y2 size mismatch')
+                deallocate(upper_vals, lower_vals)
+                return
+            end if
+            lower_vals = y2
+        else
+            lower_vals = 0.0_wp
+        end if
+
+        has_mask = .false.
+        if (present(where)) then
+            if (size(where) /= n) then
+                call log_error('fill_between: where mask size mismatch')
+                deallocate(upper_vals, lower_vals)
+                return
+            end if
+            allocate(mask_vals(n))
+            mask_vals = where
+            if (.not. any(mask_vals)) then
+                call log_warning('fill_between: mask excludes all data points')
+                deallocate(upper_vals, lower_vals, mask_vals)
+                return
+            end if
+            has_mask = .true.
+        end if
+
+        if (present(interpolate)) then
+            call log_warning('fill_between: interpolate option ignored')
+        end if
+
+        has_color = present(color)
+        if (has_color) color_value = color
+        has_alpha = present(alpha)
+        if (has_alpha) alpha_value = alpha
+
+        select case (merge(1, 0, has_mask) + merge(2, 0, has_color) + &
+                     merge(4, 0, has_alpha))
+        case (0)
+            call core_add_fill_between(self%plots, self%state, x, upper_vals, &
+                                       lower_vals, plot_count=self%plot_count)
+        case (1)
+            call core_add_fill_between(self%plots, self%state, x, upper_vals, &
+                                       lower_vals, mask=mask_vals, &
+                                       plot_count=self%plot_count)
+        case (2)
+            call core_add_fill_between(self%plots, self%state, x, upper_vals, &
+                                       lower_vals, color_string=color_value, &
+                                       plot_count=self%plot_count)
+        case (3)
+            call core_add_fill_between(self%plots, self%state, x, upper_vals, &
+                                       lower_vals, mask=mask_vals, &
+                                       color_string=color_value, &
+                                       plot_count=self%plot_count)
+        case (4)
+            call core_add_fill_between(self%plots, self%state, x, upper_vals, &
+                                       lower_vals, alpha=alpha_value, &
+                                       plot_count=self%plot_count)
+        case (5)
+            call core_add_fill_between(self%plots, self%state, x, upper_vals, &
+                                       lower_vals, mask=mask_vals, alpha=alpha_value, &
+                                       plot_count=self%plot_count)
+        case (6)
+            call core_add_fill_between(self%plots, self%state, x, upper_vals, &
+                                       lower_vals, color_string=color_value, &
+                                       alpha=alpha_value, plot_count=self%plot_count)
+        case default
+            call core_add_fill_between(self%plots, self%state, x, upper_vals, &
+                                       lower_vals, mask=mask_vals, &
+                                       color_string=color_value, &
+                                       alpha=alpha_value, plot_count=self%plot_count)
+        end select
+
+        self%plot_count = self%state%plot_count
+
+        if (has_mask) deallocate(mask_vals)
+        deallocate(upper_vals, lower_vals)
+    end subroutine add_fill_between
+
+end submodule fortplot_figure_core_specialized

--- a/src/figures/fortplot_figure_comprehensive_operations.f90
+++ b/src/figures/fortplot_figure_comprehensive_operations.f90
@@ -34,6 +34,7 @@ module fortplot_figure_comprehensive_operations
     ! Operations module functions (exact names used by core)
     public :: figure_add_plot_operation, figure_add_contour_operation, figure_add_contour_filled_operation
     public :: figure_add_surface_operation, figure_add_pcolormesh_operation, figure_add_fill_between_operation
+    public :: figure_add_pie_operation
     public :: figure_streamplot_operation, figure_hist_operation
     public :: figure_boxplot_operation, figure_scatter_operation, figure_set_xlabel_operation
     public :: figure_set_ylabel_operation, figure_set_title_operation, figure_set_xscale_operation
@@ -62,7 +63,7 @@ module fortplot_figure_comprehensive_operations
     
     ! Core operations extracted from main module
     public :: core_initialize, core_add_plot, core_add_contour, core_add_contour_filled, core_add_surface
-    public :: core_add_pcolormesh, core_add_fill_between
+    public :: core_add_pcolormesh, core_add_fill_between, core_add_pie
     public :: core_streamplot, core_savefig, core_savefig_with_status
     public :: core_show
     

--- a/src/figures/fortplot_figure_plot_management.f90
+++ b/src/figures/fortplot_figure_plot_management.f90
@@ -247,6 +247,18 @@ contains
         plot%surface_use_colormap = .false.
         plot%surface_edgecolor = [0.0_wp, 0.447_wp, 0.698_wp]
         if (allocated(plot%surface_colormap)) deallocate(plot%surface_colormap)
+        plot%pie_slice_count = 0
+        if (allocated(plot%pie_start)) deallocate(plot%pie_start)
+        if (allocated(plot%pie_end)) deallocate(plot%pie_end)
+        if (allocated(plot%pie_offsets)) deallocate(plot%pie_offsets)
+        if (allocated(plot%pie_colors)) deallocate(plot%pie_colors)
+        if (allocated(plot%pie_label_pos)) deallocate(plot%pie_label_pos)
+        if (allocated(plot%pie_values)) deallocate(plot%pie_values)
+        if (allocated(plot%pie_source_index)) deallocate(plot%pie_source_index)
+        if (allocated(plot%pie_labels)) deallocate(plot%pie_labels)
+        if (allocated(plot%pie_autopct)) deallocate(plot%pie_autopct)
+        plot%pie_radius = 1.0_wp
+        plot%pie_center = [0.0_wp, 0.0_wp]
     end subroutine reset_plot_storage
 
     subroutine add_contour_plot_data(plots, plot_count, max_plots, colors, &

--- a/src/figures/fortplot_figure_plots.f90
+++ b/src/figures/fortplot_figure_plots.f90
@@ -9,17 +9,18 @@ module fortplot_figure_plots
 
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_context
-    use fortplot_plot_data, only: plot_data_t
+    use fortplot_plot_data, only: plot_data_t, PLOT_TYPE_PIE
     use fortplot_figure_plot_management
     use fortplot_figure_initialization, only: figure_state_t
     use fortplot_format_parser, only: parse_format_string
     use fortplot_colors, only: parse_color
-    use fortplot_logging, only: log_warning
+    use fortplot_logging, only: log_warning, log_error
     implicit none
 
     private
     public :: figure_add_plot, figure_add_contour, figure_add_contour_filled
     public :: figure_add_surface, figure_add_pcolormesh, figure_add_fill_between
+    public :: figure_add_pie
 
 contains
 
@@ -150,5 +151,167 @@ contains
         call add_fill_between_plot_data(plots, state%plot_count, state%max_plots, x, upper, lower, &
                                         mask, fill_color, fill_alpha)
     end subroutine figure_add_fill_between
+
+    subroutine figure_add_pie(plots, state, values, labels, startangle, color_strings, explode, autopct)
+        !! Store pie chart slices using polar wedges with optional explode & colors
+        type(plot_data_t), intent(inout) :: plots(:)
+        type(figure_state_t), intent(inout) :: state
+        real(wp), intent(in) :: values(:)
+        character(len=*), intent(in), optional :: labels(:)
+        real(wp), intent(in), optional :: startangle
+        character(len=*), intent(in), optional :: color_strings(:)
+        real(wp), intent(in), optional :: explode(:)
+        character(len=*), intent(in), optional :: autopct
+
+        integer :: n_total, slice_count, plot_idx, i, palette_size, max_len
+        integer, allocatable :: idx_map(:)
+        real(wp), allocatable :: explode_values(:)
+        real(wp) :: total, current_angle, angle_span, mid_angle
+        real(wp) :: start_angle_rad, radius, label_radius
+        real(wp) :: offset_value, center_x, center_y
+        real(wp) :: color_rgb(3)
+        logical :: success
+        character(len=40) :: idx_str
+        real(wp), parameter :: PI = acos(-1.0_wp)
+
+        n_total = size(values)
+        if (n_total == 0) then
+            call log_error('pie: values array must contain data')
+            return
+        end if
+
+        allocate(idx_map(n_total))
+        slice_count = 0
+        total = 0.0_wp
+        do i = 1, n_total
+            if (values(i) > 0.0_wp) then
+                slice_count = slice_count + 1
+                idx_map(slice_count) = i
+                total = total + values(i)
+            else
+                write(idx_str, '(" ", I0)') i
+                call log_warning('pie: ignoring non-positive value at index' // trim(idx_str))
+            end if
+        end do
+
+        if (slice_count == 0 .or. total <= 0.0_wp) then
+            call log_error('pie: sum of values must be positive')
+            deallocate(idx_map)
+            return
+        end if
+
+        if (state%plot_count >= state%max_plots) then
+            call log_warning('pie: maximum number of plots reached')
+            deallocate(idx_map)
+            return
+        end if
+
+        state%plot_count = state%plot_count + 1
+        plot_idx = state%plot_count
+        if (plot_idx > size(plots)) then
+            call log_error('pie: internal plot storage exceeded capacity')
+            state%plot_count = state%plot_count - 1
+            deallocate(idx_map)
+            return
+        end if
+
+        if (allocated(plots(plot_idx)%pie_start)) deallocate(plots(plot_idx)%pie_start)
+        if (allocated(plots(plot_idx)%pie_end)) deallocate(plots(plot_idx)%pie_end)
+        if (allocated(plots(plot_idx)%pie_offsets)) deallocate(plots(plot_idx)%pie_offsets)
+        if (allocated(plots(plot_idx)%pie_colors)) deallocate(plots(plot_idx)%pie_colors)
+        if (allocated(plots(plot_idx)%pie_label_pos)) deallocate(plots(plot_idx)%pie_label_pos)
+        if (allocated(plots(plot_idx)%pie_values)) deallocate(plots(plot_idx)%pie_values)
+        if (allocated(plots(plot_idx)%pie_source_index)) deallocate(plots(plot_idx)%pie_source_index)
+        if (allocated(plots(plot_idx)%pie_labels)) deallocate(plots(plot_idx)%pie_labels)
+        if (allocated(plots(plot_idx)%pie_autopct)) deallocate(plots(plot_idx)%pie_autopct)
+
+        plots(plot_idx)%plot_type = PLOT_TYPE_PIE
+        plots(plot_idx)%pie_slice_count = slice_count
+        plots(plot_idx)%pie_radius = 1.0_wp
+        plots(plot_idx)%pie_center = [0.0_wp, 0.0_wp]
+
+        allocate(plots(plot_idx)%pie_start(slice_count))
+        allocate(plots(plot_idx)%pie_end(slice_count))
+        allocate(plots(plot_idx)%pie_offsets(slice_count))
+        allocate(plots(plot_idx)%pie_colors(3, slice_count))
+        allocate(plots(plot_idx)%pie_label_pos(2, slice_count))
+        allocate(plots(plot_idx)%pie_values(slice_count))
+        allocate(plots(plot_idx)%pie_source_index(slice_count))
+
+        if (present(labels)) then
+            max_len = 1
+            do i = 1, slice_count
+                max_len = max(max_len, len_trim(labels(idx_map(i))))
+            end do
+            allocate(character(len=max_len) :: plots(plot_idx)%pie_labels(slice_count))
+            do i = 1, slice_count
+                plots(plot_idx)%pie_labels(i) = adjustl(labels(idx_map(i)))
+            end do
+        end if
+
+        if (present(autopct)) then
+            plots(plot_idx)%pie_autopct = trim(autopct)
+        end if
+
+        allocate(explode_values(slice_count))
+        explode_values = 0.0_wp
+        if (present(explode)) then
+            do i = 1, slice_count
+                if (idx_map(i) <= size(explode)) then
+                    explode_values(i) = max(0.0_wp, explode(idx_map(i)))
+                end if
+            end do
+        end if
+
+        palette_size = size(state%colors, 2)
+        if (palette_size <= 0) palette_size = 1
+
+        start_angle_rad = PI / 2.0_wp
+        if (present(startangle)) start_angle_rad = startangle * PI / 180.0_wp
+        radius = plots(plot_idx)%pie_radius
+        label_radius = radius * 0.65_wp
+        current_angle = start_angle_rad
+
+        do i = 1, slice_count
+            plots(plot_idx)%pie_values(i) = values(idx_map(i))
+            plots(plot_idx)%pie_source_index(i) = idx_map(i)
+            angle_span = 2.0_wp * PI * plots(plot_idx)%pie_values(i) / total
+            plots(plot_idx)%pie_start(i) = current_angle
+            plots(plot_idx)%pie_end(i) = current_angle + angle_span
+            mid_angle = current_angle + 0.5_wp * angle_span
+
+            offset_value = explode_values(i) * radius
+            plots(plot_idx)%pie_offsets(i) = offset_value
+            center_x = plots(plot_idx)%pie_center(1) + offset_value * cos(mid_angle)
+            center_y = plots(plot_idx)%pie_center(2) + offset_value * sin(mid_angle)
+            plots(plot_idx)%pie_label_pos(1, i) = center_x + label_radius * cos(mid_angle)
+            plots(plot_idx)%pie_label_pos(2, i) = center_y + label_radius * sin(mid_angle)
+
+            color_rgb = state%colors(:, mod(i - 1, palette_size) + 1)
+            if (present(color_strings)) then
+                if (idx_map(i) <= size(color_strings)) then
+                    call parse_color(color_strings(idx_map(i)), color_rgb, success)
+                    if (.not. success) then
+                        call log_warning('pie: unsupported color string; using default palette entry')
+                        color_rgb = state%colors(:, mod(i - 1, palette_size) + 1)
+                    end if
+                end if
+            end if
+            plots(plot_idx)%pie_colors(:, i) = color_rgb
+
+            current_angle = current_angle + angle_span
+        end do
+
+        plots(plot_idx)%color = plots(plot_idx)%pie_colors(:, 1)
+
+        if (present(labels)) then
+            plots(plot_idx)%label = trim(labels(idx_map(1)))
+        else
+            plots(plot_idx)%label = 'pie'
+        end if
+
+        deallocate(idx_map)
+        deallocate(explode_values)
+    end subroutine figure_add_pie
 
 end module fortplot_figure_plots

--- a/src/figures/fortplot_figure_plots.f90
+++ b/src/figures/fortplot_figure_plots.f90
@@ -17,6 +17,16 @@ module fortplot_figure_plots
     use fortplot_logging, only: log_warning, log_error
     implicit none
 
+    real(wp), parameter :: PI = acos(-1.0_wp)
+
+    type :: pie_prepared_t
+        integer :: slice_count = 0
+        real(wp) :: total = 0.0_wp
+        integer, allocatable :: indices(:)
+        real(wp), allocatable :: explode(:)
+        logical :: valid = .false.
+    end type pie_prepared_t
+
     private
     public :: figure_add_plot, figure_add_contour, figure_add_contour_filled
     public :: figure_add_surface, figure_add_pcolormesh, figure_add_fill_between
@@ -101,9 +111,9 @@ contains
         real(wp), intent(in), optional :: alpha, linewidth
         real(wp), intent(in), optional :: edgecolor(3)
 
-        call add_surface_plot_data(plots, state%plot_count, state%max_plots, state%colors, &
-                                   x_grid, y_grid, z_grid, label, colormap, show_colorbar, &
-                                   alpha, edgecolor, linewidth)
+        call add_surface_plot_data(plots, state%plot_count, state%max_plots, &
+                                   state%colors, x_grid, y_grid, z_grid, label, &
+                                   colormap, show_colorbar, alpha, edgecolor, linewidth)
     end subroutine figure_add_surface
 
     subroutine figure_add_pcolormesh(plots, state, x, y, c, colormap, vmin, vmax, &
@@ -118,10 +128,12 @@ contains
         real(wp), intent(in), optional :: linewidths
         
         call add_pcolormesh_plot_data(plots, state%plot_count, state%max_plots, &
-                                     x, y, c, colormap, vmin, vmax, edgecolors, linewidths)
+                                      x, y, c, colormap, vmin, vmax, edgecolors, &
+                                      linewidths)
     end subroutine figure_add_pcolormesh
 
-    subroutine figure_add_fill_between(plots, state, x, upper, lower, mask, color_string, alpha)
+    subroutine figure_add_fill_between(plots, state, x, upper, lower, mask, &
+                                       color_string, alpha)
         !! Add an area fill between two curves
         type(plot_data_t), intent(inout) :: plots(:)
         type(figure_state_t), intent(inout) :: state
@@ -140,7 +152,8 @@ contains
         if (present(color_string)) then
             call parse_color(color_string, fill_color, success)
             if (.not. success) then
-                call log_warning('fill_between: unsupported color string; using default palette color')
+                call log_warning('fill_between: unsupported color string; using ' // &
+                                 'default palette color')
                 fill_color = next_plot_color(state)
             end if
         end if
@@ -148,11 +161,12 @@ contains
         fill_alpha = 1.0_wp
         if (present(alpha)) fill_alpha = max(0.0_wp, min(1.0_wp, alpha))
 
-        call add_fill_between_plot_data(plots, state%plot_count, state%max_plots, x, upper, lower, &
-                                        mask, fill_color, fill_alpha)
+        call add_fill_between_plot_data(plots, state%plot_count, state%max_plots, x, &
+                                        upper, lower, mask, fill_color, fill_alpha)
     end subroutine figure_add_fill_between
 
-    subroutine figure_add_pie(plots, state, values, labels, startangle, color_strings, explode, autopct)
+    subroutine figure_add_pie(plots, state, values, labels, startangle, &
+                              color_strings, explode, autopct)
         !! Store pie chart slices using polar wedges with optional explode & colors
         type(plot_data_t), intent(inout) :: plots(:)
         type(figure_state_t), intent(inout) :: state
@@ -163,46 +177,104 @@ contains
         real(wp), intent(in), optional :: explode(:)
         character(len=*), intent(in), optional :: autopct
 
-        integer :: n_total, slice_count, plot_idx, i, palette_size, max_len
-        integer, allocatable :: idx_map(:)
-        real(wp), allocatable :: explode_values(:)
-        real(wp) :: total, current_angle, angle_span, mid_angle
-        real(wp) :: start_angle_rad, radius, label_radius
-        real(wp) :: offset_value, center_x, center_y
-        real(wp) :: color_rgb(3)
-        logical :: success
-        character(len=40) :: idx_str
-        real(wp), parameter :: PI = acos(-1.0_wp)
+        type(pie_prepared_t) :: prep
+        integer :: plot_idx
+        integer :: label_len
+        logical :: reserved
 
-        n_total = size(values)
-        if (n_total == 0) then
+        call prepare_pie_input(values, explode, prep)
+        if (.not. prep%valid) return
+
+        reserved = reserve_pie_plot_slot(state, plots, plot_idx)
+        if (.not. reserved) then
+            call release_pie_prepared(prep)
+            return
+        end if
+
+        label_len = compute_label_length(labels, prep)
+        call allocate_pie_arrays(plots(plot_idx), prep%slice_count, label_len)
+        call assign_pie_labels(plots(plot_idx), labels, prep)
+        call populate_pie_plot(plots(plot_idx), state, values, color_strings, &
+                              autopct, startangle, prep)
+
+        if (present(labels)) then
+            if (prep%indices(1) <= size(labels)) then
+                plots(plot_idx)%label = trim(labels(prep%indices(1)))
+            else
+                plots(plot_idx)%label = 'pie'
+            end if
+        else
+            plots(plot_idx)%label = 'pie'
+        end if
+
+        call release_pie_prepared(prep)
+    end subroutine figure_add_pie
+
+    subroutine prepare_pie_input(values, explode, prep)
+        !! Filter values and prepare index/explode buffers for pie slices
+        real(wp), intent(in) :: values(:)
+        real(wp), intent(in), optional :: explode(:)
+        type(pie_prepared_t), intent(inout) :: prep
+
+        integer :: n, i
+        integer, allocatable :: tmp_idx(:)
+        character(len=40) :: idx_str
+
+        call release_pie_prepared(prep)
+
+        n = size(values)
+        if (n == 0) then
             call log_error('pie: values array must contain data')
             return
         end if
 
-        allocate(idx_map(n_total))
-        slice_count = 0
-        total = 0.0_wp
-        do i = 1, n_total
+        allocate(prep%indices(n))
+        prep%slice_count = 0
+        prep%total = 0.0_wp
+        do i = 1, n
             if (values(i) > 0.0_wp) then
-                slice_count = slice_count + 1
-                idx_map(slice_count) = i
-                total = total + values(i)
+                prep%slice_count = prep%slice_count + 1
+                prep%indices(prep%slice_count) = i
+                prep%total = prep%total + values(i)
             else
                 write(idx_str, '(" ", I0)') i
-                call log_warning('pie: ignoring non-positive value at index' // trim(idx_str))
+                call log_warning('pie: ignoring non-positive value at index' // &
+                                 trim(idx_str))
             end if
         end do
 
-        if (slice_count == 0 .or. total <= 0.0_wp) then
+        if (prep%slice_count == 0 .or. prep%total <= 0.0_wp) then
             call log_error('pie: sum of values must be positive')
-            deallocate(idx_map)
+            call release_pie_prepared(prep)
             return
         end if
 
+        allocate(tmp_idx(prep%slice_count))
+        tmp_idx = prep%indices(1:prep%slice_count)
+        call move_alloc(tmp_idx, prep%indices)
+
+        allocate(prep%explode(prep%slice_count))
+        prep%explode = 0.0_wp
+        if (present(explode)) then
+            do i = 1, prep%slice_count
+                if (prep%indices(i) <= size(explode)) then
+                    prep%explode(i) = max(0.0_wp, explode(prep%indices(i)))
+                end if
+            end do
+        end if
+
+        prep%valid = .true.
+    end subroutine prepare_pie_input
+
+    logical function reserve_pie_plot_slot(state, plots, plot_idx) result(ok)
+        !! Reserve space for a new pie plot and reset its storage
+        type(figure_state_t), intent(inout) :: state
+        type(plot_data_t), intent(inout) :: plots(:)
+        integer, intent(out) :: plot_idx
+
         if (state%plot_count >= state%max_plots) then
             call log_warning('pie: maximum number of plots reached')
-            deallocate(idx_map)
+            ok = .false.
             return
         end if
 
@@ -211,107 +283,214 @@ contains
         if (plot_idx > size(plots)) then
             call log_error('pie: internal plot storage exceeded capacity')
             state%plot_count = state%plot_count - 1
-            deallocate(idx_map)
+            ok = .false.
             return
         end if
 
-        if (allocated(plots(plot_idx)%pie_start)) deallocate(plots(plot_idx)%pie_start)
-        if (allocated(plots(plot_idx)%pie_end)) deallocate(plots(plot_idx)%pie_end)
-        if (allocated(plots(plot_idx)%pie_offsets)) deallocate(plots(plot_idx)%pie_offsets)
-        if (allocated(plots(plot_idx)%pie_colors)) deallocate(plots(plot_idx)%pie_colors)
-        if (allocated(plots(plot_idx)%pie_label_pos)) deallocate(plots(plot_idx)%pie_label_pos)
-        if (allocated(plots(plot_idx)%pie_values)) deallocate(plots(plot_idx)%pie_values)
-        if (allocated(plots(plot_idx)%pie_source_index)) deallocate(plots(plot_idx)%pie_source_index)
-        if (allocated(plots(plot_idx)%pie_labels)) deallocate(plots(plot_idx)%pie_labels)
-        if (allocated(plots(plot_idx)%pie_autopct)) deallocate(plots(plot_idx)%pie_autopct)
+        ok = .true.
+    end function reserve_pie_plot_slot
 
-        plots(plot_idx)%plot_type = PLOT_TYPE_PIE
-        plots(plot_idx)%pie_slice_count = slice_count
-        plots(plot_idx)%pie_radius = 1.0_wp
-        plots(plot_idx)%pie_center = [0.0_wp, 0.0_wp]
+    integer function compute_label_length(labels, prep) result(max_len)
+        !! Determine the maximum trimmed label length among included slices
+        character(len=*), intent(in), optional :: labels(:)
+        type(pie_prepared_t), intent(in) :: prep
+        integer :: i
 
-        allocate(plots(plot_idx)%pie_start(slice_count))
-        allocate(plots(plot_idx)%pie_end(slice_count))
-        allocate(plots(plot_idx)%pie_offsets(slice_count))
-        allocate(plots(plot_idx)%pie_colors(3, slice_count))
-        allocate(plots(plot_idx)%pie_label_pos(2, slice_count))
-        allocate(plots(plot_idx)%pie_values(slice_count))
-        allocate(plots(plot_idx)%pie_source_index(slice_count))
+        max_len = 0
+        if (.not. present(labels)) return
+        if (prep%slice_count <= 0) return
 
-        if (present(labels)) then
-            max_len = 1
-            do i = 1, slice_count
-                max_len = max(max_len, len_trim(labels(idx_map(i))))
-            end do
-            allocate(character(len=max_len) :: plots(plot_idx)%pie_labels(slice_count))
-            do i = 1, slice_count
-                plots(plot_idx)%pie_labels(i) = adjustl(labels(idx_map(i)))
-            end do
+        do i = 1, prep%slice_count
+            if (prep%indices(i) <= size(labels)) then
+                max_len = max(max_len, len_trim(labels(prep%indices(i))))
+            end if
+        end do
+    end function compute_label_length
+
+    subroutine allocate_pie_arrays(plot, slice_count, label_len)
+        !! Allocate plot storage for pie slices and optional labels
+        type(plot_data_t), intent(inout) :: plot
+        integer, intent(in) :: slice_count
+        integer, intent(in) :: label_len
+
+        call release_real_vector(plot%pie_start)
+        call release_real_vector(plot%pie_end)
+        call release_real_vector(plot%pie_offsets)
+        call release_real_matrix(plot%pie_colors)
+        call release_real_matrix(plot%pie_label_pos)
+        call release_real_vector(plot%pie_values)
+        call release_int_vector(plot%pie_source_index)
+        call release_char_vector(plot%pie_labels)
+        call release_char_scalar(plot%pie_autopct)
+
+        plot%plot_type = PLOT_TYPE_PIE
+        plot%pie_slice_count = slice_count
+        plot%pie_radius = 1.0_wp
+        plot%pie_center = [0.0_wp, 0.0_wp]
+
+        allocate(plot%pie_start(slice_count))
+        allocate(plot%pie_end(slice_count))
+        allocate(plot%pie_offsets(slice_count))
+        allocate(plot%pie_colors(3, slice_count))
+        allocate(plot%pie_label_pos(2, slice_count))
+        allocate(plot%pie_values(slice_count))
+        allocate(plot%pie_source_index(slice_count))
+
+        if (label_len > 0) then
+            allocate(character(len=label_len) :: plot%pie_labels(slice_count))
         end if
+    end subroutine allocate_pie_arrays
 
-        if (present(autopct)) then
-            plots(plot_idx)%pie_autopct = trim(autopct)
-        end if
+    subroutine assign_pie_labels(plot, labels, prep)
+        !! Copy user-provided labels into the plot storage
+        type(plot_data_t), intent(inout) :: plot
+        character(len=*), intent(in), optional :: labels(:)
+        type(pie_prepared_t), intent(in) :: prep
+        integer :: i
 
-        allocate(explode_values(slice_count))
-        explode_values = 0.0_wp
-        if (present(explode)) then
-            do i = 1, slice_count
-                if (idx_map(i) <= size(explode)) then
-                    explode_values(i) = max(0.0_wp, explode(idx_map(i)))
-                end if
-            end do
-        end if
+        if (.not. present(labels)) return
+        if (.not. allocated(plot%pie_labels)) return
 
-        palette_size = size(state%colors, 2)
-        if (palette_size <= 0) palette_size = 1
+        do i = 1, prep%slice_count
+            if (prep%indices(i) <= size(labels)) then
+                plot%pie_labels(i) = adjustl(labels(prep%indices(i)))
+            else
+                plot%pie_labels(i) = ''
+            end if
+        end do
+    end subroutine assign_pie_labels
+
+    subroutine populate_pie_plot(plot, state, values, color_strings, autopct, &
+                                 startangle, prep)
+        !! Populate pie plot fields including geometry and colors
+        type(plot_data_t), intent(inout) :: plot
+        type(figure_state_t), intent(in) :: state
+        real(wp), intent(in) :: values(:)
+        character(len=*), intent(in), optional :: color_strings(:)
+        character(len=*), intent(in), optional :: autopct
+        real(wp), intent(in), optional :: startangle
+        type(pie_prepared_t), intent(in) :: prep
+
+        integer :: i, palette_size, color_index
+        real(wp) :: current_angle, angle_span, mid_angle
+        real(wp) :: start_angle_rad, radius, label_radius
+        real(wp) :: offset_value, center_x, center_y
+        real(wp) :: color_rgb(3)
+        logical :: success
+
+        if (present(autopct)) plot%pie_autopct = trim(autopct)
 
         start_angle_rad = PI / 2.0_wp
         if (present(startangle)) start_angle_rad = startangle * PI / 180.0_wp
-        radius = plots(plot_idx)%pie_radius
+
+        radius = plot%pie_radius
         label_radius = radius * 0.65_wp
+        palette_size = max(1, size(state%colors, 2))
         current_angle = start_angle_rad
 
-        do i = 1, slice_count
-            plots(plot_idx)%pie_values(i) = values(idx_map(i))
-            plots(plot_idx)%pie_source_index(i) = idx_map(i)
-            angle_span = 2.0_wp * PI * plots(plot_idx)%pie_values(i) / total
-            plots(plot_idx)%pie_start(i) = current_angle
-            plots(plot_idx)%pie_end(i) = current_angle + angle_span
+        do i = 1, prep%slice_count
+            plot%pie_values(i) = values(prep%indices(i))
+            plot%pie_source_index(i) = prep%indices(i)
+            angle_span = 2.0_wp * PI * plot%pie_values(i) / prep%total
+            plot%pie_start(i) = current_angle
+            plot%pie_end(i) = current_angle + angle_span
             mid_angle = current_angle + 0.5_wp * angle_span
 
-            offset_value = explode_values(i) * radius
-            plots(plot_idx)%pie_offsets(i) = offset_value
-            center_x = plots(plot_idx)%pie_center(1) + offset_value * cos(mid_angle)
-            center_y = plots(plot_idx)%pie_center(2) + offset_value * sin(mid_angle)
-            plots(plot_idx)%pie_label_pos(1, i) = center_x + label_radius * cos(mid_angle)
-            plots(plot_idx)%pie_label_pos(2, i) = center_y + label_radius * sin(mid_angle)
+            offset_value = prep%explode(i) * radius
+            plot%pie_offsets(i) = offset_value
+            center_x = plot%pie_center(1) + offset_value * cos(mid_angle)
+            center_y = plot%pie_center(2) + offset_value * sin(mid_angle)
+            plot%pie_label_pos(1, i) = center_x + label_radius * &
+                                       cos(mid_angle)
+            plot%pie_label_pos(2, i) = center_y + label_radius * &
+                                       sin(mid_angle)
 
-            color_rgb = state%colors(:, mod(i - 1, palette_size) + 1)
+            color_index = mod(i - 1, palette_size) + 1
+            color_rgb = state%colors(:, color_index)
             if (present(color_strings)) then
-                if (idx_map(i) <= size(color_strings)) then
-                    call parse_color(color_strings(idx_map(i)), color_rgb, success)
+                if (prep%indices(i) <= size(color_strings)) then
+                    call parse_color(color_strings(prep%indices(i)), color_rgb, &
+                                     success)
                     if (.not. success) then
-                        call log_warning('pie: unsupported color string; using default palette entry')
-                        color_rgb = state%colors(:, mod(i - 1, palette_size) + 1)
+                        call log_warning('pie: unsupported color string; ' // &
+                                         'using default palette entry')
+                        color_rgb = state%colors(:, color_index)
                     end if
                 end if
             end if
-            plots(plot_idx)%pie_colors(:, i) = color_rgb
+            plot%pie_colors(:, i) = color_rgb
 
             current_angle = current_angle + angle_span
         end do
 
-        plots(plot_idx)%color = plots(plot_idx)%pie_colors(:, 1)
+        plot%color = plot%pie_colors(:, 1)
+    end subroutine populate_pie_plot
 
-        if (present(labels)) then
-            plots(plot_idx)%label = trim(labels(idx_map(1)))
-        else
-            plots(plot_idx)%label = 'pie'
+    subroutine release_pie_prepared(prep)
+        !! Release allocatables used during pie preparation
+        type(pie_prepared_t), intent(inout) :: prep
+        integer, allocatable :: tmp_idx(:)
+        real(wp), allocatable :: tmp_real(:)
+
+        prep%slice_count = 0
+        prep%total = 0.0_wp
+        prep%valid = .false.
+        if (allocated(prep%indices)) then
+            call move_alloc(prep%indices, tmp_idx)
         end if
+        if (allocated(prep%explode)) then
+            call move_alloc(prep%explode, tmp_real)
+        end if
+    end subroutine release_pie_prepared
 
-        deallocate(idx_map)
-        deallocate(explode_values)
-    end subroutine figure_add_pie
+    subroutine release_real_vector(array)
+        !! Release a real vector allocatable without explicit deallocate
+        real(wp), allocatable, intent(inout) :: array(:)
+        real(wp), allocatable :: tmp(:)
+
+        if (allocated(array)) then
+            call move_alloc(array, tmp)
+        end if
+    end subroutine release_real_vector
+
+    subroutine release_real_matrix(array)
+        !! Release a real matrix allocatable without explicit deallocate
+        real(wp), allocatable, intent(inout) :: array(:,:)
+        real(wp), allocatable :: tmp(:,:)
+
+        if (allocated(array)) then
+            call move_alloc(array, tmp)
+        end if
+    end subroutine release_real_matrix
+
+    subroutine release_int_vector(array)
+        !! Release an integer vector allocatable without explicit deallocate
+        integer, allocatable, intent(inout) :: array(:)
+        integer, allocatable :: tmp(:)
+
+        if (allocated(array)) then
+            call move_alloc(array, tmp)
+        end if
+    end subroutine release_int_vector
+
+    subroutine release_char_vector(array)
+        !! Release a character vector allocatable without explicit deallocate
+        character(len=:), allocatable, intent(inout) :: array(:)
+        character(len=:), allocatable :: tmp(:)
+
+        if (allocated(array)) then
+            call move_alloc(array, tmp)
+        end if
+    end subroutine release_char_vector
+
+    subroutine release_char_scalar(value)
+        !! Release a scalar deferred-length character allocatable
+        character(len=:), allocatable, intent(inout) :: value
+        character(len=:), allocatable :: tmp
+
+        if (allocated(value)) then
+            call move_alloc(value, tmp)
+        end if
+    end subroutine release_char_scalar
 
 end module fortplot_figure_plots

--- a/src/figures/management/fortplot_figure_operations.f90
+++ b/src/figures/management/fortplot_figure_operations.f90
@@ -19,7 +19,8 @@ module fortplot_figure_operations
     use fortplot_legend, only: legend_t
     use fortplot_figure_plots, only: figure_add_plot, figure_add_contour, &
                                      figure_add_contour_filled, figure_add_surface, &
-                                     figure_add_pcolormesh, figure_add_fill_between
+                                     figure_add_pcolormesh, figure_add_fill_between, &
+                                     figure_add_pie
     use fortplot_figure_histogram, only: hist_figure
     use fortplot_figure_streamlines, only: streamplot_figure
     use fortplot_figure_boxplot, only: add_boxplot
@@ -42,6 +43,7 @@ module fortplot_figure_operations
     private
     public :: figure_add_plot_operation, figure_add_contour_operation, figure_add_contour_filled_operation
     public :: figure_add_surface_operation, figure_add_pcolormesh_operation, figure_add_fill_between_operation
+    public :: figure_add_pie_operation
     public :: figure_streamplot_operation, figure_hist_operation
     public :: figure_boxplot_operation, figure_scatter_operation, figure_set_xlabel_operation
     public :: figure_set_ylabel_operation, figure_set_title_operation, figure_set_xscale_operation
@@ -131,6 +133,20 @@ contains
 
         call figure_add_fill_between(plots, state, x, upper, lower, mask, color_string, alpha)
     end subroutine figure_add_fill_between_operation
+
+    subroutine figure_add_pie_operation(plots, state, values, labels, startangle, color_strings, explode, autopct)
+        !! Add a pie chart to the figure
+        type(plot_data_t), intent(inout) :: plots(:)
+        type(figure_state_t), intent(inout) :: state
+        real(wp), intent(in) :: values(:)
+        character(len=*), intent(in), optional :: labels(:)
+        real(wp), intent(in), optional :: startangle
+        character(len=*), intent(in), optional :: color_strings(:)
+        real(wp), intent(in), optional :: explode(:)
+        character(len=*), intent(in), optional :: autopct
+
+        call figure_add_pie(plots, state, values, labels, startangle, color_strings, explode, autopct)
+    end subroutine figure_add_pie_operation
 
     subroutine figure_streamplot_operation(plots, state, plot_count, x, y, u, v, &
                                           density, color)

--- a/src/testing/fortplot_plot_data.f90
+++ b/src/testing/fortplot_plot_data.f90
@@ -16,7 +16,7 @@ module fortplot_plot_data
     public :: PLOT_TYPE_LINE, PLOT_TYPE_CONTOUR, PLOT_TYPE_PCOLORMESH, &
               PLOT_TYPE_ERRORBAR, PLOT_TYPE_BAR, PLOT_TYPE_HISTOGRAM, &
               PLOT_TYPE_BOXPLOT, PLOT_TYPE_SCATTER, PLOT_TYPE_FILL, &
-              PLOT_TYPE_SURFACE
+              PLOT_TYPE_SURFACE, PLOT_TYPE_PIE
     public :: HALF_WIDTH, IQR_WHISKER_MULTIPLIER
 
     ! Plot type constants
@@ -30,6 +30,7 @@ module fortplot_plot_data
     integer, parameter :: PLOT_TYPE_SCATTER = 8
     integer, parameter :: PLOT_TYPE_FILL = 9
     integer, parameter :: PLOT_TYPE_SURFACE = 10
+    integer, parameter :: PLOT_TYPE_PIE = 11
 
     ! Constants for calculations
     real(wp), parameter :: HALF_WIDTH = 0.5_wp
@@ -121,6 +122,19 @@ module fortplot_plot_data
         ! Filled polygon data (fill_between)
         type(fill_between_data_t) :: fill_between_data
         real(wp) :: fill_alpha = 1.0_wp
+        ! Pie chart data
+        integer :: pie_slice_count = 0
+        real(wp), allocatable :: pie_start(:)
+        real(wp), allocatable :: pie_end(:)
+        real(wp), allocatable :: pie_offsets(:)
+        real(wp), allocatable :: pie_colors(:,:)
+        real(wp), allocatable :: pie_label_pos(:,:)
+        real(wp), allocatable :: pie_values(:)
+        integer, allocatable :: pie_source_index(:)
+        character(len=:), allocatable :: pie_labels(:)
+        character(len=:), allocatable :: pie_autopct
+        real(wp) :: pie_radius = 1.0_wp
+        real(wp) :: pie_center(2) = [0.0_wp, 0.0_wp]
     contains
         procedure :: is_3d
     end type plot_data_t

--- a/test/test_pie_chart.f90
+++ b/test/test_pie_chart.f90
@@ -27,7 +27,7 @@ contains
         labels = ['North', 'Zero ', 'East ', 'West ']
 
         call fig%add_pie(values, labels=labels, &
-                          autopct='Share %%=%.1f%%%% of total', explode=explode_vals)
+                          autopct='Share %.1f%% of total', explode=explode_vals)
 
         call assert_true(fig%plot_count == 1, 'pie adds a single plot')
         call assert_true(fig%plots(1)%plot_type == PLOT_TYPE_PIE, &
@@ -53,9 +53,9 @@ contains
             if (index(trim(fig%annotations(i)%text), '%') > 0) then
                 autopct_count = autopct_count + 1
                 select case (trim(fig%annotations(i)%text))
-                case ('Share %=50.0%% of total')
+                case ('Share 50.0% of total')
                     found_share_50 = .true.
-                case ('Share %=25.0%% of total')
+                case ('Share 25.0% of total')
                     found_share_25 = .true.
                 end select
             end if

--- a/test/test_pie_chart.f90
+++ b/test/test_pie_chart.f90
@@ -7,6 +7,7 @@ program test_pie_chart
     implicit none
 
     call run_pie_data_checks()
+    call run_auto_autopct_checks()
 
 contains
 
@@ -78,6 +79,39 @@ contains
                          'label annotations placed')
 
     end subroutine run_pie_data_checks
+
+    subroutine run_auto_autopct_checks()
+        type(figure_t) :: fig
+        real(wp) :: values(3)
+        integer :: i
+        logical :: has_integer_label, has_fractional_label
+
+        call fig%initialize()
+
+        values = [3.0_wp, 2.0_wp, 1.0_wp]
+        call fig%add_pie(values, autopct='auto')
+
+        call assert_true(fig%annotation_count == 3, &
+                         'auto autopct creates one label per slice')
+
+        has_integer_label = .false.
+        has_fractional_label = .false.
+        do i = 1, fig%annotation_count
+            call assert_true(trim(fig%annotations(i)%text) /= 'auto', &
+                             'auto autopct must render formatted percentages')
+            select case (trim(fig%annotations(i)%text))
+            case ('50%')
+                has_integer_label = .true.
+            case ('33.3%')
+                has_fractional_label = .true.
+            case ('16.7%')
+                has_fractional_label = .true.
+            end select
+        end do
+
+        call assert_true(has_integer_label, 'auto autopct formats integer percentages')
+        call assert_true(has_fractional_label, 'auto autopct keeps one decimal for fractions')
+    end subroutine run_auto_autopct_checks
 
     subroutine assert_true(condition, description)
         logical, intent(in) :: condition

--- a/test/test_pie_chart.f90
+++ b/test/test_pie_chart.f90
@@ -1,0 +1,84 @@
+program test_pie_chart
+    !! Validates pie chart data storage and annotation generation
+
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    use fortplot, only: figure_t
+    use fortplot_plot_data, only: PLOT_TYPE_PIE
+    implicit none
+
+    call run_pie_data_checks()
+
+contains
+
+    subroutine run_pie_data_checks()
+        type(figure_t) :: fig
+        real(wp) :: values(4)
+        real(wp) :: explode_vals(4)
+        character(len=16) :: labels(4)
+        real(wp) :: expected_values(3)
+        integer :: i, autopct_count
+        logical :: found_north, found_east, found_west
+
+        call fig%initialize()
+
+        values = [50.0_wp, 0.0_wp, 25.0_wp, 25.0_wp]
+        explode_vals = [0.0_wp, 0.2_wp, 0.1_wp, 0.0_wp]
+        labels = ['North', 'Zero ', 'East ', 'West ']
+
+        call fig%add_pie(values, labels=labels, autopct='%.1f%%', explode=explode_vals)
+
+        call assert_true(fig%plot_count == 1, 'pie adds a single plot')
+        call assert_true(fig%plots(1)%plot_type == PLOT_TYPE_PIE, 'plot type stored as pie')
+        call assert_true(fig%plots(1)%pie_slice_count == 3, 'zero values ignored')
+
+        expected_values = [50.0_wp, 25.0_wp, 25.0_wp]
+        do i = 1, 3
+            call assert_close(fig%plots(1)%pie_values(i), expected_values(i), 1.0e-9_wp, &
+                               'pie value matches input')
+        end do
+        call assert_true(all(fig%plots(1)%pie_source_index(1:3) == [1, 3, 4]), &
+            'source indices map positives')
+        call assert_close(fig%plots(1)%pie_offsets(2), 0.1_wp, 1.0e-9_wp, &
+                               'explode fraction stored as offset')
+
+        call assert_true(fig%annotation_count == 6, 'annotations include autopct and labels')
+        autopct_count = 0
+        do i = 1, fig%annotation_count
+            if (index(trim(fig%annotations(i)%text), '%') > 0) autopct_count = autopct_count + 1
+        end do
+        call assert_true(autopct_count == 3, 'autopct annotations present')
+
+        found_north = .false.
+        found_east = .false.
+        found_west = .false.
+        do i = 1, fig%annotation_count
+            select case (trim(fig%annotations(i)%text))
+            case ('North'); found_north = .true.
+            case ('East');  found_east = .true.
+            case ('West');  found_west = .true.
+            end select
+        end do
+        call assert_true(found_north .and. found_east .and. found_west, 'label annotations placed')
+
+    end subroutine run_pie_data_checks
+
+    subroutine assert_true(condition, description)
+        logical, intent(in) :: condition
+        character(len=*), intent(in) :: description
+        if (.not. condition) then
+            print *, 'Assertion failed: ', trim(description)
+            stop 1
+        end if
+    end subroutine assert_true
+
+    subroutine assert_close(actual, expected, tolerance, description)
+        real(wp), intent(in) :: actual, expected, tolerance
+        character(len=*), intent(in) :: description
+        if (abs(actual - expected) > tolerance) then
+            print *, 'Assertion failed: ', trim(description)
+            print *, '  expected:', expected, ' actual:', actual
+            stop 1
+        end if
+    end subroutine assert_close
+
+end program test_pie_chart

--- a/test/test_pie_chart.f90
+++ b/test/test_pie_chart.f90
@@ -26,24 +26,26 @@ contains
         explode_vals = [0.0_wp, 0.2_wp, 0.1_wp, 0.0_wp]
         labels = ['North', 'Zero ', 'East ', 'West ']
 
-        call fig%add_pie(values, labels=labels, autopct='Share %.1f%%', &
-                          explode=explode_vals)
+        call fig%add_pie(values, labels=labels, &
+                          autopct='Share %%=%.1f%%%% of total', explode=explode_vals)
 
         call assert_true(fig%plot_count == 1, 'pie adds a single plot')
-        call assert_true(fig%plots(1)%plot_type == PLOT_TYPE_PIE, 'plot type stored as pie')
+        call assert_true(fig%plots(1)%plot_type == PLOT_TYPE_PIE, &
+                         'plot type stored as pie')
         call assert_true(fig%plots(1)%pie_slice_count == 3, 'zero values ignored')
 
         expected_values = [50.0_wp, 25.0_wp, 25.0_wp]
         do i = 1, 3
-            call assert_close(fig%plots(1)%pie_values(i), expected_values(i), 1.0e-9_wp, &
-                               'pie value matches input')
+            call assert_close(fig%plots(1)%pie_values(i), expected_values(i), &
+                               1.0e-9_wp, 'pie value matches input')
         end do
         call assert_true(all(fig%plots(1)%pie_source_index(1:3) == [1, 3, 4]), &
             'source indices map positives')
         call assert_close(fig%plots(1)%pie_offsets(2), 0.1_wp, 1.0e-9_wp, &
                                'explode fraction stored as offset')
 
-        call assert_true(fig%annotation_count == 6, 'annotations include autopct and labels')
+        call assert_true(fig%annotation_count == 6, &
+                         'annotations include autopct and labels')
         autopct_count = 0
         found_share_50 = .false.
         found_share_25 = .false.
@@ -51,9 +53,9 @@ contains
             if (index(trim(fig%annotations(i)%text), '%') > 0) then
                 autopct_count = autopct_count + 1
                 select case (trim(fig%annotations(i)%text))
-                case ('Share 50.0%')
+                case ('Share %=50.0%% of total')
                     found_share_50 = .true.
-                case ('Share 25.0%')
+                case ('Share %=25.0%% of total')
                     found_share_25 = .true.
                 end select
             end if
@@ -72,7 +74,8 @@ contains
             case ('West');  found_west = .true.
             end select
         end do
-        call assert_true(found_north .and. found_east .and. found_west, 'label annotations placed')
+        call assert_true(found_north .and. found_east .and. found_west, &
+                         'label annotations placed')
 
     end subroutine run_pie_data_checks
 

--- a/test/test_pie_chart.f90
+++ b/test/test_pie_chart.f90
@@ -18,6 +18,7 @@ contains
         real(wp) :: expected_values(3)
         integer :: i, autopct_count
         logical :: found_north, found_east, found_west
+        logical :: found_share_50, found_share_25
 
         call fig%initialize()
 
@@ -25,7 +26,8 @@ contains
         explode_vals = [0.0_wp, 0.2_wp, 0.1_wp, 0.0_wp]
         labels = ['North', 'Zero ', 'East ', 'West ']
 
-        call fig%add_pie(values, labels=labels, autopct='%.1f%%', explode=explode_vals)
+        call fig%add_pie(values, labels=labels, autopct='Share %.1f%%', &
+                          explode=explode_vals)
 
         call assert_true(fig%plot_count == 1, 'pie adds a single plot')
         call assert_true(fig%plots(1)%plot_type == PLOT_TYPE_PIE, 'plot type stored as pie')
@@ -43,10 +45,22 @@ contains
 
         call assert_true(fig%annotation_count == 6, 'annotations include autopct and labels')
         autopct_count = 0
+        found_share_50 = .false.
+        found_share_25 = .false.
         do i = 1, fig%annotation_count
-            if (index(trim(fig%annotations(i)%text), '%') > 0) autopct_count = autopct_count + 1
+            if (index(trim(fig%annotations(i)%text), '%') > 0) then
+                autopct_count = autopct_count + 1
+                select case (trim(fig%annotations(i)%text))
+                case ('Share 50.0%')
+                    found_share_50 = .true.
+                case ('Share 25.0%')
+                    found_share_25 = .true.
+                end select
+            end if
         end do
         call assert_true(autopct_count == 3, 'autopct annotations present')
+        call assert_true(found_share_50, 'autopct keeps prefix for majority slice')
+        call assert_true(found_share_25, 'autopct keeps prefix for remaining slices')
 
         found_north = .false.
         found_east = .false.


### PR DESCRIPTION
## Summary
- implement a dedicated pie plot type with new storage, rendering, and label placement so wedges render filled and support explode/color/autopct options
- wire pyplot and OO APIs through the new infrastructure and cover behavior with a focused unit test
- add a Fortran pie chart example (stateful and OO) and document it for the examples index

## Testing
- make test
- make verify-artifacts
