### PR TITLE
fix: Any other plot types besides bar and pie not working or no (fixes #1356)

### DIFF
--- a/example/fortran/polar_demo/README.md
+++ b/example/fortran/polar_demo/README.md
@@ -1,0 +1,9 @@
+# polar_demo
+
+Demonstrates fortplot's polar plotting API with custom colors, linestyles, and markers.
+
+```sh
+make example ARGS="polar_demo"
+```
+
+Generated outputs are written to `output/example/fortran/polar_demo/` as PNG and text summaries.

--- a/example/fortran/polar_demo/polar_demo.f90
+++ b/example/fortran/polar_demo/polar_demo.f90
@@ -1,0 +1,44 @@
+program polar_demo
+    !! Demonstrates polar plot styling with color, linestyle, and marker support
+    use iso_fortran_env, only: wp => real64
+    use fortplot, only: figure, polar, title, legend, savefig_with_status
+    use fortplot_errors, only: SUCCESS
+    implicit none
+
+    call render_polar_examples()
+
+contains
+
+    subroutine render_polar_examples()
+        integer, parameter :: n = 360
+        real(wp) :: theta(n), radius_primary(n), radius_secondary(n)
+        integer :: i, status
+        logical :: ok
+
+        do i = 1, n
+            theta(i) = 2.0_wp * acos(-1.0_wp) * real(i - 1, wp) / real(n, wp)
+            radius_primary(i) = 1.0_wp + 0.3_wp * sin(4.0_wp * theta(i))
+            radius_secondary(i) = 0.6_wp + 0.2_wp * cos(3.0_wp * theta(i))
+        end do
+
+        call figure()
+        call polar(theta, radius_primary, fmt='r-', label='primary rose', &
+                   linestyle='--', marker='o', color='red')
+        call polar(theta, radius_secondary, label='secondary petals', &
+                   linestyle='-.', marker='s', color='#1f77b4')
+        call title('polar_demo: custom colors, markers, and linestyles')
+        call legend()
+
+        ok = .true.
+        call savefig_with_status('output/example/fortran/polar_demo/' // &
+                                 'polar_demo.png', status)
+        if (status /= SUCCESS) ok = .false.
+        call savefig_with_status('output/example/fortran/polar_demo/' // &
+                                 'polar_demo.txt', status)
+        if (status /= SUCCESS) ok = .false.
+        if (.not. ok) then
+            print *, 'WARNING: polar_demo failed to write one or more outputs'
+        end if
+    end subroutine render_polar_examples
+
+end program polar_demo

--- a/src/figures/core/fortplot_figure_core_specialized.f90
+++ b/src/figures/core/fortplot_figure_core_specialized.f90
@@ -177,6 +177,21 @@ contains
             if (len_trim(linestyle) > 0) final_linestyle = trim(linestyle)
         end if
 
+        if (len_trim(final_linestyle) > 0) then
+            select case (trim(final_linestyle))
+            case ('solid', 'Solid', 'SOLID')
+                final_linestyle = '-'
+            case ('dashed', 'Dashed', 'DASHED')
+                final_linestyle = '--'
+            case ('dotted', 'Dotted', 'DOTTED')
+                final_linestyle = ':'
+            case ('dashdot', 'Dashdot', 'DASHDOT')
+                final_linestyle = '-.'
+            case ('none', 'None', 'NONE')
+                final_linestyle = 'None'
+            end select
+        end if
+
         have_color = .false.
         if (present(color)) then
             call parse_color(color, color_rgb, color_ok)
@@ -188,7 +203,12 @@ contains
             end if
         else if (allocated(fmt_color)) then
             call parse_color(fmt_color, color_rgb, color_ok)
-            if (color_ok) have_color = .true.
+            if (color_ok) then
+                have_color = .true.
+            else
+                call log_warning('polar: unsupported color ' // trim(fmt_color) // &
+                                 '; using default palette color')
+            end if
         end if
 
         style_buffer = ''

--- a/test/test_pyplot_legacy_order.f90
+++ b/test/test_pyplot_legacy_order.f90
@@ -119,6 +119,25 @@ contains
         call polar(theta, r, 'r-', 'legacy-polar', '--', 'o', 'red')
         call assert_label_anywhere(fig, 'legacy-polar')
         call assert_polar_style(fig, expected_color, '--', 'o')
+
+        call reset_global(fig)
+        call parse_color('green', expected_color, color_ok)
+        if (.not. color_ok) then
+            error stop 'test_polar: expected named style color parse to succeed'
+        end if
+        call polar(theta, r, label='named-style', linestyle='solid', marker='x', &
+                   color='green')
+        call assert_label_anywhere(fig, 'named-style')
+        call assert_polar_style(fig, expected_color, '-', 'x')
+
+        call reset_global(fig)
+        call parse_color('m', expected_color, color_ok)
+        if (.not. color_ok) then
+            error stop 'test_polar: expected fmt color parse to succeed'
+        end if
+        call polar(theta, r, fmt='m:', label='fmt-color-only')
+        call assert_label_anywhere(fig, 'fmt-color-only')
+        call assert_polar_style(fig, expected_color, ':', '')
     end subroutine test_polar
 
     subroutine test_pie()


### PR DESCRIPTION
## Summary
- implement full color and style handling for polar plots and drop placeholder warnings
- forward color/alpha through fill helper and add regression coverage for both
- add a polar_demo example showcasing marker/linestyle/color options

## Verification
- make test
- make verify-artifacts
- make example ARGS="polar_demo"
