### PR TITLE
fix: Pie chart should have axis equal default (fixes #1364)

### DIFF
--- a/src/figures/core/fortplot_figure_core_io_compat.f90
+++ b/src/figures/core/fortplot_figure_core_io_compat.f90
@@ -33,7 +33,8 @@ module fortplot_figure_core_io
     use fortplot_annotation_rendering, only: render_figure_annotations
     use fortplot_figure_io, only: save_backend_with_status
     use fortplot_figure_utilities, only: is_interactive_environment, wait_for_user_input
-    use fortplot_plot_data, only: plot_data_t, subplot_data_t
+    use fortplot_plot_data, only: plot_data_t, subplot_data_t, PLOT_TYPE_PIE
+    use fortplot_scales, only: apply_scale_transform
     implicit none
 
     private
@@ -213,6 +214,10 @@ contains
                                         state%y_max_transformed, &
                                         state%xscale, state%yscale, &
                                         state%symlog_threshold)
+
+        if (contains_pie_plot_impl(plots, plot_count)) then
+            call enforce_pie_axis_equal_impl(state)
+        end if
         
         call render_single_axes_impl(state, plots, plot_count, annotations, annotation_count)
         state%rendered = .true.
@@ -365,6 +370,67 @@ contains
             end if
         end if
     end subroutine render_single_axes_impl
+
+    logical function contains_pie_plot_impl(plots, plot_count) result(has_pie)
+        !! Detect pie charts within the provided plot collection
+        type(plot_data_t), intent(in) :: plots(:)
+        integer, intent(in) :: plot_count
+        integer :: i
+
+        has_pie = .false.
+        do i = 1, plot_count
+            if (plots(i)%plot_type == PLOT_TYPE_PIE) then
+                has_pie = .true.
+                exit
+            end if
+        end do
+    end function contains_pie_plot_impl
+
+    subroutine enforce_pie_axis_equal_impl(state)
+        !! Ensure equal axis scaling for pie chart rendering in the legacy pipeline
+        type(figure_state_t), intent(inout) :: state
+
+        real(wp) :: plot_width_px, plot_height_px
+        real(wp) :: data_range_x, data_range_y
+        real(wp) :: aspect_pixels, range_ratio
+        real(wp) :: center_x, center_y
+        real(wp) :: adjusted_range
+        real(wp), parameter :: EPS = 1.0e-12_wp
+
+        if (state%xlim_set .or. state%ylim_set) return
+
+        plot_width_px = real(state%width, wp) * &
+                        max(0.0_wp, 1.0_wp - state%margin_left - state%margin_right)
+        plot_height_px = real(state%height, wp) * &
+                         max(0.0_wp, 1.0_wp - state%margin_bottom - state%margin_top)
+        if (plot_width_px <= EPS .or. plot_height_px <= EPS) return
+
+        data_range_x = state%x_max - state%x_min
+        data_range_y = state%y_max - state%y_min
+        if (data_range_x <= EPS .or. data_range_y <= EPS) return
+
+        aspect_pixels = plot_width_px / plot_height_px
+        range_ratio = data_range_x / data_range_y
+
+        if (abs(range_ratio - aspect_pixels) <= 1.0e-9_wp) then
+            return
+        else if (range_ratio > aspect_pixels) then
+            adjusted_range = data_range_x / aspect_pixels
+            center_y = 0.5_wp * (state%y_max + state%y_min)
+            state%y_min = center_y - 0.5_wp * adjusted_range
+            state%y_max = center_y + 0.5_wp * adjusted_range
+        else
+            adjusted_range = data_range_y * aspect_pixels
+            center_x = 0.5_wp * (state%x_max + state%x_min)
+            state%x_min = center_x - 0.5_wp * adjusted_range
+            state%x_max = center_x + 0.5_wp * adjusted_range
+        end if
+
+        state%x_min_transformed = apply_scale_transform(state%x_min, state%xscale, state%symlog_threshold)
+        state%x_max_transformed = apply_scale_transform(state%x_max, state%xscale, state%symlog_threshold)
+        state%y_min_transformed = apply_scale_transform(state%y_min, state%yscale, state%symlog_threshold)
+        state%y_max_transformed = apply_scale_transform(state%y_max, state%yscale, state%symlog_threshold)
+    end subroutine enforce_pie_axis_equal_impl
 
 end module fortplot_figure_core_io
 ! ==== End: src/figures/core/fortplot_figure_core_io.f90 ====

--- a/src/figures/core/fortplot_figure_core_io_compat.f90
+++ b/src/figures/core/fortplot_figure_core_io_compat.f90
@@ -33,8 +33,8 @@ module fortplot_figure_core_io
     use fortplot_annotation_rendering, only: render_figure_annotations
     use fortplot_figure_io, only: save_backend_with_status
     use fortplot_figure_utilities, only: is_interactive_environment, wait_for_user_input
-    use fortplot_plot_data, only: plot_data_t, subplot_data_t, PLOT_TYPE_PIE
-    use fortplot_scales, only: apply_scale_transform
+    use fortplot_plot_data, only: plot_data_t, subplot_data_t
+    use fortplot_figure_aspect, only: contains_pie_plot, enforce_pie_axis_equal
     implicit none
 
     private
@@ -215,8 +215,8 @@ contains
                                         state%xscale, state%yscale, &
                                         state%symlog_threshold)
 
-        if (contains_pie_plot_impl(plots, plot_count)) then
-            call enforce_pie_axis_equal_impl(state)
+        if (contains_pie_plot(plots, plot_count)) then
+            call enforce_pie_axis_equal(state)
         end if
         
         call render_single_axes_impl(state, plots, plot_count, annotations, annotation_count)
@@ -370,67 +370,6 @@ contains
             end if
         end if
     end subroutine render_single_axes_impl
-
-    logical function contains_pie_plot_impl(plots, plot_count) result(has_pie)
-        !! Detect pie charts within the provided plot collection
-        type(plot_data_t), intent(in) :: plots(:)
-        integer, intent(in) :: plot_count
-        integer :: i
-
-        has_pie = .false.
-        do i = 1, plot_count
-            if (plots(i)%plot_type == PLOT_TYPE_PIE) then
-                has_pie = .true.
-                exit
-            end if
-        end do
-    end function contains_pie_plot_impl
-
-    subroutine enforce_pie_axis_equal_impl(state)
-        !! Ensure equal axis scaling for pie chart rendering in the legacy pipeline
-        type(figure_state_t), intent(inout) :: state
-
-        real(wp) :: plot_width_px, plot_height_px
-        real(wp) :: data_range_x, data_range_y
-        real(wp) :: aspect_pixels, range_ratio
-        real(wp) :: center_x, center_y
-        real(wp) :: adjusted_range
-        real(wp), parameter :: EPS = 1.0e-12_wp
-
-        if (state%xlim_set .or. state%ylim_set) return
-
-        plot_width_px = real(state%width, wp) * &
-                        max(0.0_wp, 1.0_wp - state%margin_left - state%margin_right)
-        plot_height_px = real(state%height, wp) * &
-                         max(0.0_wp, 1.0_wp - state%margin_bottom - state%margin_top)
-        if (plot_width_px <= EPS .or. plot_height_px <= EPS) return
-
-        data_range_x = state%x_max - state%x_min
-        data_range_y = state%y_max - state%y_min
-        if (data_range_x <= EPS .or. data_range_y <= EPS) return
-
-        aspect_pixels = plot_width_px / plot_height_px
-        range_ratio = data_range_x / data_range_y
-
-        if (abs(range_ratio - aspect_pixels) <= 1.0e-9_wp) then
-            return
-        else if (range_ratio > aspect_pixels) then
-            adjusted_range = data_range_x / aspect_pixels
-            center_y = 0.5_wp * (state%y_max + state%y_min)
-            state%y_min = center_y - 0.5_wp * adjusted_range
-            state%y_max = center_y + 0.5_wp * adjusted_range
-        else
-            adjusted_range = data_range_y * aspect_pixels
-            center_x = 0.5_wp * (state%x_max + state%x_min)
-            state%x_min = center_x - 0.5_wp * adjusted_range
-            state%x_max = center_x + 0.5_wp * adjusted_range
-        end if
-
-        state%x_min_transformed = apply_scale_transform(state%x_min, state%xscale, state%symlog_threshold)
-        state%x_max_transformed = apply_scale_transform(state%x_max, state%xscale, state%symlog_threshold)
-        state%y_min_transformed = apply_scale_transform(state%y_min, state%yscale, state%symlog_threshold)
-        state%y_max_transformed = apply_scale_transform(state%y_max, state%yscale, state%symlog_threshold)
-    end subroutine enforce_pie_axis_equal_impl
 
 end module fortplot_figure_core_io
 ! ==== End: src/figures/core/fortplot_figure_core_io.f90 ====

--- a/src/figures/fortplot_figure_aspect.f90
+++ b/src/figures/fortplot_figure_aspect.f90
@@ -1,0 +1,82 @@
+module fortplot_figure_aspect
+    !! Helper routines for enforcing axis aspect ratios in figures
+
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    use fortplot_plot_data, only: plot_data_t, PLOT_TYPE_PIE
+    use fortplot_figure_initialization, only: figure_state_t
+    use fortplot_scales, only: apply_scale_transform
+    implicit none
+
+    private
+    public :: contains_pie_plot, enforce_pie_axis_equal
+
+contains
+
+    logical function contains_pie_plot(plots, plot_count) result(has_pie)
+        !! Detect whether a collection of plots contains at least one pie chart
+        type(plot_data_t), intent(in) :: plots(:)
+        integer, intent(in) :: plot_count
+        integer :: i, upper
+
+        has_pie = .false.
+        upper = min(plot_count, size(plots))
+        do i = 1, upper
+            if (plots(i)%plot_type == PLOT_TYPE_PIE) then
+                has_pie = .true.
+                return
+            end if
+        end do
+    end function contains_pie_plot
+
+    subroutine enforce_pie_axis_equal(state)
+        !! Adjust the figure axis limits so pie charts render with equal scaling
+        type(figure_state_t), intent(inout) :: state
+
+        real(wp), parameter :: EPS = 1.0e-12_wp
+        real(wp), parameter :: ASPECT_TOL = 1.0e-9_wp
+        real(wp) :: plot_width_px, plot_height_px
+        real(wp) :: data_range_x, data_range_y
+        real(wp) :: aspect_pixels, range_ratio
+        real(wp) :: center_x, center_y
+        real(wp) :: adjusted_range
+
+        if (state%xlim_set .or. state%ylim_set) return
+
+        plot_width_px = real(state%width, wp) * &
+                        max(0.0_wp, 1.0_wp - state%margin_left - state%margin_right)
+        plot_height_px = real(state%height, wp) * &
+                         max(0.0_wp, 1.0_wp - state%margin_bottom - state%margin_top)
+        if (plot_width_px <= EPS .or. plot_height_px <= EPS) return
+
+        data_range_x = state%x_max - state%x_min
+        data_range_y = state%y_max - state%y_min
+        if (data_range_x <= EPS .or. data_range_y <= EPS) return
+
+        aspect_pixels = plot_width_px / plot_height_px
+        range_ratio = data_range_x / data_range_y
+
+        if (abs(range_ratio - aspect_pixels) <= ASPECT_TOL) return
+
+        if (range_ratio > aspect_pixels) then
+            adjusted_range = data_range_x / aspect_pixels
+            center_y = 0.5_wp * (state%y_max + state%y_min)
+            state%y_min = center_y - 0.5_wp * adjusted_range
+            state%y_max = center_y + 0.5_wp * adjusted_range
+        else
+            adjusted_range = data_range_y * aspect_pixels
+            center_x = 0.5_wp * (state%x_max + state%x_min)
+            state%x_min = center_x - 0.5_wp * adjusted_range
+            state%x_max = center_x + 0.5_wp * adjusted_range
+        end if
+
+        state%x_min_transformed = apply_scale_transform(state%x_min, state%xscale, &
+                                                        state%symlog_threshold)
+        state%x_max_transformed = apply_scale_transform(state%x_max, state%xscale, &
+                                                        state%symlog_threshold)
+        state%y_min_transformed = apply_scale_transform(state%y_min, state%yscale, &
+                                                        state%symlog_threshold)
+        state%y_max_transformed = apply_scale_transform(state%y_max, state%yscale, &
+                                                        state%symlog_threshold)
+    end subroutine enforce_pie_axis_equal
+
+end module fortplot_figure_aspect

--- a/src/figures/management/fortplot_figure_operations.f90
+++ b/src/figures/management/fortplot_figure_operations.f90
@@ -14,7 +14,7 @@ module fortplot_figure_operations
 
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_context
-    use fortplot_plot_data, only: plot_data_t
+    use fortplot_plot_data, only: plot_data_t, PLOT_TYPE_PIE
     use fortplot_figure_initialization, only: figure_state_t
     use fortplot_legend, only: legend_t
     use fortplot_figure_plots, only: figure_add_plot, figure_add_contour, &
@@ -38,6 +38,7 @@ module fortplot_figure_operations
                                                     render_figure_axes_labels_only
     use fortplot_figure_grid, only: render_grid_lines
     use fortplot_annotation_rendering, only: render_figure_annotations
+    use fortplot_scales, only: apply_scale_transform
     implicit none
 
     private
@@ -332,6 +333,10 @@ contains
                                         state%y_max_transformed, &
                                         state%xscale, state%yscale, &
                                         state%symlog_threshold)
+
+        if (contains_pie_plot(plots, plot_count)) then
+            call enforce_pie_axis_equal(state)
+        end if
         
         ! Setup coordinate system
         call setup_coordinate_system(state%backend, &
@@ -398,5 +403,66 @@ contains
         
         state%rendered = .true.
     end subroutine figure_render
+
+    logical function contains_pie_plot(plots, plot_count) result(has_pie)
+        !! Detect whether any plot in the current figure is a pie chart
+        type(plot_data_t), intent(in) :: plots(:)
+        integer, intent(in) :: plot_count
+        integer :: i
+
+        has_pie = .false.
+        do i = 1, plot_count
+            if (plots(i)%plot_type == PLOT_TYPE_PIE) then
+                has_pie = .true.
+                exit
+            end if
+        end do
+    end function contains_pie_plot
+
+    subroutine enforce_pie_axis_equal(state)
+        !! Enforce equal data scaling when rendering pie charts
+        type(figure_state_t), intent(inout) :: state
+
+        real(wp) :: plot_width_px, plot_height_px
+        real(wp) :: data_range_x, data_range_y
+        real(wp) :: aspect_pixels, range_ratio
+        real(wp) :: center_x, center_y
+        real(wp) :: adjusted_range
+        real(wp), parameter :: EPS = 1.0e-12_wp
+
+        if (state%xlim_set .or. state%ylim_set) return
+
+        plot_width_px = real(state%width, wp) * &
+                        max(0.0_wp, 1.0_wp - state%margin_left - state%margin_right)
+        plot_height_px = real(state%height, wp) * &
+                         max(0.0_wp, 1.0_wp - state%margin_bottom - state%margin_top)
+        if (plot_width_px <= EPS .or. plot_height_px <= EPS) return
+
+        data_range_x = state%x_max - state%x_min
+        data_range_y = state%y_max - state%y_min
+        if (data_range_x <= EPS .or. data_range_y <= EPS) return
+
+        aspect_pixels = plot_width_px / plot_height_px
+        range_ratio = data_range_x / data_range_y
+
+        if (abs(range_ratio - aspect_pixels) <= 1.0e-9_wp) then
+            return
+        else if (range_ratio > aspect_pixels) then
+            adjusted_range = data_range_x / aspect_pixels
+            center_y = 0.5_wp * (state%y_max + state%y_min)
+            state%y_min = center_y - 0.5_wp * adjusted_range
+            state%y_max = center_y + 0.5_wp * adjusted_range
+        else
+            adjusted_range = data_range_y * aspect_pixels
+            center_x = 0.5_wp * (state%x_max + state%x_min)
+            state%x_min = center_x - 0.5_wp * adjusted_range
+            state%x_max = center_x + 0.5_wp * adjusted_range
+        end if
+
+        state%x_min_transformed = apply_scale_transform(state%x_min, state%xscale, state%symlog_threshold)
+        state%x_max_transformed = apply_scale_transform(state%x_max, state%xscale, state%symlog_threshold)
+        state%y_min_transformed = apply_scale_transform(state%y_min, state%yscale, state%symlog_threshold)
+        state%y_max_transformed = apply_scale_transform(state%y_max, state%yscale, state%symlog_threshold)
+    end subroutine enforce_pie_axis_equal
 
 end module fortplot_figure_operations

--- a/test/test_pie_axis_equal.f90
+++ b/test/test_pie_axis_equal.f90
@@ -1,0 +1,51 @@
+program test_pie_axis_equal
+    use iso_fortran_env, only: real64
+    use fortplot, only: figure, pie, savefig, get_global_figure, figure_t
+    implicit none
+
+    character(len=*), parameter :: output_dir = 'build/test/output/'
+    character(len=*), parameter :: filename = output_dir//'test_pie_axis_equal.png'
+    real(real64) :: values(3)
+    class(figure_t), pointer :: fig_ptr
+    real(real64) :: plot_width_px, plot_height_px
+    real(real64) :: range_x, range_y
+    real(real64) :: scale_x, scale_y
+    real(real64) :: aspect_diff
+
+    values = [1.0_real64, 3.0_real64, 2.0_real64]
+
+    call figure()
+    call pie(values)
+    call savefig(filename)
+
+    fig_ptr => get_global_figure()
+
+    range_x = fig_ptr%state%x_max - fig_ptr%state%x_min
+    range_y = fig_ptr%state%y_max - fig_ptr%state%y_min
+
+    if (range_x <= 0.0_real64 .or. range_y <= 0.0_real64) then
+        error stop 'Pie axis ranges are invalid'
+    end if
+
+    plot_width_px = real(fig_ptr%state%width, real64) * &
+                    max(0.0_real64, 1.0_real64 - fig_ptr%state%margin_left - &
+                    fig_ptr%state%margin_right)
+    plot_height_px = real(fig_ptr%state%height, real64) * &
+                     max(0.0_real64, 1.0_real64 - fig_ptr%state%margin_bottom - &
+                     fig_ptr%state%margin_top)
+
+    if (plot_width_px <= 0.0_real64 .or. plot_height_px <= 0.0_real64) then
+        error stop 'Plot area dimensions are invalid'
+    end if
+
+    scale_x = plot_width_px / range_x
+    scale_y = plot_height_px / range_y
+    aspect_diff = abs(scale_x - scale_y) / max(scale_x, scale_y)
+
+    if (aspect_diff > 1.0e-6_real64) then
+        write(*,*) 'scale_x = ', scale_x, 'scale_y = ', scale_y
+        error stop 'Pie axis scaling is not equal'
+    end if
+
+    print *, '✓ Pie chart uses equal axis scaling by default'
+end program test_pie_axis_equal

--- a/test/test_pie_axis_equal.f90
+++ b/test/test_pie_axis_equal.f90
@@ -1,40 +1,43 @@
 program test_pie_axis_equal
-    use iso_fortran_env, only: real64
+    use, intrinsic :: iso_fortran_env, only: dp => real64
     use fortplot, only: figure, pie, savefig, get_global_figure, figure_t
     implicit none
 
     character(len=*), parameter :: output_dir = 'build/test/output/'
     character(len=*), parameter :: filename = output_dir//'test_pie_axis_equal.png'
-    real(real64) :: values(3)
+    real(dp) :: values(3)
     class(figure_t), pointer :: fig_ptr
-    real(real64) :: plot_width_px, plot_height_px
-    real(real64) :: range_x, range_y
-    real(real64) :: scale_x, scale_y
-    real(real64) :: aspect_diff
+    real(dp) :: plot_width_px, plot_height_px
+    real(dp) :: range_x, range_y
+    real(dp) :: scale_x, scale_y
+    real(dp) :: aspect_diff
 
-    values = [1.0_real64, 3.0_real64, 2.0_real64]
+    values = [1.0_dp, 3.0_dp, 2.0_dp]
 
     call figure()
     call pie(values)
     call savefig(filename)
 
     fig_ptr => get_global_figure()
+    if (.not. associated(fig_ptr)) then
+        error stop 'Global figure not available after pie render'
+    end if
 
     range_x = fig_ptr%state%x_max - fig_ptr%state%x_min
     range_y = fig_ptr%state%y_max - fig_ptr%state%y_min
 
-    if (range_x <= 0.0_real64 .or. range_y <= 0.0_real64) then
+    if (range_x <= 0.0_dp .or. range_y <= 0.0_dp) then
         error stop 'Pie axis ranges are invalid'
     end if
 
-    plot_width_px = real(fig_ptr%state%width, real64) * &
-                    max(0.0_real64, 1.0_real64 - fig_ptr%state%margin_left - &
+    plot_width_px = real(fig_ptr%state%width, dp) * &
+                    max(0.0_dp, 1.0_dp - fig_ptr%state%margin_left - &
                     fig_ptr%state%margin_right)
-    plot_height_px = real(fig_ptr%state%height, real64) * &
-                     max(0.0_real64, 1.0_real64 - fig_ptr%state%margin_bottom - &
+    plot_height_px = real(fig_ptr%state%height, dp) * &
+                     max(0.0_dp, 1.0_dp - fig_ptr%state%margin_bottom - &
                      fig_ptr%state%margin_top)
 
-    if (plot_width_px <= 0.0_real64 .or. plot_height_px <= 0.0_real64) then
+    if (plot_width_px <= 0.0_dp .or. plot_height_px <= 0.0_dp) then
         error stop 'Plot area dimensions are invalid'
     end if
 
@@ -42,7 +45,7 @@ program test_pie_axis_equal
     scale_y = plot_height_px / range_y
     aspect_diff = abs(scale_x - scale_y) / max(scale_x, scale_y)
 
-    if (aspect_diff > 1.0e-6_real64) then
+    if (aspect_diff > 1.0e-6_dp) then
         write(*,*) 'scale_x = ', scale_x, 'scale_y = ', scale_y
         error stop 'Pie axis scaling is not equal'
     end if


### PR DESCRIPTION
## Summary
- enforce equal axis scaling when rendering pie charts
- apply the same adjustment in the legacy rendering path
- add regression coverage for pie axis aspect ratio

## Verification
- make test