### PR TITLE
fix: Implement twin_x and twin_y (fixes #1358)

### DIFF
--- a/example/fortran/README.md
+++ b/example/fortran/README.md
@@ -41,6 +41,7 @@ make example ARGS="example_name"
 - [legend_demo](./legend_demo/) - Legend placement options
 - [unicode_demo](./unicode_demo/) - Mathematical symbols
 - [grid_demo](./grid_demo/) - Grid lines and formatting
+- [twin_axes_demo](./twin_axes_demo/) - Dual axes with independent scales
 
 ### Annotations and Layout
 - [annotation_demo](./annotation_demo/) - Text and arrow annotations

--- a/example/fortran/twin_axes_demo/README.md
+++ b/example/fortran/twin_axes_demo/README.md
@@ -1,0 +1,17 @@
+# twin_axes_demo
+
+Demonstrates the `twinx` and `twiny` helpers introduced in issue #1358. The
+demo plots three synthetic time series and assigns each to a different axis:
+
+- Left y-axis: primary signal (temperature-like)
+- Right y-axis: secondary signal with log scaling
+- Top x-axis: cumulative index with log scaling
+
+Run the example via:
+
+```bash
+make example ARGS="twin_axes_demo"
+```
+
+Outputs are written to `output/example/fortran/twin_axes_demo/` in PNG and ASCII
+formats.

--- a/example/fortran/twin_axes_demo/twin_axes_demo.f90
+++ b/example/fortran/twin_axes_demo/twin_axes_demo.f90
@@ -1,0 +1,55 @@
+program twin_axes_demo
+    !! Demonstrates twin x/y axis support with independent scaling and labels
+    use iso_fortran_env, only: wp => real64
+    use fortplot, only: figure, plot, twinx, twiny, use_axis, xlabel, ylabel, title
+    use fortplot, only: legend, set_yscale, set_xscale, savefig_with_status
+    use fortplot_errors, only: SUCCESS
+    implicit none
+
+    integer, parameter :: n = 120
+    real(wp) :: time_hours(n)
+    real(wp) :: primary_signal(n)
+    real(wp) :: secondary_signal(n)
+    real(wp) :: cumulative_index(n)
+    integer :: i, status
+    logical :: ok
+
+    do i = 1, n
+        time_hours(i) = real(i - 1, wp) / 4.0_wp
+        primary_signal(i) = 15.0_wp + 8.0_wp * sin( &
+            2.0_wp * acos(-1.0_wp) * time_hours(i) / 24.0_wp)
+        secondary_signal(i) = 40.0_wp + 10.0_wp * exp(-0.05_wp * time_hours(i))
+        cumulative_index(i) = log(1.0_wp + real(i, wp))
+    end do
+
+    call figure()
+    call plot(time_hours, primary_signal, label='Primary axis')
+    call ylabel('Temperature (relative)')
+
+    call twinx()
+    call plot(time_hours, secondary_signal, label='Secondary axis')
+    call set_yscale('log')
+    call ylabel('Humidity (log scale)')
+
+    call twiny()
+    call plot(cumulative_index, primary_signal, label='Top axis')
+    call set_xscale('log')
+    call xlabel('Cumulative index (log scale)')
+
+    call use_axis('primary')
+    call xlabel('Time (hours)')
+    call title('Twin axis demo')
+    call legend()
+
+    ok = .true.
+    call savefig_with_status('output/example/fortran/twin_axes_demo/' // &
+                             'twin_axes_demo.png', status)
+    if (status /= SUCCESS) ok = .false.
+    call savefig_with_status('output/example/fortran/twin_axes_demo/' // &
+                             'twin_axes_demo.txt', status)
+    if (status /= SUCCESS) ok = .false.
+    if (.not. ok) then
+        print *, 'WARNING: Failed to write one or more twin axis demo outputs'
+    end if
+
+end program twin_axes_demo

--- a/src/backends/raster/fortplot_raster_labels.f90
+++ b/src/backends/raster/fortplot_raster_labels.f90
@@ -10,14 +10,18 @@ module fortplot_raster_labels
     use fortplot_text_helpers, only: prepare_mathtext_if_needed
     use fortplot_margins, only: plot_area_t
     use fortplot_raster_core, only: raster_image_t
-    use fortplot_bitmap, only: render_text_to_bitmap, rotate_bitmap_90_ccw, composite_bitmap_to_raster
-    use fortplot_raster_ticks, only: last_y_tick_max_width, Y_TICK_LABEL_RIGHT_PAD
+    use fortplot_bitmap, only: render_text_to_bitmap, rotate_bitmap_90_ccw, rotate_bitmap_90_cw, composite_bitmap_to_raster
+    use fortplot_raster_ticks, only: last_y_tick_max_width, last_y_tick_max_width_right, &
+                                     last_x_tick_max_height_top, Y_TICK_LABEL_RIGHT_PAD, &
+                                     Y_TICK_LABEL_LEFT_PAD, X_TICK_LABEL_TOP_PAD
     use, intrinsic :: iso_fortran_env, only: wp => real64
     implicit none
 
     private
     public :: raster_draw_axis_labels
     public :: raster_render_ylabel
+    public :: raster_render_ylabel_right
+    public :: raster_draw_top_xlabel
     public :: render_title_centered
     public :: compute_title_position
     public :: compute_ylabel_x_pos
@@ -123,6 +127,74 @@ contains
         deallocate(text_bitmap, rotated_bitmap)
     end subroutine raster_render_ylabel
 
+    integer function y_tick_label_left_edge_at_axis(plot_area, max_width_measured)
+        !! Compute the leftmost edge of right-side y-tick labels relative to the axis
+        type(plot_area_t), intent(in) :: plot_area
+        integer, intent(in) :: max_width_measured
+
+        y_tick_label_left_edge_at_axis = plot_area%left + plot_area%width + TICK_MARK_LENGTH + Y_TICK_LABEL_LEFT_PAD
+    end function y_tick_label_left_edge_at_axis
+
+    integer function compute_ylabel_right_x_pos(y_tick_label_edge, rotated_width, plot_area, canvas_width)
+        !! Compute x-position for right-side ylabel avoiding overlap with tick labels
+        integer, intent(in) :: y_tick_label_edge
+        integer, intent(in) :: rotated_width
+        type(plot_area_t), intent(in) :: plot_area
+        integer, intent(in) :: canvas_width
+
+        compute_ylabel_right_x_pos = y_tick_label_edge + YLABEL_EXTRA_GAP
+        if (compute_ylabel_right_x_pos + rotated_width > canvas_width - 15) then
+            compute_ylabel_right_x_pos = max(plot_area%left + plot_area%width + 5, canvas_width - rotated_width - 15)
+        end if
+    end function compute_ylabel_right_x_pos
+
+    subroutine raster_render_ylabel_right(raster, width, height, plot_area, ylabel)
+        !! Render rotated ylabel along the right side of the axis
+        type(raster_image_t), intent(inout) :: raster
+        integer, intent(in) :: width, height
+        type(plot_area_t), intent(in) :: plot_area
+        character(len=*), intent(in) :: ylabel
+        character(len=500) :: processed_text
+        character(len=600) :: math_ready
+        character(len=600) :: escaped_text
+        integer :: processed_len, math_len
+        integer(1), allocatable :: text_bitmap(:,:,:), rotated_bitmap(:,:,:)
+        integer :: text_width, text_height, text_descent
+        integer :: rotated_width, rotated_height
+        integer :: target_x, target_y
+        integer :: y_tick_label_edge
+
+        if (len_trim(ylabel) == 0) return
+
+        call process_latex_in_text(trim(ylabel), processed_text, processed_len)
+        call prepare_mathtext_if_needed(processed_text(1:processed_len), math_ready, math_len)
+        call escape_unicode_for_raster(math_ready(1:math_len), escaped_text)
+
+        text_width = calculate_text_width(trim(escaped_text))
+        text_height = calculate_text_height(trim(escaped_text))
+        text_descent = calculate_text_descent(trim(escaped_text))
+
+        allocate(text_bitmap(text_width, text_height, 3))
+        text_bitmap = -1_1
+
+        call render_text_to_bitmap(text_bitmap, text_width, text_height, 0, text_height - text_descent, &
+            trim(escaped_text))
+
+        rotated_width = text_height
+        rotated_height = text_width
+        allocate(rotated_bitmap(rotated_width, rotated_height, 3))
+        call rotate_bitmap_90_cw(text_bitmap, rotated_bitmap, text_width, text_height)
+
+        y_tick_label_edge = y_tick_label_left_edge_at_axis(plot_area, last_y_tick_max_width_right)
+        target_x = compute_ylabel_right_x_pos(y_tick_label_edge, rotated_width, plot_area, width)
+        target_y = plot_area%bottom + plot_area%height/2 - rotated_height/2
+
+        call composite_bitmap_to_raster(raster%image_data, width, height, rotated_bitmap, &
+            rotated_width, rotated_height, target_x, target_y)
+
+        deallocate(text_bitmap, rotated_bitmap)
+    end subroutine raster_render_ylabel_right
+
     integer function y_tick_label_right_edge_at_axis(plot_area, max_width_measured)
         !! Compute the rightmost edge of y-tick labels relative to the y-axis
         type(plot_area_t), intent(in) :: plot_area
@@ -155,6 +227,44 @@ contains
             end if
         end block
     end function compute_ylabel_x_pos
+
+    integer function compute_top_xlabel_y_pos(plot_area, label_height)
+        !! Compute y-position for an x-label rendered above the axis
+        type(plot_area_t), intent(in) :: plot_area
+        integer, intent(in) :: label_height
+
+        compute_top_xlabel_y_pos = max(1, plot_area%bottom - X_TICK_LABEL_TOP_PAD - last_x_tick_max_height_top - label_height - 5)
+    end function compute_top_xlabel_y_pos
+
+    subroutine raster_draw_top_xlabel(raster, width, height, plot_area, xlabel)
+        !! Render an xlabel centered above the plot area
+        type(raster_image_t), intent(inout) :: raster
+        integer, intent(in) :: width, height
+        type(plot_area_t), intent(in) :: plot_area
+        character(len=*), intent(in) :: xlabel
+        character(len=500) :: processed_text
+        character(len=600) :: math_ready
+        character(len=600) :: escaped_text
+        integer :: processed_len, math_len
+        integer :: label_width, label_height
+        integer :: label_x, label_y
+
+        if (len_trim(xlabel) == 0) return
+
+        call process_latex_in_text(trim(xlabel), processed_text, processed_len)
+        call prepare_mathtext_if_needed(processed_text(1:processed_len), math_ready, math_len)
+        call escape_unicode_for_raster(math_ready(1:math_len), escaped_text)
+
+        label_width = calculate_text_width(trim(escaped_text))
+        label_height = calculate_text_height(trim(escaped_text))
+        if (label_height <= 0) label_height = 12
+
+        label_x = plot_area%left + plot_area%width/2 - label_width/2
+        label_y = compute_top_xlabel_y_pos(plot_area, label_height)
+
+        call render_text_to_image(raster%image_data, width, height, label_x, label_y, &
+            trim(escaped_text), 0_1, 0_1, 0_1)
+    end subroutine raster_draw_top_xlabel
 
     subroutine render_title_centered(raster, width, height, plot_area, title_text)
         !! Render title centered above the plot area

--- a/src/core/fortplot.f90
+++ b/src/core/fortplot.f90
@@ -93,7 +93,7 @@ module fortplot
                                    add_plot, add_contour, add_contour_filled, add_pcolormesh, add_errorbar, &
                                    add_3d_plot, add_surface, add_scatter, &
                                    set_xscale, set_yscale, xlim, ylim, &
-                                   set_line_width, set_ydata, &
+                                   set_line_width, set_ydata, use_axis, get_active_axis, &
                                    show, show_viewer, &
                                    ensure_global_figure_initialized, get_global_figure
 
@@ -127,7 +127,7 @@ module fortplot
     public :: figure, subplot, subplots, subplots_grid
     public :: xlabel, ylabel, title, legend, grid
     public :: xlim, ylim, set_xscale, set_yscale
-    public :: set_line_width, set_ydata
+    public :: set_line_width, set_ydata, use_axis, get_active_axis
     public :: savefig, savefig_with_status
     
     ! Extended plotting functions

--- a/src/figures/core/fortplot_figure_core_io_compat.f90
+++ b/src/figures/core/fortplot_figure_core_io_compat.f90
@@ -284,7 +284,8 @@ contains
                                        subplots_array(i,j)%xlabel, &
                                        subplots_array(i,j)%ylabel, &
                                        subplots_array(i,j)%plots, &
-                                       subplots_array(i,j)%plot_count)
+                                       subplots_array(i,j)%plot_count, &
+                                       has_twinx=.false., has_twiny=.false.)
 
                 if (subplots_array(i,j)%plot_count > 0) then
                     call render_all_plots(state%backend, subplots_array(i,j)%plots, subplots_array(i,j)%plot_count, &
@@ -301,7 +302,8 @@ contains
                                                    subplots_array(i,j)%xlabel, &
                                                    subplots_array(i,j)%ylabel, &
                                                    subplots_array(i,j)%plots, &
-                                                   subplots_array(i,j)%plot_count)
+                                                   subplots_array(i,j)%plot_count, &
+                                                   has_twinx=.false., has_twiny=.false.)
             end do
         end do
     end subroutine render_subplots_impl
@@ -338,7 +340,12 @@ contains
         call render_figure_axes(state%backend, state%xscale, state%yscale, &
                                state%symlog_threshold, state%x_min, state%x_max, &
                                state%y_min, state%y_max, state%title, &
-                               state%xlabel, state%ylabel, plots, plot_count)
+                               state%xlabel, state%ylabel, plots, plot_count, &
+                               has_twinx=state%has_twinx, twinx_y_min=state%twinx_y_min, &
+                               twinx_y_max=state%twinx_y_max, twinx_ylabel=state%twinx_ylabel, &
+                               twinx_yscale=state%twinx_yscale, has_twiny=state%has_twiny, &
+                               twiny_x_min=state%twiny_x_min, twiny_x_max=state%twiny_x_max, &
+                               twiny_xlabel=state%twiny_xlabel, twiny_xscale=state%twiny_xscale)
 
         if (plot_count > 0) then
             call render_all_plots(state%backend, plots, plot_count, &
@@ -347,13 +354,18 @@ contains
                                  state%xscale, state%yscale, state%symlog_threshold, &
                                  state%width, state%height, &
                                  state%margin_left, state%margin_right, &
-                                 state%margin_bottom, state%margin_top)
+                                 state%margin_bottom, state%margin_top, state=state)
         end if
 
         call render_figure_axes_labels_only(state%backend, state%xscale, state%yscale, &
                                            state%symlog_threshold, state%x_min, state%x_max, &
                                            state%y_min, state%y_max, state%title, &
-                                           state%xlabel, state%ylabel, plots, plot_count)
+                                           state%xlabel, state%ylabel, plots, plot_count, &
+                                           has_twinx=state%has_twinx, twinx_y_min=state%twinx_y_min, &
+                                           twinx_y_max=state%twinx_y_max, twinx_ylabel=state%twinx_ylabel, &
+                                           twinx_yscale=state%twinx_yscale, has_twiny=state%has_twiny, &
+                                           twiny_x_min=state%twiny_x_min, twiny_x_max=state%twiny_x_max, &
+                                           twiny_xlabel=state%twiny_xlabel, twiny_xscale=state%twiny_xscale)
 
         if (state%show_legend .and. state%legend_data%num_entries > 0) then
             call state%legend_data%render(state%backend)

--- a/src/figures/core/fortplot_figure_core_ops.f90
+++ b/src/figures/core/fortplot_figure_core_ops.f90
@@ -520,7 +520,7 @@ contains
         real(wp), intent(in) :: default_color(3)
         
         ! Delegate to efficient scatter implementation
-        call figure_scatter_operation(plots, state%plot_count, &
+        call figure_scatter_operation(state, plots, state%plot_count, &
                                      x, y, s, c, marker, markersize, color, &
                                      colormap, vmin, vmax, label, show_colorbar, &
                                      default_color)
@@ -546,10 +546,11 @@ contains
         call figure_hist_operation(plots, state, plot_count, data, bins, density, label, color)
     end subroutine core_hist
 
-    subroutine core_boxplot(plots, plot_count, data, position, width, label, &
+    subroutine core_boxplot(plots, state, plot_count, data, position, width, label, &
                            show_outliers, horizontal, color, max_plots)
         !! Create a box plot
         type(plot_data_t), allocatable, intent(inout) :: plots(:)
+        type(figure_state_t), intent(in) :: state
         integer, intent(inout) :: plot_count
         real(wp), intent(in) :: data(:)
         real(wp), intent(in), optional :: position
@@ -560,7 +561,7 @@ contains
         character(len=*), intent(in), optional :: color
         integer, intent(in) :: max_plots
         
-        call figure_boxplot_operation(plots, plot_count, data, position, width, label, &
+        call figure_boxplot_operation(state, plots, plot_count, data, position, width, label, &
                                      show_outliers, horizontal, color, max_plots)
     end subroutine core_boxplot
 

--- a/src/figures/fortplot_figure_data_ranges.f90
+++ b/src/figures/fortplot_figure_data_ranges.f90
@@ -18,7 +18,7 @@ contains
                                           x_min, x_max, y_min, y_max, &
                                           x_min_transformed, x_max_transformed, &
                                           y_min_transformed, y_max_transformed, &
-                                          xscale, yscale, symlog_threshold)
+                                          xscale, yscale, symlog_threshold, axis_filter)
         !! Calculate overall data ranges for the figure with robust edge case handling
         !! Fixed Issue #432: Handles zero-size arrays and single points properly
         type(plot_data_t), intent(in) :: plots(:)
@@ -29,10 +29,16 @@ contains
         real(wp), intent(out) :: y_min_transformed, y_max_transformed
         character(len=*), intent(in) :: xscale, yscale
         real(wp), intent(in) :: symlog_threshold
-        
+        integer, intent(in), optional :: axis_filter
+
         real(wp) :: x_min_data, x_max_data, y_min_data, y_max_data
         logical :: first_plot, has_valid_data
         integer :: i
+        integer :: filtered_axis
+        logical :: use_filter
+
+        use_filter = present(axis_filter)
+        if (use_filter) filtered_axis = axis_filter
         
         ! Initialize data ranges and check for early return
         call initialize_data_ranges(xlim_set, ylim_set, x_min, x_max, y_min, y_max, &
@@ -45,6 +51,9 @@ contains
         
         ! Process all plots to calculate data ranges
         do i = 1, plot_count
+            if (use_filter) then
+                if (plots(i)%axis /= filtered_axis) cycle
+            end if
             select case (plots(i)%plot_type)
             case (PLOT_TYPE_LINE)
                 call process_line_plot_ranges(plots(i), first_plot, has_valid_data, &

--- a/src/interfaces/fortplot_matplotlib.f90
+++ b/src/interfaces/fortplot_matplotlib.f90
@@ -17,7 +17,7 @@ module fortplot_matplotlib
         add_contour, add_contour_filled, add_pcolormesh, add_surface, &
         xlabel, ylabel, title, legend, grid, &
         xlim, ylim, set_xscale, set_yscale, &
-        set_line_width, set_ydata, &
+        set_line_width, set_ydata, use_axis, get_active_axis, &
         figure, subplot, subplots, subplots_grid, savefig, savefig_with_status, &
         show, show_viewer, get_global_figure, ensure_global_figure_initialized
     
@@ -42,7 +42,7 @@ module fortplot_matplotlib
     ! Axis and annotation functions
     public :: xlabel, ylabel, title, legend, grid
     public :: xlim, ylim, set_xscale, set_yscale
-    public :: set_line_width, set_ydata
+    public :: set_line_width, set_ydata, use_axis, get_active_axis
     public :: text, annotate
     
     ! Figure management functions

--- a/src/interfaces/fortplot_matplotlib_advanced.f90
+++ b/src/interfaces/fortplot_matplotlib_advanced.f90
@@ -9,7 +9,7 @@ module fortplot_matplotlib_advanced
         add_contour_filled, add_pcolormesh, add_surface
     use fortplot_matplotlib_axes, only: &
         xlabel, ylabel, title, legend, grid, xlim, ylim, set_xscale, set_yscale, &
-        set_line_width, set_ydata
+        set_line_width, set_ydata, use_axis, get_active_axis
     use fortplot_matplotlib_session, only: &
         ensure_global_figure_initialized, get_global_figure, figure, subplot, &
         subplots, subplots_grid, savefig, savefig_with_status, show_data, &
@@ -31,7 +31,7 @@ module fortplot_matplotlib_advanced
 
     public :: xlabel, ylabel, title, legend, grid
     public :: xlim, ylim, set_xscale, set_yscale
-    public :: set_line_width, set_ydata
+    public :: set_line_width, set_ydata, use_axis, get_active_axis
 
     public :: figure, subplot, subplots, subplots_grid
     public :: savefig, savefig_with_status

--- a/src/interfaces/fortplot_matplotlib_axes.f90
+++ b/src/interfaces/fortplot_matplotlib_axes.f90
@@ -20,6 +20,8 @@ module fortplot_matplotlib_axes
     public :: set_yscale
     public :: set_line_width
     public :: set_ydata
+    public :: use_axis
+    public :: get_active_axis
 
 contains
 
@@ -134,5 +136,17 @@ contains
         call ensure_fig_init()
         call fig%set_ydata(1, ydata)
     end subroutine set_ydata
+
+    subroutine use_axis(axis_name)
+        character(len=*), intent(in) :: axis_name
+        call ensure_fig_init()
+        call fig%use_axis(axis_name)
+    end subroutine use_axis
+
+    function get_active_axis() result(axis_name)
+        character(len=10) :: axis_name
+        call ensure_fig_init()
+        axis_name = fig%get_active_axis()
+    end function get_active_axis
 
 end module fortplot_matplotlib_axes

--- a/src/interfaces/fortplot_matplotlib_plots_new.f90
+++ b/src/interfaces/fortplot_matplotlib_plots_new.f90
@@ -104,13 +104,13 @@ contains
     end subroutine fill_between
 
     subroutine twinx()
-        !! Create a twin x-axis (placeholder - not fully implemented)
+        !! Activate a secondary y-axis that shares the x-axis but renders on the right
         call ensure_fig_init()
         call fig%twinx()
     end subroutine twinx
 
     subroutine twiny()
-        !! Create a twin y-axis (placeholder - not fully implemented)
+        !! Activate a secondary x-axis that shares the y-axis but renders on the top
         call ensure_fig_init()
         call fig%twiny()
     end subroutine twiny

--- a/src/testing/fortplot_plot_data.f90
+++ b/src/testing/fortplot_plot_data.f90
@@ -13,6 +13,7 @@ module fortplot_plot_data
 
     private
     public :: plot_data_t, arrow_data_t, subplot_t, subplot_data_t
+    public :: AXIS_PRIMARY, AXIS_TWINX, AXIS_TWINY
     public :: PLOT_TYPE_LINE, PLOT_TYPE_CONTOUR, PLOT_TYPE_PCOLORMESH, &
               PLOT_TYPE_ERRORBAR, PLOT_TYPE_BAR, PLOT_TYPE_HISTOGRAM, &
               PLOT_TYPE_BOXPLOT, PLOT_TYPE_SCATTER, PLOT_TYPE_FILL, &
@@ -35,6 +36,11 @@ module fortplot_plot_data
     ! Constants for calculations
     real(wp), parameter :: HALF_WIDTH = 0.5_wp
     real(wp), parameter :: IQR_WHISKER_MULTIPLIER = 1.5_wp
+
+    ! Axis selection identifiers for multi-axis figures
+    integer, parameter :: AXIS_PRIMARY = 0
+    integer, parameter :: AXIS_TWINX  = 1
+    integer, parameter :: AXIS_TWINY  = 2
 
     type :: arrow_data_t
         !! Data container for streamplot arrows
@@ -135,6 +141,8 @@ module fortplot_plot_data
         character(len=:), allocatable :: pie_autopct
         real(wp) :: pie_radius = 1.0_wp
         real(wp) :: pie_center(2) = [0.0_wp, 0.0_wp]
+        ! Axis assignment (primary by default)
+        integer :: axis = AXIS_PRIMARY
     contains
         procedure :: is_3d
     end type plot_data_t


### PR DESCRIPTION
## Summary
- implement twin axis state management with `use_axis` and secondary scales
- render right/top axes and labels for raster backends and update pyplot facade
- add twin axes regression test and fortran example documenting the feature

## Verification
- `fpm test --target test_matplotlib_new_functions`
- `make verify-artifacts`
