### PR TITLE
fix: bug: errorbar ignores elinewidth and capthick (fixes #1369)

### DIFF
--- a/src/figures/fortplot_figure_rendering_pipeline.f90
+++ b/src/figures/fortplot_figure_rendering_pipeline.f90
@@ -473,6 +473,7 @@ contains
         real(wp) :: x_min_curr, x_max_curr, y_min_curr, y_max_curr
         character(len=10) :: xscale_curr, yscale_curr
         real(wp) :: primary_x_min, primary_x_max, primary_y_min, primary_y_max
+        real(wp) :: default_line_width
 
         has_state = present(state)
         if (has_state) then
@@ -480,6 +481,9 @@ contains
             primary_x_max = state%x_max_transformed
             primary_y_min = state%y_min_transformed
             primary_y_max = state%y_max_transformed
+            default_line_width = state%current_line_width
+        else
+            default_line_width = 1.0_wp
         end if
 
         do i = 1, plot_count
@@ -583,7 +587,7 @@ contains
 
             case (PLOT_TYPE_ERRORBAR)
                 call render_errorbar_plot(backend, plots(i), xscale_curr, yscale_curr, &
-                                          symlog_threshold)
+                                          symlog_threshold, default_line_width)
                 ! Always attempt to render markers for errorbar plots; 
                 ! render_markers internally validates presence/emptiness.
                 call render_markers(backend, plots(i), &

--- a/src/interfaces/fortplot_matplotlib_plot_wrappers.f90
+++ b/src/interfaces/fortplot_matplotlib_plot_wrappers.f90
@@ -54,17 +54,20 @@ contains
         end if
     end subroutine plot
 
-    subroutine errorbar(x, y, xerr, yerr, fmt, label, capsize, linestyle, marker, color)
+    subroutine errorbar(x, y, xerr, yerr, fmt, label, capsize, linestyle, marker, &
+                        color, elinewidth, capthick)
         real(wp), intent(in) :: x(:), y(:)
         real(wp), intent(in), optional :: xerr(:), yerr(:)
         character(len=*), intent(in), optional :: fmt, label, linestyle, marker
         real(wp), intent(in), optional :: capsize
         real(wp), intent(in), optional :: color(3)
+        real(wp), intent(in), optional :: elinewidth, capthick
 
         call ensure_fig_init()
         ! Route to the actual errorbar implementation so error bars are visible
         call errorbar_impl(fig, x, y, xerr=xerr, yerr=yerr, label=label, &
-                           capsize=capsize, marker=marker, color=color)
+                           capsize=capsize, marker=marker, color=color, &
+                           elinewidth=elinewidth, capthick=capthick)
     end subroutine errorbar
 
     subroutine bar(x, height, width, bottom, label, color, edgecolor, align)

--- a/src/interfaces/fortplot_matplotlib_plot_wrappers.f90
+++ b/src/interfaces/fortplot_matplotlib_plot_wrappers.f90
@@ -242,16 +242,18 @@ contains
     end subroutine add_plot
 
     subroutine add_errorbar(x, y, xerr, yerr, fmt, label, capsize, linestyle, &
-                               marker, color)
+                               marker, color, elinewidth, capthick)
         real(wp), intent(in) :: x(:), y(:)
         real(wp), intent(in), optional :: xerr(:), yerr(:)
         character(len=*), intent(in), optional :: fmt, label, linestyle, marker
         real(wp), intent(in), optional :: capsize
         real(wp), intent(in), optional :: color(3)
+        real(wp), intent(in), optional :: elinewidth, capthick
 
         call ensure_fig_init()
         call errorbar_impl(fig, x, y, xerr=xerr, yerr=yerr, label=label, &
-                           capsize=capsize, marker=marker, color=color)
+                           capsize=capsize, marker=marker, color=color, &
+                           elinewidth=elinewidth, capthick=capthick)
     end subroutine add_errorbar
 
     subroutine add_3d_plot(x, y, z, label, linestyle, color, linewidth, marker, &

--- a/src/plotting/fortplot_errorbar_plots.f90
+++ b/src/plotting/fortplot_errorbar_plots.f90
@@ -37,10 +37,6 @@ contains
         real(wp), intent(in), optional :: color(3)
         
         integer :: plot_idx, color_idx
-        real(wp) :: ms_dummy, ct_dummy
-        if (present(markersize)) ms_dummy = markersize
-        if (present(capthick)) ct_dummy = capthick
-        
         self%plot_count = self%plot_count + 1
         plot_idx = self%plot_count
         
@@ -96,6 +92,12 @@ contains
         
         if (present(elinewidth)) then
             self%plots(plot_idx)%elinewidth = elinewidth
+        end if
+
+        if (present(capthick)) then
+            self%plots(plot_idx)%capthick = capthick
+        else
+            self%plots(plot_idx)%capthick = self%plots(plot_idx)%elinewidth
         end if
         
         if (present(marker)) then

--- a/src/testing/fortplot_plot_data.f90
+++ b/src/testing/fortplot_plot_data.f90
@@ -109,6 +109,7 @@ module fortplot_plot_data
         real(wp), allocatable :: yerr_lower(:), yerr_upper(:)
         real(wp) :: capsize = 5.0_wp
         real(wp) :: elinewidth = 1.0_wp
+        real(wp) :: capthick = 1.0_wp
         logical :: has_xerr = .false., has_yerr = .false.
         logical :: asymmetric_xerr = .false., asymmetric_yerr = .false.
         ! Scatter plot data

--- a/test/test_stateful_api_fast.f90
+++ b/test/test_stateful_api_fast.f90
@@ -125,6 +125,9 @@ contains
                           fig%plots(plot_idx)%plot_type == PLOT_TYPE_ERRORBAR)
         call check_result("errorbar with yerr -> has_yerr", &
                           fig%plots(plot_idx)%has_yerr)
+        call check_result("errorbar with yerr -> default capthick", &
+                          abs(fig%plots(plot_idx)%capthick - &
+                              fig%plots(plot_idx)%elinewidth) < 1.0d-12)
 
         call errorbar(x, y, xerr=yerr)
         fig => get_global_figure()
@@ -143,6 +146,14 @@ contains
                           fig%plots(plot_idx)%has_xerr)
         call check_result("errorbar with both -> has_yerr", &
                           fig%plots(plot_idx)%has_yerr)
+
+        call errorbar(x, y, yerr=yerr, elinewidth=3.0d0, capthick=2.0d0)
+        fig => get_global_figure()
+        plot_idx = fig%plot_count
+        call check_result("errorbar stores elinewidth override", &
+                          abs(fig%plots(plot_idx)%elinewidth - 3.0d0) < 1.0d-12)
+        call check_result("errorbar stores capthick override", &
+                          abs(fig%plots(plot_idx)%capthick - 2.0d0) < 1.0d-12)
     end subroutine test_errorbar_api
     
     subroutine test_boxplot_api()

--- a/test/test_stateful_api_fast.f90
+++ b/test/test_stateful_api_fast.f90
@@ -154,6 +154,14 @@ contains
                           abs(fig%plots(plot_idx)%elinewidth - 3.0d0) < 1.0d-12)
         call check_result("errorbar stores capthick override", &
                           abs(fig%plots(plot_idx)%capthick - 2.0d0) < 1.0d-12)
+
+        call add_errorbar(x, y, yerr=yerr, elinewidth=4.0d0, capthick=1.5d0)
+        fig => get_global_figure()
+        plot_idx = fig%plot_count
+        call check_result("add_errorbar stores elinewidth override", &
+                          abs(fig%plots(plot_idx)%elinewidth - 4.0d0) < 1.0d-12)
+        call check_result("add_errorbar stores capthick override", &
+                          abs(fig%plots(plot_idx)%capthick - 1.5d0) < 1.0d-12)
     end subroutine test_errorbar_api
     
     subroutine test_boxplot_api()


### PR DESCRIPTION
## Summary
- capture `capthick` alongside `elinewidth` in errorbar plot data and default it sensibly
- drive the backend renderer with those widths and reset to the figure default when done
- expose the styling knobs through the stateful wrapper and cover them in the fast API test

## Verification
- fpm test --target test_stateful_api_fast
- make test-ci
