### PR TITLE
fix: fix: refresh make test-ci target list (fixes #1373)

### DIFF
--- a/scripts/verify_ci_fpm_targets.sh
+++ b/scripts/verify_ci_fpm_targets.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <target> [<target>...]" >&2
+  exit 2
+fi
+
+extra_args=()
+if [[ -n "${FPM_FLAGS_TEST:-}" ]]; then
+  # shellcheck disable=SC2206
+  extra_args=(${FPM_FLAGS_TEST})
+fi
+
+mapfile -t available < <(fpm test "${extra_args[@]}" --list 2>&1 \
+  | awk '$1 != "Matched" {print $1}')
+
+missing=()
+for target in "$@"; do
+  if ! printf '%s\n' "${available[@]}" | grep -Fxq "${target}"; then
+    missing+=("${target}")
+  fi
+done
+
+if (( ${#missing[@]} )); then
+  echo "Missing fpm test targets:" >&2
+  for target in "${missing[@]}"; do
+    echo "  ${target}" >&2
+  done
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- drop the deleted test_show_fallback_mechanisms target and use the current test_scatter_enhanced_core in the CI list
- document the curated CI Fortran targets and add a guard that ensures they still exist before running
- keep the CI output readable with grouped echo statements while preserving the existing regression checks

## Verification
- make test-ci
  - PASS: Testing core API and backend smoke coverage
  - PASS: CI essential test suite completed successfully
