### PR TITLE
fix: refactor: centralize documentation helper utilities (fixes #1371)

### DIFF
--- a/app/update_example_index.f90
+++ b/app/update_example_index.f90
@@ -1,5 +1,6 @@
 program update_example_index
     use, intrinsic :: iso_fortran_env, only: error_unit
+    use fortplot_doc_utils, only: file_exists, title_case
     implicit none
 
     type :: example_entry_t
@@ -70,7 +71,7 @@ contains
         allocate(character(len=name_len) :: entry%name)
         entry%name = trim(raw_name)
 
-        entry%title = to_title_case(entry%name)
+        entry%title = title_case(entry%name)
 
         doc_path = 'doc/examples/' // entry%name // '.md'
         entry%has_doc = file_exists(doc_path)
@@ -329,97 +330,6 @@ contains
             out(idx+1:idx+3) = '...'
         end if
     end function truncate_desc
-
-    pure function to_title_case(name) result(out)
-        character(len=*), intent(in) :: name
-        character(len=:), allocatable :: out
-        character(len=1) :: ch
-        integer :: i
-        logical :: new_word
-
-        out = ''
-        new_word = .true.
-        do i = 1, len_trim(name)
-            ch = name(i:i)
-            select case (ch)
-            case ('_', '-')
-                if (len(out) > 0) then
-                    if (out(len(out):len(out)) /= ' ') then
-                        out = out // ' '
-                    end if
-                end if
-                new_word = .true.
-            case default
-                if (new_word) then
-                    out = out // char_upper(ch)
-                    new_word = .false.
-                else
-                    if (len(out) > 0) then
-                        if (is_digit(out(len(out):len(out))) .and. &
-                            is_alpha(ch)) then
-                            out = out // char_upper(ch)
-                        else
-                            out = out // char_lower(ch)
-                        end if
-                    else
-                        out = out // char_lower(ch)
-                    end if
-                end if
-            end select
-        end do
-        if (len(out) > 0) then
-            if (out(len(out):len(out)) == ' ') then
-                out = out(1:len(out)-1)
-            end if
-        end if
-    end function to_title_case
-
-    pure function char_lower(ch) result(out)
-        character(len=1), intent(in) :: ch
-        character(len=1) :: out
-        integer :: code
-
-        code = iachar(ch)
-        if (code >= iachar('A') .and. code <= iachar('Z')) then
-            out = achar(code + 32)
-        else
-            out = ch
-        end if
-    end function char_lower
-
-    pure function char_upper(ch) result(out)
-        character(len=1), intent(in) :: ch
-        character(len=1) :: out
-        integer :: code
-
-        code = iachar(ch)
-        if (code >= iachar('a') .and. code <= iachar('z')) then
-            out = achar(code - 32)
-        else
-            out = ch
-        end if
-    end function char_upper
-
-    pure logical function is_digit(ch)
-        character(len=1), intent(in) :: ch
-        integer :: code
-
-        code = iachar(ch)
-        is_digit = code >= iachar('0') .and. code <= iachar('9')
-    end function is_digit
-
-    pure logical function is_alpha(ch)
-        character(len=1), intent(in) :: ch
-        integer :: code
-
-        code = iachar(char_lower(ch))
-        is_alpha = code >= iachar('a') .and. code <= iachar('z')
-    end function is_alpha
-
-    logical function file_exists(path)
-        character(len=*), intent(in) :: path
-        inquire(file=trim(path), exist=file_exists)
-    end function file_exists
 
     subroutine run_command(command, action_desc)
         character(len=*), intent(in) :: command

--- a/doc/examples/index.md
+++ b/doc/examples/index.md
@@ -15,7 +15,7 @@ listed here the next time the documentation is rebuilt.
 - [Animation](./animation.html) - Documentation for this example is auto-generated.
 - [Annotation Demo](./annotation_demo.html) - Documentation for this example is auto-generated.
 - [Ascii Heatmap](./ascii_heatmap.html) - Documentation for this example is auto-generated.
-- [Bar Chart Demo](./bar_chart_demo.html) - Grouped vertical and horizontal bar charts.
+- [Bar Chart Demo](./bar_chart_demo.html) - Grouped bar charts for categorical comparisons using both the pyplot-style
 - [Basic Plots](./basic_plots.html) - Documentation for this example is auto-generated.
 - [Boxplot Demo](./boxplot_demo.html) - Demonstrates box-and-whisker plots for statistical data visualization.
 - [Colored Contours](./colored_contours.html) - Documentation for this example is auto-generated.
@@ -32,12 +32,15 @@ listed here the next time the documentation is rebuilt.
 - [Mathtext Demo](./mathtext_demo.html) - Documentation for this example is auto-generated.
 - [Pcolormesh Demo](./pcolormesh_demo.html) - Documentation for this example is auto-generated.
 - [Pcolormesh Negative](./pcolormesh_negative.html) - Documentation for this example is auto-generated.
+- [Pie Chart Demo](https://github.com/lazy-fortran/fortplot/tree/main/example/fortran/pie_chart_demo) - Documentation pending; browse the source tree.
+- [Polar Demo](https://github.com/lazy-fortran/fortplot/tree/main/example/fortran/polar_demo) - Documentation pending; browse the source tree.
 - [Scale Examples](./scale_examples.html) - Documentation for this example is auto-generated.
 - [Scatter Demo](./scatter_demo.html) - Demonstrates enhanced scatter plotting with color mapping, variable marker sizes, and bubble charts.
 - [Show Viewer Demo](./show_viewer_demo.html) - Documentation for this example is auto-generated.
 - [Smart Show Demo](./smart_show_demo.html) - Documentation for this example is auto-generated.
 - [Streamplot Demo](./streamplot_demo.html) - Documentation for this example is auto-generated.
 - [Subplot Demo](./subplot_demo.html) - Demonstration of subplot functionality using the stateful API.
+- [Twin Axes Demo](https://github.com/lazy-fortran/fortplot/tree/main/example/fortran/twin_axes_demo) - Documentation pending; browse the source tree.
 - [Unicode Demo](./unicode_demo.html) - Documentation for this example is auto-generated.
 
 <!-- AUTO_EXAMPLES_END -->

--- a/doc/index.md
+++ b/doc/index.md
@@ -32,7 +32,7 @@ and links directly to the source code.
 - [Animation](./examples/animation.html) - Documentation for this example is auto-generated.
 - [Annotation Demo](./examples/annotation_demo.html) - Documentation for this example is auto-generated.
 - [Ascii Heatmap](./examples/ascii_heatmap.html) - Documentation for this example is auto-generated.
-- [Bar Chart Demo](./examples/bar_chart_demo.html) - Grouped vertical and horizontal bar charts.
+- [Bar Chart Demo](./examples/bar_chart_demo.html) - Grouped bar charts for categorical comparisons using both the pyplot-style
 - [Basic Plots](./examples/basic_plots.html) - Documentation for this example is auto-generated.
 - [Boxplot Demo](./examples/boxplot_demo.html) - Demonstrates box-and-whisker plots for statistical data visualization.
 - [Colored Contours](./examples/colored_contours.html) - Documentation for this example is auto-generated.
@@ -49,12 +49,15 @@ and links directly to the source code.
 - [Mathtext Demo](./examples/mathtext_demo.html) - Documentation for this example is auto-generated.
 - [Pcolormesh Demo](./examples/pcolormesh_demo.html) - Documentation for this example is auto-generated.
 - [Pcolormesh Negative](./examples/pcolormesh_negative.html) - Documentation for this example is auto-generated.
+- [Pie Chart Demo](https://github.com/lazy-fortran/fortplot/tree/main/example/fortran/pie_chart_demo) - Documentation pending; browse the source tree.
+- [Polar Demo](https://github.com/lazy-fortran/fortplot/tree/main/example/fortran/polar_demo) - Documentation pending; browse the source tree.
 - [Scale Examples](./examples/scale_examples.html) - Documentation for this example is auto-generated.
 - [Scatter Demo](./examples/scatter_demo.html) - Demonstrates enhanced scatter plotting with color mapping, variable marker sizes, and bubble charts.
 - [Show Viewer Demo](./examples/show_viewer_demo.html) - Documentation for this example is auto-generated.
 - [Smart Show Demo](./examples/smart_show_demo.html) - Documentation for this example is auto-generated.
 - [Streamplot Demo](./examples/streamplot_demo.html) - Documentation for this example is auto-generated.
 - [Subplot Demo](./examples/subplot_demo.html) - Demonstration of subplot functionality using the stateful API.
+- [Twin Axes Demo](https://github.com/lazy-fortran/fortplot/tree/main/example/fortran/twin_axes_demo) - Documentation pending; browse the source tree.
 - [Unicode Demo](./examples/unicode_demo.html) - Documentation for this example is auto-generated.
 
 <!-- AUTO_EXAMPLES_END -->

--- a/src/documentation/fortplot_documentation.f90
+++ b/src/documentation/fortplot_documentation.f90
@@ -2,6 +2,9 @@ module fortplot_documentation
     !! Consolidated documentation generation module combining core utilities,
     !! processing logic, and output generation
     use fortplot_directory_listing, only: list_directory_entries
+    use fortplot_doc_utils, only: &
+        build_file_path, check_file_exists, file_exists, get_file_extension, &
+        lowercase_string, replace_extension, title_case
     implicit none
     private
 
@@ -83,45 +86,6 @@ contains
     ! Core Utilities Section (from doc_core)
     ! ========================================
 
-    logical function check_file_exists(dir, filename)
-        character(len=*), intent(in) :: dir, filename
-        character(len=PATH_MAX_LEN) :: full_path
-        logical :: exists
-
-        ! Build full path
-        full_path = trim(adjustl(dir)) // '/' // trim(adjustl(filename))
-
-        ! Check existence
-        inquire(file=full_path, exist=exists)
-        check_file_exists = exists
-    end function check_file_exists
-
-    function get_file_extension(filename) result(extension)
-        character(len=*), intent(in) :: filename
-        character(len=:), allocatable :: extension
-        integer :: dot_pos
-
-        dot_pos = index(filename, '.', back=.true.)
-        if (dot_pos > 0) then
-            extension = filename(dot_pos+1:)
-        else
-            extension = ''
-        end if
-    end function get_file_extension
-
-    function replace_extension(filename, new_ext) result(new_filename)
-        character(len=*), intent(in) :: filename, new_ext
-        character(len=:), allocatable :: new_filename
-        integer :: dot_pos
-
-        dot_pos = index(filename, '.', back=.true.)
-        if (dot_pos > 0) then
-            new_filename = filename(1:dot_pos) // trim(new_ext)
-        else
-            new_filename = trim(filename) // '.' // trim(new_ext)
-        end if
-    end function replace_extension
-
     subroutine copy_file_content(input_file, output_file)
         character(len=*), intent(in) :: input_file, output_file
         integer :: input_unit, output_unit, ios
@@ -144,13 +108,6 @@ contains
         close(input_unit)
         close(output_unit)
     end subroutine copy_file_content
-
-    pure subroutine build_file_path(dir, filename, full_path)
-        character(len=*), intent(in) :: dir, filename
-        character(len=PATH_MAX_LEN), intent(out) :: full_path
-
-        full_path = trim(adjustl(dir)) // '/' // trim(adjustl(filename))
-    end subroutine build_file_path
 
     pure subroutine build_readme_path(example_dir, readme_file)
         character(len=*), intent(in) :: example_dir
@@ -190,41 +147,6 @@ contains
 
         local_path = 'example/' // trim(example_name) // '.f90'
     end subroutine build_local_fortran_path
-
-    function title_case(input_str) result(output_str)
-        character(len=*), intent(in) :: input_str
-        character(len=:), allocatable :: output_str
-        integer :: i
-        logical :: capitalize_next
-
-        output_str = input_str
-        capitalize_next = .true.
-
-        do i = 1, len(output_str)
-            if (capitalize_next .and. output_str(i:i) >= 'a' .and. output_str(i:i) <= 'z') then
-                output_str(i:i) = char(ichar(output_str(i:i)) - 32)
-                capitalize_next = .false.
-            else if (output_str(i:i) == '_' .or. output_str(i:i) == ' ') then
-                output_str(i:i) = ' '
-                capitalize_next = .true.
-            else
-                capitalize_next = .false.
-            end if
-        end do
-    end function title_case
-
-    function lowercase_string(input_str) result(output_str)
-        character(len=*), intent(in) :: input_str
-        character(len=:), allocatable :: output_str
-        integer :: i
-
-        output_str = input_str
-        do i = 1, len(output_str)
-            if (output_str(i:i) >= 'A' .and. output_str(i:i) <= 'Z') then
-                output_str(i:i) = char(ichar(output_str(i:i)) + 32)
-            end if
-        end do
-    end function lowercase_string
 
     function get_output_title(filename) result(title)
         character(len=*), intent(in) :: filename

--- a/src/utilities/doc/fortplot_doc_utils.f90
+++ b/src/utilities/doc/fortplot_doc_utils.f90
@@ -1,0 +1,158 @@
+module fortplot_doc_utils
+    implicit none
+    private
+
+    public :: build_file_path
+    public :: get_file_extension
+    public :: replace_extension
+    public :: title_case
+    public :: lowercase_string
+    public :: file_exists
+    public :: check_file_exists
+
+contains
+
+    pure subroutine build_file_path(dir, filename, full_path)
+        character(len=*), intent(in) :: dir, filename
+        character(len=*), intent(out) :: full_path
+
+        full_path = trim(adjustl(dir)) // '/' // trim(adjustl(filename))
+    end subroutine build_file_path
+
+    pure function get_file_extension(filename) result(extension)
+        character(len=*), intent(in) :: filename
+        character(len=:), allocatable :: extension
+        integer :: dot_pos
+
+        dot_pos = index(filename, '.', back=.true.)
+        if (dot_pos > 0) then
+            extension = filename(dot_pos+1:)
+        else
+            extension = ''
+        end if
+    end function get_file_extension
+
+    pure function replace_extension(filename, new_ext) result(new_filename)
+        character(len=*), intent(in) :: filename, new_ext
+        character(len=:), allocatable :: new_filename
+        integer :: dot_pos
+
+        dot_pos = index(filename, '.', back=.true.)
+        if (dot_pos > 0) then
+            new_filename = filename(1:dot_pos) // trim(new_ext)
+        else
+            new_filename = trim(filename) // '.' // trim(new_ext)
+        end if
+    end function replace_extension
+
+    pure function title_case(value) result(output)
+        character(len=*), intent(in) :: value
+        character(len=:), allocatable :: output
+        character(len=1) :: ch
+        integer :: i
+        logical :: new_word
+
+        output = ''
+        new_word = .true.
+        do i = 1, len_trim(value)
+            ch = value(i:i)
+            select case (ch)
+            case ('_', '-', ' ')
+                if (len(output) > 0) then
+                    if (output(len(output):len(output)) /= ' ') then
+                        output = output // ' '
+                    end if
+                end if
+                new_word = .true.
+            case default
+                if (new_word) then
+                    output = output // char_upper(ch)
+                    new_word = .false.
+                else if (len(output) > 0) then
+                    if (is_digit(output(len(output):len(output))) .and. &
+                        is_alpha(ch)) then
+                        output = output // char_upper(ch)
+                    else
+                        output = output // char_lower(ch)
+                    end if
+                else
+                    output = output // char_lower(ch)
+                end if
+            end select
+        end do
+
+        if (len(output) > 0) then
+            if (output(len(output):len(output)) == ' ') then
+                output = output(1:len(output)-1)
+            end if
+        end if
+    end function title_case
+
+    pure function lowercase_string(value) result(output)
+        character(len=*), intent(in) :: value
+        character(len=:), allocatable :: output
+        integer :: i
+
+        output = value
+        do i = 1, len(output)
+            output(i:i) = char_lower(output(i:i))
+        end do
+    end function lowercase_string
+
+    logical function file_exists(path)
+        character(len=*), intent(in) :: path
+
+        inquire(file=trim(path), exist=file_exists)
+    end function file_exists
+
+    logical function check_file_exists(dir, filename)
+        character(len=*), intent(in) :: dir, filename
+        character(len=:), allocatable :: full_path
+
+        full_path = trim(adjustl(dir)) // '/' // trim(adjustl(filename))
+        check_file_exists = file_exists(full_path)
+    end function check_file_exists
+
+    pure function char_lower(ch) result(out)
+        character(len=1), intent(in) :: ch
+        character(len=1) :: out
+        integer :: code
+
+        code = iachar(ch)
+        if (code >= iachar('A') .and. code <= iachar('Z')) then
+            out = achar(code + 32)
+        else
+            out = ch
+        end if
+    end function char_lower
+
+    pure function char_upper(ch) result(out)
+        character(len=1), intent(in) :: ch
+        character(len=1) :: out
+        integer :: code
+
+        code = iachar(ch)
+        if (code >= iachar('a') .and. code <= iachar('z')) then
+            out = achar(code - 32)
+        else
+            out = ch
+        end if
+    end function char_upper
+
+    pure logical function is_digit(ch)
+        character(len=1), intent(in) :: ch
+        integer :: code
+
+        code = iachar(ch)
+        is_digit = code >= iachar('0') .and. code <= iachar('9')
+    end function is_digit
+
+    pure logical function is_alpha(ch)
+        character(len=1), intent(in) :: ch
+        integer :: code
+
+        code = iachar(char_lower(ch))
+        is_alpha = code >= iachar('a') .and. code <= iachar('z')
+    end function is_alpha
+
+end module fortplot_doc_utils

--- a/test/test_doc_core.f90
+++ b/test/test_doc_core.f90
@@ -8,12 +8,20 @@ program test_doc_core
     character(len=PATH_MAX_LEN) :: url
 
     ! title_case
-    call assert_eq('title_case basic_plots', title_case('basic_plots'), 'Basic Plots')
-    call assert_eq('title_case single', title_case('animation'), 'Animation')
+    call assert_eq('title_case basic_plots', &
+        title_case('basic_plots'), 'Basic Plots')
+    call assert_eq('title_case single', &
+        title_case('animation'), 'Animation')
+    call assert_eq('title_case hyphen', &
+        title_case('multi-axis_plot'), 'Multi Axis Plot')
+    call assert_eq('title_case digits', &
+        title_case('3d_rotation'), '3D Rotation')
 
     ! get_output_title
-    call assert_eq('get_output_title png', get_output_title('simple_plot.png'), 'Simple Plot')
-    call assert_eq('get_output_title noext', get_output_title('multi_line'), 'Multi Line')
+    call assert_eq('get_output_title png', &
+        get_output_title('simple_plot.png'), 'Simple Plot')
+    call assert_eq('get_output_title noext', &
+        get_output_title('multi_line'), 'Multi Line')
 
     ! build_python_path
     call build_python_path('basic_plots', got)
@@ -22,7 +30,8 @@ program test_doc_core
 
     ! extension helpers
     call assert_eq('get_file_extension', get_file_extension('file.mp4'), 'mp4')
-    call assert_eq('replace_extension', replace_extension('image.png','pdf'), 'image.pdf')
+    call assert_eq('replace_extension', &
+        replace_extension('image.png','pdf'), 'image.pdf')
 
     ! build_fortran_url suffix check
     call build_fortran_url('marker_demo', url)
@@ -46,4 +55,3 @@ contains
     end subroutine assert_eq
 
 end program test_doc_core
-


### PR DESCRIPTION
## Summary
- extract shared documentation helpers into `fortplot_doc_utils` and reuse them in both generators
- update `update_example_index` and doc tests to consume the shared helpers and cover digit/hyphen title casing
- regenerate `doc/index.md` and `doc/examples/index.md` via the refreshed helpers for consistent output

## Verification
- `fpm test --target test_doc_core` (`All doc core tests passed!`)
- `fpm run --target update_example_index` (`Project is up to date`; updated `doc/index.md`, `doc/examples/index.md`)
