### PR TITLE
fix: weing math rendering of subscripts outside math mode (fixes #1378)

### DIFF
--- a/src/text/fortplot_text_helpers.f90
+++ b/src/text/fortplot_text_helpers.f90
@@ -1,7 +1,6 @@
 module fortplot_text_helpers
     !! Small helpers for preparing text for backends
     use, intrinsic :: iso_fortran_env, only: wp => real64
-    use fortplot_text_layout, only: has_mathtext
     implicit none
 
     private
@@ -10,8 +9,7 @@ module fortplot_text_helpers
 contains
 
     pure subroutine prepare_mathtext_if_needed(input_text, output_text, out_len)
-        !! If text contains ^ or _ but no $...$, wrap with $ delimiters
-        !! so downstream mathtext-aware renderers parse superscripts/subscripts.
+        !! Return trimmed text and leave math parsing decisions to explicit $...$ delimiters.
         character(len=*), intent(in) :: input_text
         character(len=*), intent(out) :: output_text
         integer, intent(out) :: out_len
@@ -27,23 +25,16 @@ contains
             return
         end if
 
-        if (has_mathtext(trimmed) .or. index(trimmed, '$') > 0) then
-            ! Already mathtext-delimited
+        output_text = ''
+
+        if (len(output_text) >= n) then
             output_text = trimmed
             out_len = n
-        else if (index(trimmed, '^') > 0 .or. index(trimmed, '_') > 0) then
-            ! Add $ delimiters to engage mathtext pipeline in raster layout/renderers
-            if (len(output_text) >= n + 2) then
-                output_text = '$' // trimmed(1:n) // '$'
-                out_len = n + 2
-            else
-                ! Fallback: truncate safely if caller provided too-small buffer
-                output_text = '$' // trimmed(1:min(n, max(0, len(output_text)-2))) // '$'
-                out_len = min(n, max(0, len(output_text)-2)) + 2
-            end if
         else
-            output_text = trimmed
-            out_len = n
+            out_len = len(output_text)
+            if (out_len > 0) then
+                output_text(1:out_len) = trimmed(1:out_len)
+            end if
         end if
     end subroutine prepare_mathtext_if_needed
 

--- a/test/test_text_helpers_mathtext_wrap.f90
+++ b/test/test_text_helpers_mathtext_wrap.f90
@@ -3,18 +3,18 @@ program test_text_helpers_mathtext_wrap
     implicit none
 
     character(len=256) :: out
-    character(len=6)   :: small
+    character(len=4)   :: small
     integer :: n
 
     call prepare_mathtext_if_needed('x^3', out, n)
-    if (out(1:n) /= '$x^3$') then
-        print *, 'FAIL: x^3 should wrap to $x^3$'
+    if (out(1:n) /= 'x^3') then
+        print *, 'FAIL: x^3 should remain literal without $ delimiters'
         stop 1
     end if
 
     call prepare_mathtext_if_needed('x_1', out, n)
-    if (out(1:n) /= '$x_1$') then
-        print *, 'FAIL: x_1 should wrap to $x_1$'
+    if (out(1:n) /= 'x_1') then
+        print *, 'FAIL: x_1 should remain literal without $ delimiters'
         stop 1
     end if
 
@@ -32,7 +32,7 @@ program test_text_helpers_mathtext_wrap
 
     call prepare_mathtext_if_needed('price is $5 and cost^2', out, n)
     if (out(1:n) /= 'price is $5 and cost^2') then
-        print *, 'FAIL: presence of $ should prevent auto-wrap'
+        print *, 'FAIL: presence of literal $ should leave text unchanged'
         stop 1
     end if
 
@@ -42,18 +42,17 @@ program test_text_helpers_mathtext_wrap
         stop 1
     end if
 
-    ! Small-buffer truncation behavior: input requires 8 chars ('$x^1234$'),
-    ! but buffer is only 6; ensure safe wrap with truncation and correct length
+    ! Small-buffer behavior: ensure content truncates safely when buffer is too small
     small = ''
     call prepare_mathtext_if_needed('x^1234', small, n)
     if (n /= len(small)) then
-        print *, 'FAIL: small buffer out_len mismatch'
+        print *, 'FAIL: small buffer out_len should match buffer length'
         stop 1
     end if
-    if (small(1:1) /= '$' .or. small(n:n) /= '$') then
-        print *, 'FAIL: small buffer should still be wrapped with $ delimiters'
+    if (small(1:n) /= 'x^12') then
+        print *, 'FAIL: small buffer should contain truncated literal input'
         stop 1
     end if
 
-    print *, 'PASS: prepare_mathtext_if_needed wraps as expected'
+    print *, 'PASS: prepare_mathtext_if_needed preserves literal math markers as expected'
 end program test_text_helpers_mathtext_wrap


### PR DESCRIPTION
## Summary
- stop injecting `$` delimiters for bare carets/underscores so literal text like `polar_plots` stays unchanged
- adjust helper tests to cover literal handling and truncated-buffer behaviour

## Verification
- make test
- make verify-artifacts  \
  `[ok] symlog ylabel shows superscript three (unicode)`
