### PR TITLE
fix: Pie chart in example not wirh equal axes (fixes #1377)

### DIFF
--- a/example/fortran/pie_chart_demo/pie_chart_demo.f90
+++ b/example/fortran/pie_chart_demo/pie_chart_demo.f90
@@ -2,7 +2,7 @@ program pie_chart_demo
     !! Demonstrates pie charts with exploded wedges and autopct labels
 
     use, intrinsic :: iso_fortran_env, only: dp => real64
-    use fortplot, only: figure, pie, title, savefig_with_status, figure_t
+    use fortplot, only: figure, pie, title, legend, savefig_with_status, figure_t
     use fortplot_errors, only: SUCCESS
     implicit none
 
@@ -29,6 +29,7 @@ contains
         call figure(figsize=[6.0_dp, 6.0_dp])
         call pie(sales, labels=labels, autopct='%.1f%%', explode=explode_vals, startangle=90.0_dp)
         call title('Regional revenue share')
+        call legend('east')
 
         ok = .true.
         call savefig_with_status('output/example/fortran/pie_chart_demo/stateful_sales.png', status)
@@ -50,7 +51,7 @@ contains
         integer :: status
         logical :: ok
 
-        call fig%initialize()
+        call fig%initialize(width=640, height=640)
 
         sources = [42.0_dp, 28.0_dp, 18.0_dp, 12.0_dp]
         explode_vals = [0.1_dp, 0.0_dp, 0.0_dp, 0.05_dp]
@@ -61,6 +62,7 @@ contains
 
         call fig%set_title('Clean energy capacity mix')
         call fig%add_pie(sources, labels=labels, autopct='%.0f%%', explode=explode_vals, startangle=75.0_dp)
+        call fig%legend(location='east')
 
         ok = .true.
         call fig%savefig_with_status('output/example/fortran/pie_chart_demo/oo_energy.png', status)

--- a/src/figures/fortplot_figure_aspect.f90
+++ b/src/figures/fortplot_figure_aspect.f90
@@ -8,7 +8,7 @@ module fortplot_figure_aspect
     implicit none
 
     private
-    public :: contains_pie_plot, enforce_pie_axis_equal
+    public :: contains_pie_plot, enforce_pie_axis_equal, only_pie_plots
 
 contains
 
@@ -27,6 +27,26 @@ contains
             end if
         end do
     end function contains_pie_plot
+
+    logical function only_pie_plots(plots, plot_count) result(all_pie)
+        !! Check if every plot in the collection is a pie chart
+        type(plot_data_t), intent(in) :: plots(:)
+        integer, intent(in) :: plot_count
+        integer :: i, upper
+
+        all_pie = .false.
+        if (plot_count <= 0) return
+        upper = min(plot_count, size(plots))
+        if (upper <= 0) return
+
+        all_pie = .true.
+        do i = 1, upper
+            if (plots(i)%plot_type /= PLOT_TYPE_PIE) then
+                all_pie = .false.
+                return
+            end if
+        end do
+    end function only_pie_plots
 
     subroutine enforce_pie_axis_equal(state)
         !! Adjust the figure axis limits so pie charts render with equal scaling

--- a/src/figures/fortplot_figure_rendering_pipeline.f90
+++ b/src/figures/fortplot_figure_rendering_pipeline.f90
@@ -28,7 +28,7 @@ module fortplot_figure_rendering_pipeline
     private
     public :: calculate_figure_data_ranges, setup_coordinate_system
     public :: render_figure_background, render_figure_axes, render_all_plots
-    public :: render_figure_axes_labels_only
+    public :: render_figure_axes_labels_only, render_title_only
     
 contains
     
@@ -240,6 +240,24 @@ contains
             end if
         end select
     end subroutine render_figure_axes_labels_only
+
+    subroutine render_title_only(backend, title, x_min, x_max, y_min, y_max)
+        !! Render only the figure title without drawing axes
+        class(plot_context), intent(inout) :: backend
+        character(len=:), allocatable, intent(in) :: title
+        real(wp), intent(in) :: x_min, x_max, y_min, y_max
+        real(wp) :: y_span, y_pos, x_pos
+
+        if (.not. allocated(title)) return
+        if (len_trim(title) == 0) return
+
+        call backend%color(0.0_wp, 0.0_wp, 0.0_wp)
+
+        y_span = max(1.0e-6_wp, y_max - y_min)
+        x_pos = 0.5_wp * (x_min + x_max)
+        y_pos = y_max + 0.08_wp * y_span
+        call backend%text(x_pos, y_pos, title)
+    end subroutine render_title_only
 
     subroutine detect_3d_extent(plots, plot_count, has_3d, zmin, zmax)
         !! Detect if any plot is 3D and compute z-range

--- a/src/figures/fortplot_figure_rendering_pipeline.f90
+++ b/src/figures/fortplot_figure_rendering_pipeline.f90
@@ -243,6 +243,12 @@ contains
 
     subroutine render_title_only(backend, title, x_min, x_max, y_min, y_max)
         !! Render only the figure title without drawing axes
+        use fortplot_raster, only: raster_context
+        use fortplot_raster_labels, only: render_title_centered
+        use fortplot_pdf, only: pdf_context
+        use fortplot_pdf_core, only: PDF_TITLE_SIZE
+        use fortplot_pdf_text, only: estimate_pdf_text_width
+        use fortplot_ascii, only: ascii_context
         class(plot_context), intent(inout) :: backend
         character(len=:), allocatable, intent(in) :: title
         real(wp), intent(in) :: x_min, x_max, y_min, y_max
@@ -251,12 +257,47 @@ contains
         if (.not. allocated(title)) return
         if (len_trim(title) == 0) return
 
-        call backend%color(0.0_wp, 0.0_wp, 0.0_wp)
+        select type (backend)
+        class is (raster_context)
+            call render_title_centered(backend%raster, backend%width, backend%height, &
+                                       backend%plot_area, trim(title))
+            return
+        class is (pdf_context)
+            block
+                real(wp) :: area_width
+                real(wp) :: area_height
+                real(wp) :: title_width_pdf
+                real(wp) :: x_range
+                real(wp) :: y_range
+                real(wp) :: x_fraction
+                real(wp) :: x_start
+                real(wp) :: y_offset
+
+                area_width = max(1.0e-9_wp, real(backend%plot_area%width, wp))
+                area_height = max(1.0e-9_wp, real(backend%plot_area%height, wp))
+                x_range = max(1.0e-9_wp, x_max - x_min)
+                y_range = max(1.0e-9_wp, y_max - y_min)
+
+                title_width_pdf = estimate_pdf_text_width(trim(title), PDF_TITLE_SIZE)
+                x_fraction = min(1.0_wp, title_width_pdf / area_width)
+                x_start = x_min + 0.5_wp * x_range * (1.0_wp - x_fraction)
+
+                y_offset = (20.0_wp / area_height) * y_range
+                call backend%color(0.0_wp, 0.0_wp, 0.0_wp)
+                call backend%text(x_start, y_max + y_offset, trim(title))
+            end block
+            return
+        class is (ascii_context)
+            call backend%set_title(trim(title))
+            return
+        class default
+            call backend%color(0.0_wp, 0.0_wp, 0.0_wp)
+        end select
 
         y_span = max(1.0e-6_wp, y_max - y_min)
         x_pos = 0.5_wp * (x_min + x_max)
         y_pos = y_max + 0.08_wp * y_span
-        call backend%text(x_pos, y_pos, title)
+        call backend%text(x_pos, y_pos, trim(title))
     end subroutine render_title_only
 
     subroutine detect_3d_extent(plots, plot_count, has_3d, zmin, zmax)

--- a/src/figures/management/fortplot_figure_operations.f90
+++ b/src/figures/management/fortplot_figure_operations.f90
@@ -35,10 +35,11 @@ module fortplot_figure_operations
                                                     render_figure_background, &
                                                     render_figure_axes, &
                                                     render_all_plots, &
-                                                    render_figure_axes_labels_only
+                                                    render_figure_axes_labels_only, &
+                                                    render_title_only
     use fortplot_figure_grid, only: render_grid_lines
     use fortplot_annotation_rendering, only: render_figure_annotations
-    use fortplot_figure_aspect, only: contains_pie_plot, enforce_pie_axis_equal
+    use fortplot_figure_aspect, only: contains_pie_plot, enforce_pie_axis_equal, only_pie_plots
     implicit none
 
     private
@@ -359,6 +360,8 @@ contains
         real(wp) :: twinx_y_min_trans, twinx_y_max_trans
         real(wp) :: twiny_x_min, twiny_x_max
         real(wp) :: twiny_x_min_trans, twiny_x_max_trans
+        logical :: has_pie_plots
+        logical :: pie_only
 
         ! Calculate final data ranges
         call calculate_figure_data_ranges(plots, plot_count, &
@@ -420,8 +423,11 @@ contains
             state%twiny_x_max_transformed = twiny_x_max_trans
         end if
 
-        if (contains_pie_plot(plots, plot_count)) then
+        has_pie_plots = contains_pie_plot(plots, plot_count)
+        pie_only = .false.
+        if (has_pie_plots) then
             call enforce_pie_axis_equal(state)
+            pie_only = only_pie_plots(plots, plot_count)
         end if
         
         ! Setup coordinate system
@@ -447,16 +453,21 @@ contains
                                   state%grid_linestyle)
         end if
         
-        ! Render axes
-        call render_figure_axes(state%backend, state%xscale, state%yscale, &
-                               state%symlog_threshold, state%x_min, state%x_max, &
-                               state%y_min, state%y_max, state%title, &
-                               state%xlabel, state%ylabel, plots, plot_count, &
-                               has_twinx=state%has_twinx, twinx_y_min=state%twinx_y_min, &
-                               twinx_y_max=state%twinx_y_max, twinx_ylabel=state%twinx_ylabel, &
-                               twinx_yscale=state%twinx_yscale, has_twiny=state%has_twiny, &
-                               twiny_x_min=state%twiny_x_min, twiny_x_max=state%twiny_x_max, &
-                               twiny_xlabel=state%twiny_xlabel, twiny_xscale=state%twiny_xscale)
+        ! Render axes or title depending on plot types
+        if (.not. pie_only) then
+            call render_figure_axes(state%backend, state%xscale, state%yscale, &
+                                   state%symlog_threshold, state%x_min, state%x_max, &
+                                   state%y_min, state%y_max, state%title, &
+                                   state%xlabel, state%ylabel, plots, plot_count, &
+                                   has_twinx=state%has_twinx, twinx_y_min=state%twinx_y_min, &
+                                   twinx_y_max=state%twinx_y_max, twinx_ylabel=state%twinx_ylabel, &
+                                   twinx_yscale=state%twinx_yscale, has_twiny=state%has_twiny, &
+                                   twiny_x_min=state%twiny_x_min, twiny_x_max=state%twiny_x_max, &
+                                   twiny_xlabel=state%twiny_xlabel, twiny_xscale=state%twiny_xscale)
+        else
+            call render_title_only(state%backend, state%title, state%x_min, state%x_max, &
+                                   state%y_min, state%y_max)
+        end if
         
         ! Render all plots (only if there are plots to render)
         if (plot_count > 0) then
@@ -470,15 +481,17 @@ contains
         end if
         
         ! Render axis labels AFTER plots (for raster backends only to prevent overlap)
-        call render_figure_axes_labels_only(state%backend, state%xscale, state%yscale, &
-                                           state%symlog_threshold, state%x_min, state%x_max, &
-                                           state%y_min, state%y_max, state%title, &
-                                           state%xlabel, state%ylabel, plots, plot_count, &
-                                           has_twinx=state%has_twinx, twinx_y_min=state%twinx_y_min, &
-                                           twinx_y_max=state%twinx_y_max, twinx_ylabel=state%twinx_ylabel, &
-                                           twinx_yscale=state%twinx_yscale, has_twiny=state%has_twiny, &
-                                           twiny_x_min=state%twiny_x_min, twiny_x_max=state%twiny_x_max, &
-                                           twiny_xlabel=state%twiny_xlabel, twiny_xscale=state%twiny_xscale)
+        if (.not. pie_only) then
+            call render_figure_axes_labels_only(state%backend, state%xscale, state%yscale, &
+                                               state%symlog_threshold, state%x_min, state%x_max, &
+                                               state%y_min, state%y_max, state%title, &
+                                               state%xlabel, state%ylabel, plots, plot_count, &
+                                               has_twinx=state%has_twinx, twinx_y_min=state%twinx_y_min, &
+                                               twinx_y_max=state%twinx_y_max, twinx_ylabel=state%twinx_ylabel, &
+                                               twinx_yscale=state%twinx_yscale, has_twiny=state%has_twiny, &
+                                               twiny_x_min=state%twiny_x_min, twiny_x_max=state%twiny_x_max, &
+                                               twiny_xlabel=state%twiny_xlabel, twiny_xscale=state%twiny_xscale)
+        end if
         
         ! Render legend if requested
         if (state%show_legend .and. state%legend_data%num_entries > 0) then

--- a/test/test_pie_axis_equal_oo.f90
+++ b/test/test_pie_axis_equal_oo.f90
@@ -1,0 +1,59 @@
+program test_pie_axis_equal_oo
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use fortplot, only: figure_t
+    use fortplot_figure_aspect, only: only_pie_plots
+    implicit none
+
+    type(figure_t) :: fig
+    real(dp) :: values(4)
+    real(dp) :: explode(4)
+    character(len=20) :: labels(4)
+    character(len=*), parameter :: output_dir = 'build/test/output/'
+    character(len=*), parameter :: filename = output_dir//'test_pie_axis_equal_oo.png'
+    real(dp) :: plot_width_px, plot_height_px
+    real(dp) :: range_x, range_y
+    real(dp) :: scale_x, scale_y
+    real(dp) :: aspect_diff
+
+    values = [42.0_dp, 28.0_dp, 18.0_dp, 12.0_dp]
+    explode = [0.1_dp, 0.0_dp, 0.0_dp, 0.05_dp]
+    labels(1) = 'Solar'
+    labels(2) = 'Wind'
+    labels(3) = 'Hydro'
+    labels(4) = 'Storage'
+
+    call fig%initialize()
+    call fig%add_pie(values, labels=labels, autopct='%.0f%%', startangle=75.0_dp, explode=explode)
+    call fig%savefig(filename)
+
+    if (.not. only_pie_plots(fig%plots, fig%plot_count)) then
+        error stop 'OO pie should be the sole plot type'
+    end if
+
+    range_x = fig%state%x_max - fig%state%x_min
+    range_y = fig%state%y_max - fig%state%y_min
+
+    if (range_x <= 0.0_dp .or. range_y <= 0.0_dp) then
+        error stop 'Pie axis ranges are invalid for OO figure'
+    end if
+
+    plot_width_px = real(fig%state%width, dp) * &
+                    max(0.0_dp, 1.0_dp - fig%state%margin_left - fig%state%margin_right)
+    plot_height_px = real(fig%state%height, dp) * &
+                     max(0.0_dp, 1.0_dp - fig%state%margin_bottom - fig%state%margin_top)
+
+    if (plot_width_px <= 0.0_dp .or. plot_height_px <= 0.0_dp) then
+        error stop 'Plot area dimensions are invalid for OO figure'
+    end if
+
+    scale_x = plot_width_px / range_x
+    scale_y = plot_height_px / range_y
+    aspect_diff = abs(scale_x - scale_y) / max(scale_x, scale_y)
+
+    if (aspect_diff > 1.0e-6_dp) then
+        write(*,*) 'scale_x = ', scale_x, 'scale_y = ', scale_y
+        error stop 'OO pie axis scaling is not equal'
+    end if
+
+    print *, '✓ OO pie chart uses equal axis scaling by default'
+end program test_pie_axis_equal_oo


### PR DESCRIPTION
## Summary
- hide axes for figures that only contain pie plots and render titles directly so circles stay undistorted
- update the pie chart demo to add legends and use a square canvas for the OO case
- add an OO regression test covering pie aspect handling and ensure pie-only detection works

## Verification
- fpm test --target test_pie_axis_equal
- fpm test --target test_pie_axis_equal_oo
- fpm test --target test_matplotlib_new_functions_oo
- make example ARGS="pie_chart_demo"
- pdftotext output/example/fortran/pie_chart_demo/oo_energy.pdf - | head
  - Clean energy capacity mix
  - Storage / Hydro / Wind / Solar labels only
