### PR TITLE
fix: bug: stream plot arrows still all over the place (fixes #1379)

### DIFF
--- a/src/backends/raster/fortplot_raster.f90
+++ b/src/backends/raster/fortplot_raster.f90
@@ -280,6 +280,7 @@ contains
         real(wp) :: arrow_length, arrow_width, norm_dx, norm_dy
         real(wp) :: perp_x, perp_y  ! Perpendicular vector for arrow width
         real(wp) :: x1, y1, x2, y2, x3, y3  ! Triangle vertices
+        real(wp) :: shaft_base_x, shaft_base_y
         real(wp) :: magnitude
         integer(1) :: r, g, b
         real(wp) :: px, py, ddx, ddy
@@ -316,13 +317,21 @@ contains
         ! Base vertices of arrow head
         x2 = px - arrow_length * norm_dx + arrow_width * perp_x
         y2 = py - arrow_length * norm_dy + arrow_width * perp_y
-        
+
         x3 = px - arrow_length * norm_dx - arrow_width * perp_x
         y3 = py - arrow_length * norm_dy - arrow_width * perp_y
-        
+
+        shaft_base_x = px - arrow_length * norm_dx
+        shaft_base_y = py - arrow_length * norm_dy
+
         ! Get current color for filling
         call this%raster%get_color_bytes(r, g, b)
-        
+
+        call draw_line_distance_aa(this%raster%image_data, this%width, this%height, &
+                                   shaft_base_x, shaft_base_y, px, py, &
+                                   real(r, wp) / 255.0_wp, real(g, wp) / 255.0_wp, &
+                                   real(b, wp) / 255.0_wp, 1.0_wp)
+
         ! Draw filled triangle arrow head
         call fill_triangle(this%raster%image_data, this%width, this%height, &
                           x1, y1, x2, y2, x3, y3, r, g, b)

--- a/src/figures/core/fortplot_figure_core_main.f90
+++ b/src/figures/core/fortplot_figure_core_main.f90
@@ -511,10 +511,15 @@ contains
 
     subroutine clear_backend_arrows(self)
         class(figure_t), intent(inout) :: self
+        logical :: had_arrows
 
+        had_arrows = .false.
         if (allocated(self%state%stream_arrows)) then
+            had_arrows = size(self%state%stream_arrows) > 0
             deallocate(self%state%stream_arrows)
         end if
+
+        if (had_arrows) self%state%rendered = .false.
     end subroutine clear_backend_arrows
     function get_x_min(self) result(x_min)
         class(figure_t), intent(in) :: self

--- a/src/figures/core/fortplot_figure_core_main.f90
+++ b/src/figures/core/fortplot_figure_core_main.f90
@@ -36,7 +36,6 @@ module fortplot_figure_core
         
         type(plot_data_t), allocatable :: plots(:)
         type(plot_data_t), allocatable :: streamlines(:)
-        type(arrow_data_t), allocatable :: arrow_data(:)
         type(text_annotation_t), allocatable :: annotations(:)
         integer :: annotation_count = 0
         integer :: max_annotations = 1000
@@ -110,6 +109,7 @@ module fortplot_figure_core
         procedure :: backend_color
         procedure :: backend_line
         procedure :: backend_arrow
+        procedure :: clear_backend_arrows
         procedure :: backend_associated
         procedure :: get_x_min
         procedure :: get_x_max
@@ -508,6 +508,14 @@ contains
         character(len=*), intent(in) :: style
         call core_backend_arrow(self%state, x, y, dx, dy, size, style)
     end subroutine backend_arrow
+
+    subroutine clear_backend_arrows(self)
+        class(figure_t), intent(inout) :: self
+
+        if (allocated(self%state%stream_arrows)) then
+            deallocate(self%state%stream_arrows)
+        end if
+    end subroutine clear_backend_arrows
     function get_x_min(self) result(x_min)
         class(figure_t), intent(in) :: self
         real(wp) :: x_min

--- a/src/figures/fortplot_figure_rendering_pipeline.f90
+++ b/src/figures/fortplot_figure_rendering_pipeline.f90
@@ -7,7 +7,7 @@ module fortplot_figure_rendering_pipeline
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_context
     use fortplot_figure_data_ranges, only: calculate_figure_data_ranges
-    use fortplot_plot_data, only: plot_data_t, PLOT_TYPE_LINE, &
+    use fortplot_plot_data, only: plot_data_t, arrow_data_t, PLOT_TYPE_LINE, &
                                   PLOT_TYPE_CONTOUR, PLOT_TYPE_PCOLORMESH, &
                                   PLOT_TYPE_SCATTER, PLOT_TYPE_FILL, &
                                   PLOT_TYPE_BOXPLOT, PLOT_TYPE_ERRORBAR, &
@@ -28,6 +28,7 @@ module fortplot_figure_rendering_pipeline
     private
     public :: calculate_figure_data_ranges, setup_coordinate_system
     public :: render_figure_background, render_figure_axes, render_all_plots
+    public :: render_streamplot_arrows
     public :: render_figure_axes_labels_only, render_title_only
     
 contains
@@ -665,5 +666,19 @@ contains
             call backend%set_coordinates(primary_x_min, primary_x_max, primary_y_min, primary_y_max)
         end if
     end subroutine render_all_plots
+
+    subroutine render_streamplot_arrows(backend, arrows)
+        !! Render queued streamplot arrows after plot lines are drawn
+        class(plot_context), intent(inout) :: backend
+        type(arrow_data_t), intent(in) :: arrows(:)
+        integer :: i
+
+        if (size(arrows) <= 0) return
+
+        do i = 1, size(arrows)
+            call backend%draw_arrow(arrows(i)%x, arrows(i)%y, arrows(i)%dx, arrows(i)%dy, &
+                                    arrows(i)%size, arrows(i)%style)
+        end do
+    end subroutine render_streamplot_arrows
 
 end module fortplot_figure_rendering_pipeline

--- a/src/figures/management/fortplot_figure_initialization.f90
+++ b/src/figures/management/fortplot_figure_initialization.f90
@@ -8,7 +8,7 @@ module fortplot_figure_initialization
     use fortplot_context
     use fortplot_utils, only: initialize_backend
     use fortplot_legend, only: legend_t
-    use fortplot_plot_data, only: plot_data_t, AXIS_PRIMARY, AXIS_TWINX, AXIS_TWINY
+    use fortplot_plot_data, only: plot_data_t, arrow_data_t, AXIS_PRIMARY, AXIS_TWINX, AXIS_TWINY
     implicit none
     
     private
@@ -93,6 +93,9 @@ module fortplot_figure_initialization
         character(len=1) :: grid_axis = 'b'
         real(wp) :: grid_alpha = 0.3_wp
         character(len=10) :: grid_linestyle = '-'
+
+        ! Streamplot arrow storage (rendered after plots)
+        type(arrow_data_t), allocatable :: stream_arrows(:)
     end type figure_state_t
     
 contains
@@ -238,6 +241,8 @@ contains
         if (allocated(state%twiny_xlabel)) deallocate(state%twiny_xlabel)
         
         state%has_error = .false.
+
+        if (allocated(state%stream_arrows)) deallocate(state%stream_arrows)
     end subroutine reset_figure_state
     
     subroutine setup_figure_backend(state, backend_name)

--- a/src/figures/management/fortplot_figure_management.f90
+++ b/src/figures/management/fortplot_figure_management.f90
@@ -109,6 +109,9 @@ contains
         state%title = ''
         state%xlabel = ''
         state%ylabel = ''
+        if (allocated(state%stream_arrows)) then
+            deallocate(state%stream_arrows)
+        end if
         ! Clean up backward compatibility members via assignment
         title_target = ''
         xlabel_target = ''
@@ -211,7 +214,10 @@ contains
         state%title = ''
         state%xlabel = ''
         state%ylabel = ''
-        
+        if (allocated(state%stream_arrows)) then
+            deallocate(state%stream_arrows)
+        end if
+
         ! Clear annotation count
         annotation_count = 0
         

--- a/src/figures/management/fortplot_figure_operations.f90
+++ b/src/figures/management/fortplot_figure_operations.f90
@@ -35,6 +35,7 @@ module fortplot_figure_operations
                                                     render_figure_background, &
                                                     render_figure_axes, &
                                                     render_all_plots, &
+                                                    render_streamplot_arrows, &
                                                     render_figure_axes_labels_only, &
                                                     render_title_only
     use fortplot_figure_grid, only: render_grid_lines
@@ -478,6 +479,12 @@ contains
                                  state%width, state%height, &
                                  state%margin_left, state%margin_right, &
                                  state%margin_bottom, state%margin_top, state=state)
+        end if
+
+        if (allocated(state%stream_arrows)) then
+            if (size(state%stream_arrows) > 0) then
+                call render_streamplot_arrows(state%backend, state%stream_arrows)
+            end if
         end if
         
         ! Render axis labels AFTER plots (for raster backends only to prevent overlap)

--- a/src/interfaces/fortplot_matplotlib_field_wrappers.f90
+++ b/src/interfaces/fortplot_matplotlib_field_wrappers.f90
@@ -128,7 +128,6 @@ contains
         integer :: nx, ny
         real(wp) :: asize
         character(len=16) :: astyle
-        integer :: arrow_total
 
         call ensure_fig_init()
 
@@ -164,6 +163,8 @@ contains
             deallocate(traj_x, traj_y)
         end do
 
+        call fig%clear_backend_arrows()
+
         ! Optional: draw arrows along streamlines when requested
         if (present(arrow_scale) .or. present(arrowsize) .or. present(arrowstyle)) then
             asize = 1.0_wp
@@ -177,7 +178,6 @@ contains
                 astyle = trim(adjustl(arrowstyle))
             end if
             if (astyle == 'filled') astyle = '->'
-            call fig%clear_backend_arrows()
             do i = 1, n_traj
                 if (traj_lengths(i) < 5) cycle
                 ! Place ~3 arrows per trajectory, similar to core

--- a/src/interfaces/fortplot_matplotlib_field_wrappers.f90
+++ b/src/interfaces/fortplot_matplotlib_field_wrappers.f90
@@ -128,6 +128,7 @@ contains
         integer :: nx, ny
         real(wp) :: asize
         character(len=16) :: astyle
+        integer :: arrow_total
 
         call ensure_fig_init()
 
@@ -171,8 +172,12 @@ contains
             else if (present(arrow_scale)) then
                 asize = arrow_scale
             end if
-            astyle = 'filled'
-            if (present(arrowstyle)) astyle = arrowstyle
+            astyle = '->'
+            if (present(arrowstyle)) then
+                astyle = trim(adjustl(arrowstyle))
+            end if
+            if (astyle == 'filled') astyle = '->'
+            call fig%clear_backend_arrows()
             do i = 1, n_traj
                 if (traj_lengths(i) < 5) cycle
                 ! Place ~3 arrows per trajectory, similar to core

--- a/src/plotting/fortplot_streamplot_core.f90
+++ b/src/plotting/fortplot_streamplot_core.f90
@@ -147,8 +147,8 @@ contains
 
         arrow_count = 0
 
-        if (allocated(fig%arrow_data)) then
-            deallocate(fig%arrow_data)
+        if (allocated(fig%state%stream_arrows)) then
+            deallocate(fig%state%stream_arrows)
         end if
 
         if (n_trajectories <= 0) return
@@ -202,9 +202,9 @@ contains
         if (arrow_count > 0) then
             allocate(trimmed(arrow_count))
             trimmed = arrow_buffer(1:arrow_count)
-            call move_alloc(trimmed, fig%arrow_data)
+            call move_alloc(trimmed, fig%state%stream_arrows)
         else
-            if (allocated(fig%arrow_data)) deallocate(fig%arrow_data)
+            if (allocated(fig%state%stream_arrows)) deallocate(fig%state%stream_arrows)
         end if
 
         if (allocated(arrow_buffer)) deallocate(arrow_buffer)

--- a/test/test_streamplot.f90
+++ b/test/test_streamplot.f90
@@ -1,5 +1,6 @@
 program test_streamplot
     use fortplot
+    use fortplot_streamplot_core, only: setup_streamplot_parameters
     use, intrinsic :: iso_fortran_env, only: real64
     implicit none
     
@@ -8,6 +9,7 @@ program test_streamplot
     call test_basic_streamplot()
     call test_streamplot_parameters()
     call test_streamplot_grid_validation()
+    call test_streamplot_arrow_clearing()
     
     print *, "All streamplot tests passed!"
     
@@ -88,5 +90,33 @@ contains
             stop 1
         end if
     end subroutine
-    
+
+    subroutine test_streamplot_arrow_clearing()
+        type(figure_t) :: fig
+        real(real64), dimension(5) :: x = [0.0, 1.0, 2.0, 3.0, 4.0]
+        real(real64), dimension(4) :: y = [0.0, 1.0, 2.0, 3.0]
+        real(real64), dimension(5,4) :: u, v
+        integer :: i, j
+
+        do j = 1, 4
+            do i = 1, 5
+                u(i,j) = 1.0_real64
+                v(i,j) = 0.0_real64
+            end do
+        end do
+
+        call fig%initialize(400, 300)
+        call setup_streamplot_parameters(fig, x, y, u, v)
+        if (.not. allocated(fig%state%stream_arrows)) then
+            print *, "ERROR: Expected stream arrows after default streamplot"
+            stop 1
+        end if
+
+        call setup_streamplot_parameters(fig, x, y, u, v, arrowsize=0.0_real64)
+        if (allocated(fig%state%stream_arrows)) then
+            print *, "ERROR: Stream arrows not cleared when arrowsize=0"
+            stop 1
+        end if
+    end subroutine test_streamplot_arrow_clearing
+
 end program test_streamplot


### PR DESCRIPTION

## Summary
- queue streamlined arrows instead of drawing per-point so placements stay inside axes
- normalize arrow styles and draw raster shafts to match streamline direction
- reuse stored arrow list during rendering for consistent backend output

## Verification
- make example ARGS="streamplot_demo"
- make verify-artifacts

Artifacts: output/example/fortran/streamplot_demo/streamplot_arrows.png
