### PR TITLE
fix: docs: replace lingering fortplotlib branding (fixes #1374)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,12 +264,12 @@ The FORD documentation configuration is split between two locations:
 
 ❌ **Don't do this in doc.md**:
 ```markdown
-# project: fortplotlib
+# project: fortplot
 ```
 
 ✅ **Do this in doc.md**:
 ```
-project: fortplotlib
+project: fortplot
 ```
 
 The project name is already defined in `fpm.toml` as `project = "fortplot"`, so it doesn't need to be duplicated in `doc.md`. Having it in both places can cause redundant headers on the GitHub Pages site.

--- a/doc.md
+++ b/doc.md
@@ -1,4 +1,4 @@
-Welcome to the fortplotlib documentation. This library provides a modern, matplotlib-inspired plotting interface for Fortran with multiple backends including PNG, PDF, and ASCII.
+Welcome to the fortplot documentation. This library provides a modern, matplotlib-inspired plotting interface for Fortran with multiple backends including PNG, PDF, and ASCII.
 
 ## Features
 

--- a/doc/examples/index.md
+++ b/doc/examples/index.md
@@ -1,9 +1,9 @@
 title: Examples Gallery
 ---
 
-# fortplotlib Examples Gallery
+# fortplot Examples Gallery
 
-This gallery showcases the capabilities of fortplotlib through various examples. Each example includes the source code, rendered outputs in different formats (PNG, ASCII, PDF), and explanations.
+This gallery showcases the capabilities of fortplot through various examples. Each example includes the source code, rendered outputs in different formats (PNG, ASCII, PDF), and explanations.
 
 The sections below are generated automatically from the example
 directories tracked in `example/fortran`. Any new example folder will be

--- a/example/fortran/scatter_demo/scatter_demo.f90
+++ b/example/fortran/scatter_demo/scatter_demo.f90
@@ -1,5 +1,5 @@
 program scatter_demo
-    !! Demonstrates 2D scatter plots with fortplotlib
+    !! Demonstrates 2D scatter plots with fortplot
     !! Shows the clean scatter API for 2D data
     
     use iso_fortran_env, only: wp => real64

--- a/example/python/scatter3d_demo/scatter3d_demo.py
+++ b/example/python/scatter3d_demo/scatter3d_demo.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """
 Demonstrates 3D scatter plots with matplotlib
-Equivalent to fortplotlib's scatter3d_demo.f90
+Equivalent to fortplot's scatter3d_demo.f90
 
-This shows the matplotlib approach for comparison with fortplotlib's cleaner API.
+This shows the matplotlib approach for comparison with fortplot's cleaner API.
 """
 
 from pathlib import Path
@@ -23,7 +23,7 @@ _OUTDIR = _default_outdir()
 def out(name: str) -> str:
     return str(_OUTDIR / name)
 
-# Generate the same data as fortplotlib example
+# Generate the same data as the fortplot example
 n = 100
 theta = 2.0 * np.pi * np.arange(n) / (n - 1)
 phi = np.pi * (np.arange(n) / (n - 1) - 0.5)

--- a/example/python/scatter_demo/scatter_demo.py
+++ b/example/python/scatter_demo/scatter_demo.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """
 Demonstrates 2D scatter plots with matplotlib
-Equivalent to fortplotlib's scatter_demo.f90
+Equivalent to fortplot's scatter_demo.f90
 
-This shows the matplotlib approach for comparison with fortplotlib's cleaner API.
+This shows the matplotlib approach for comparison with fortplot's cleaner API.
 """
 
 from pathlib import Path


### PR DESCRIPTION
## Summary
- rename lingering fortplotlib branding in docs and examples to fortplot
- update agent guidance samples to reference fortplot configuration
- sync comments/docstrings so scatter demos point back to fortplot sources

## Verification
- `make test`
- `rg 'fortplotlib'` (only `.git/logs` matches remain)
