### PR TITLE
fix: restore streamplot arrow rendering

### DIFF
--- a/src/figures/plot_types/fortplot_figure_streamlines.f90
+++ b/src/figures/plot_types/fortplot_figure_streamlines.f90
@@ -5,8 +5,10 @@ module fortplot_figure_streamlines
     !! Extracted from fortplot_figure_core to improve modularity
     
     use, intrinsic :: iso_fortran_env, only: wp => real64
-    use fortplot_plot_data, only: plot_data_t
+    use fortplot_plot_data, only: plot_data_t, arrow_data_t
     use fortplot_figure_initialization, only: figure_state_t
+    use fortplot_streamplot_arrow_utils, only: compute_streamplot_arrows, &
+        map_grid_index_to_coord
     implicit none
     
     private
@@ -43,7 +45,7 @@ contains
     end subroutine clear_streamline_data
 
     subroutine streamplot_figure(plots, state, plot_count, x, y, u, v, &
-                                density, color)
+        density, color)
         !! Add streamline plot to figure - direct streamline generation
         use fortplot_streamplot_matplotlib, only: streamplot_matplotlib
         use fortplot_plot_data, only: PLOT_TYPE_LINE
@@ -60,6 +62,10 @@ contains
         integer :: n_trajectories, i, j, plot_idx
         integer, allocatable :: trajectory_lengths(:)
         real(wp), allocatable :: traj_x(:), traj_y(:)
+        type(arrow_data_t), allocatable :: computed_arrows(:)
+        logical :: had_arrows
+        real(wp), parameter :: default_arrow_size = 1.0_wp
+        character(len=2), parameter :: default_arrow_style = '->'
         
         ! Basic validation
         if (.not. streamplot_basic_validation(x, y, u, v)) then
@@ -85,7 +91,25 @@ contains
         end if
         
         ! Generate streamlines using matplotlib algorithm
-        call streamplot_matplotlib(x, y, u, v, plot_density, trajectories, n_trajectories, trajectory_lengths)
+        call streamplot_matplotlib(x, y, u, v, plot_density, trajectories, &
+            n_trajectories, trajectory_lengths)
+
+        had_arrows = .false.
+        if (allocated(state%stream_arrows)) then
+            had_arrows = size(state%stream_arrows) > 0
+            deallocate(state%stream_arrows)
+        end if
+
+        call compute_streamplot_arrows(trajectories, n_trajectories, &
+            trajectory_lengths, x, y, default_arrow_size, &
+            default_arrow_style, computed_arrows)
+
+        if (allocated(computed_arrows)) then
+            call move_alloc(computed_arrows, state%stream_arrows)
+            state%rendered = .false.
+        else
+            if (had_arrows) state%rendered = .false.
+        end if
         
         ! Add each trajectory as a line plot
         do i = 1, n_trajectories
@@ -100,11 +124,8 @@ contains
             allocate(traj_x(trajectory_lengths(i)), traj_y(trajectory_lengths(i)))
             
             do j = 1, trajectory_lengths(i)
-                ! Convert grid coords to data coords
-                traj_x(j) = real(trajectories(i, j, 1), wp) * (x(size(x)) - x(1)) / &
-                           real(size(x) - 1, wp) + x(1)
-                traj_y(j) = real(trajectories(i, j, 2), wp) * (y(size(y)) - y(1)) / &
-                           real(size(y) - 1, wp) + y(1)
+                traj_x(j) = map_grid_index_to_coord(real(trajectories(i, j, 1), wp), x)
+                traj_y(j) = map_grid_index_to_coord(real(trajectories(i, j, 2), wp), y)
             end do
             
             ! Set plot type and data

--- a/src/plotting/fortplot_streamplot_arrow_utils.f90
+++ b/src/plotting/fortplot_streamplot_arrow_utils.f90
@@ -4,12 +4,14 @@ module fortplot_streamplot_arrow_utils
     use, intrinsic :: iso_fortran_env, only: wp => real64
     use fortplot_constants, only: EPSILON_COMPARE
     use fortplot_plot_data, only: arrow_data_t
+    use fortplot_figure_initialization, only: figure_state_t
 
     implicit none
     private
 
     public :: validate_streamplot_arrow_parameters
     public :: compute_streamplot_arrows
+    public :: replace_stream_arrows
     public :: map_grid_index_to_coord
 
 contains
@@ -127,6 +129,27 @@ contains
         if (allocated(traj_y)) deallocate(traj_y)
         if (allocated(arc_lengths)) deallocate(arc_lengths)
     end subroutine compute_streamplot_arrows
+
+    subroutine replace_stream_arrows(state, arrows)
+        !! Replace figure state stream arrows and manage rendered flag
+        type(figure_state_t), intent(inout) :: state
+        type(arrow_data_t), allocatable, intent(inout) :: arrows(:)
+
+        logical :: had_arrows
+
+        had_arrows = .false.
+        if (allocated(state%stream_arrows)) then
+            had_arrows = size(state%stream_arrows) > 0
+            deallocate(state%stream_arrows)
+        end if
+
+        if (allocated(arrows)) then
+            call move_alloc(arrows, state%stream_arrows)
+            state%rendered = .false.
+        else
+            if (had_arrows) state%rendered = .false.
+        end if
+    end subroutine replace_stream_arrows
 
     pure function map_grid_index_to_coord(grid_index, grid_values) result(coord)
         !! Convert matplotlib-style grid index to data coordinate

--- a/src/plotting/fortplot_streamplot_arrow_utils.f90
+++ b/src/plotting/fortplot_streamplot_arrow_utils.f90
@@ -1,0 +1,211 @@
+module fortplot_streamplot_arrow_utils
+    !! Shared utilities for streamplot arrow placement
+
+    use, intrinsic :: iso_fortran_env, only: wp => real64
+    use fortplot_constants, only: EPSILON_COMPARE
+    use fortplot_plot_data, only: arrow_data_t
+
+    implicit none
+    private
+
+    public :: validate_streamplot_arrow_parameters
+    public :: compute_streamplot_arrows
+    public :: map_grid_index_to_coord
+
+contains
+
+    subroutine validate_streamplot_arrow_parameters(arrowsize_opt, arrowstyle_opt, &
+        & arrow_size_val, arrow_style_val, has_error)
+        !! Validate arrow size and style inputs (matplotlib compatible)
+        real(wp), intent(in), optional :: arrowsize_opt
+        character(len=*), intent(in), optional :: arrowstyle_opt
+        real(wp), intent(out) :: arrow_size_val
+        character(len=10), intent(out) :: arrow_style_val
+        logical, intent(out) :: has_error
+
+        has_error = .false.
+        arrow_size_val = 1.0_wp
+        if (present(arrowsize_opt)) then
+            if (arrowsize_opt < 0.0_wp) then
+                has_error = .true.
+                return
+            end if
+            arrow_size_val = arrowsize_opt
+        end if
+
+        arrow_style_val = '->'
+        if (present(arrowstyle_opt)) then
+            select case (trim(arrowstyle_opt))
+            case ('->', '-', '<-', '<->')
+                arrow_style_val = trim(arrowstyle_opt)
+            case default
+                has_error = .true.
+                return
+            end select
+        end if
+    end subroutine validate_streamplot_arrow_parameters
+
+    subroutine compute_streamplot_arrows(trajectories, n_trajectories, &
+        & trajectory_lengths, x_grid, y_grid, arrow_size, &
+        & arrow_style, arrows)
+        !! Compute arrow metadata for streamlines based on trajectory geometry
+        real, intent(in) :: trajectories(:,:,:)
+        integer, intent(in) :: n_trajectories
+        integer, intent(in) :: trajectory_lengths(:)
+        real(wp), intent(in) :: x_grid(:), y_grid(:)
+        real(wp), intent(in) :: arrow_size
+        character(len=*), intent(in) :: arrow_style
+        type(arrow_data_t), allocatable, intent(out) :: arrows(:)
+
+        integer :: traj_idx, n_points, target_index
+        integer :: arrow_count
+        real(wp), allocatable :: traj_x(:), traj_y(:)
+        real(wp), allocatable :: arc_lengths(:)
+        real(wp) :: total_length, half_length
+        real(wp) :: segment_start_length, segment_length
+        real(wp) :: position_t, arrow_x, arrow_y
+        real(wp) :: segment_dx, segment_dy, direction_norm
+        type(arrow_data_t), allocatable :: buffer(:)
+
+        if (allocated(arrows)) deallocate(arrows)
+
+        if (n_trajectories <= 0) return
+        if (arrow_size <= 0.0_wp) return
+
+        allocate(buffer(n_trajectories))
+        arrow_count = 0
+
+        do traj_idx = 1, n_trajectories
+            n_points = trajectory_lengths(traj_idx)
+            if (n_points < 2) cycle
+
+            call extract_trajectory_data(trajectories, traj_idx, n_points, &
+                x_grid, y_grid, traj_x, traj_y)
+            call compute_segment_lengths(traj_x, traj_y, arc_lengths, total_length)
+            if (total_length <= EPSILON_COMPARE) cycle
+
+            half_length = 0.5_wp * total_length
+            target_index = locate_half_length(arc_lengths, half_length)
+            if (target_index < 1 .or. target_index >= n_points) cycle
+
+            if (target_index == 1) then
+                segment_start_length = 0.0_wp
+            else
+                segment_start_length = arc_lengths(target_index - 1)
+            end if
+
+            segment_length = arc_lengths(target_index) - segment_start_length
+            if (segment_length <= EPSILON_COMPARE) cycle
+
+            position_t = (half_length - segment_start_length) / segment_length
+            position_t = max(0.0_wp, min(1.0_wp, position_t))
+
+            segment_dx = traj_x(target_index + 1) - traj_x(target_index)
+            segment_dy = traj_y(target_index + 1) - traj_y(target_index)
+            direction_norm = sqrt(segment_dx*segment_dx + segment_dy*segment_dy)
+            if (direction_norm <= EPSILON_COMPARE) cycle
+
+            arrow_x = traj_x(target_index) + position_t * segment_dx
+            arrow_y = traj_y(target_index) + position_t * segment_dy
+
+            arrow_count = arrow_count + 1
+            buffer(arrow_count)%x = arrow_x
+            buffer(arrow_count)%y = arrow_y
+            buffer(arrow_count)%dx = segment_dx / direction_norm
+            buffer(arrow_count)%dy = segment_dy / direction_norm
+            buffer(arrow_count)%size = arrow_size
+            buffer(arrow_count)%style = arrow_style
+        end do
+
+        if (arrow_count > 0) then
+            allocate(arrows(arrow_count))
+            arrows = buffer(1:arrow_count)
+        end if
+
+        if (allocated(buffer)) deallocate(buffer)
+        if (allocated(traj_x)) deallocate(traj_x)
+        if (allocated(traj_y)) deallocate(traj_y)
+        if (allocated(arc_lengths)) deallocate(arc_lengths)
+    end subroutine compute_streamplot_arrows
+
+    pure function map_grid_index_to_coord(grid_index, grid_values) result(coord)
+        !! Convert matplotlib-style grid index to data coordinate
+        real(wp), intent(in) :: grid_index
+        real(wp), intent(in) :: grid_values(:)
+        real(wp) :: coord
+        real(wp) :: span, denom
+
+        if (size(grid_values) <= 1) then
+            coord = grid_values(1)
+            return
+        end if
+
+        span = grid_values(size(grid_values)) - grid_values(1)
+        denom = real(size(grid_values) - 1, wp)
+        coord = grid_values(1) + grid_index * span / denom
+    end function map_grid_index_to_coord
+
+    subroutine extract_trajectory_data(trajectories, traj_idx, n_points, &
+        x_grid, y_grid, traj_x, traj_y)
+        !! Convert stored grid indices into data coordinates for a trajectory
+        real, intent(in) :: trajectories(:,:,:)
+        integer, intent(in) :: traj_idx, n_points
+        real(wp), intent(in) :: x_grid(:), y_grid(:)
+        real(wp), allocatable, intent(inout) :: traj_x(:), traj_y(:)
+        integer :: j
+
+        if (allocated(traj_x)) deallocate(traj_x)
+        if (allocated(traj_y)) deallocate(traj_y)
+        allocate(traj_x(n_points), traj_y(n_points))
+
+        do j = 1, n_points
+            traj_x(j) = map_grid_index_to_coord( &
+                real(trajectories(traj_idx, j, 1), wp), x_grid)
+            traj_y(j) = map_grid_index_to_coord( &
+                real(trajectories(traj_idx, j, 2), wp), y_grid)
+        end do
+    end subroutine extract_trajectory_data
+
+    subroutine compute_segment_lengths(traj_x, traj_y, arc_lengths, total_length)
+        !! Compute cumulative arc lengths along a trajectory
+        real(wp), intent(in) :: traj_x(:), traj_y(:)
+        real(wp), allocatable, intent(inout) :: arc_lengths(:)
+        real(wp), intent(out) :: total_length
+        integer :: n_segments, i
+        real(wp) :: segment_length
+
+        n_segments = size(traj_x) - 1
+        if (allocated(arc_lengths)) deallocate(arc_lengths)
+
+        if (n_segments <= 0) then
+            total_length = 0.0_wp
+            return
+        end if
+
+        allocate(arc_lengths(n_segments))
+        total_length = 0.0_wp
+
+        do i = 1, n_segments
+            segment_length = sqrt((traj_x(i + 1) - traj_x(i))**2 + &
+                                  (traj_y(i + 1) - traj_y(i))**2)
+            total_length = total_length + segment_length
+            arc_lengths(i) = total_length
+        end do
+    end subroutine compute_segment_lengths
+
+    integer function locate_half_length(arc_lengths, half_length) result(target_index)
+        !! Locate the index of the point just before the halfway distance
+        real(wp), intent(in) :: arc_lengths(:), half_length
+        integer :: i
+
+        target_index = size(arc_lengths)
+
+        do i = 1, size(arc_lengths)
+            if (arc_lengths(i) >= half_length) then
+                target_index = i
+                exit
+            end if
+        end do
+    end function locate_half_length
+
+end module fortplot_streamplot_arrow_utils

--- a/src/plotting/fortplot_streamplot_core.f90
+++ b/src/plotting/fortplot_streamplot_core.f90
@@ -11,7 +11,7 @@ module fortplot_streamplot_core
     use fortplot_streamplot_matplotlib
     use fortplot_streamplot_arrow_utils, only: &
         validate_streamplot_arrow_parameters, compute_streamplot_arrows, &
-        map_grid_index_to_coord
+        replace_stream_arrows, map_grid_index_to_coord
 
     implicit none
 
@@ -126,24 +126,12 @@ contains
         character(len=*), intent(in) :: arrow_style
         
         type(arrow_data_t), allocatable :: computed(:)
-        logical :: had_existing
-
-        had_existing = .false.
-        if (allocated(fig%state%stream_arrows)) then
-            had_existing = size(fig%state%stream_arrows) > 0
-            deallocate(fig%state%stream_arrows)
-        end if
 
         call compute_streamplot_arrows(trajectories, n_trajectories, &
             trajectory_lengths, x_grid, y_grid, arrow_size, arrow_style, &
             computed)
 
-        if (allocated(computed)) then
-            call move_alloc(computed, fig%state%stream_arrows)
-            fig%state%rendered = .false.
-        else
-            if (had_existing) fig%state%rendered = .false.
-        end if
+        call replace_stream_arrows(fig%state, computed)
     end subroutine generate_streamplot_arrows
 
     subroutine add_trajectories_to_figure(fig, trajectories, n_trajectories, lengths, &

--- a/src/plotting/fortplot_streamplot_core.f90
+++ b/src/plotting/fortplot_streamplot_core.f90
@@ -9,20 +9,25 @@ module fortplot_streamplot_core
     use fortplot_figure_core, only: figure_t
     use fortplot_plot_data, only: arrow_data_t
     use fortplot_streamplot_matplotlib
+    use fortplot_streamplot_arrow_utils, only: &
+        validate_streamplot_arrow_parameters, compute_streamplot_arrows, &
+        map_grid_index_to_coord
 
     implicit none
 
     private
-    public :: setup_streamplot_parameters, generate_streamlines, add_streamline_to_figure
+    public :: setup_streamplot_parameters, generate_streamlines, &
+        add_streamline_to_figure
 
 contains
 
-    subroutine setup_streamplot_parameters(self, x, y, u, v, density, color, linewidth, &
-                                          rtol, atol, max_time, arrowsize, arrowstyle)
+    subroutine setup_streamplot_parameters(self, x, y, u, v, density, color, &
+        linewidth, rtol, atol, max_time, arrowsize, arrowstyle)
         !! Setup and validate streamplot parameters (focused on validation logic)
         class(figure_t), intent(inout) :: self
         real(wp), intent(in) :: x(:), y(:), u(:,:), v(:,:)
-        real(wp), intent(in), optional :: density, linewidth, rtol, atol, max_time, arrowsize
+        real(wp), intent(in), optional :: density, linewidth, rtol, atol, max_time, &
+            arrowsize
         real(wp), intent(in), optional :: color(3)
         character(len=*), intent(in), optional :: arrowstyle
         
@@ -32,6 +37,7 @@ contains
         real, allocatable :: trajectories(:,:,:)
         integer :: n_trajectories
         integer, allocatable :: trajectory_lengths(:)
+        logical :: arrow_params_error
         if (present(linewidth)) lw_dummy = linewidth
         if (present(rtol)) rt_dummy = rtol
         if (present(atol)) at_dummy = atol
@@ -53,57 +59,33 @@ contains
         if (present(density)) plot_density = density
         
         ! Validate and set arrow parameters
-        call validate_arrow_parameters(self, arrowsize, arrowstyle, arrow_size_val, arrow_style_val)
-        if (self%state%has_error) return
+        call validate_streamplot_arrow_parameters(arrowsize, arrowstyle, &
+            arrow_size_val, arrow_style_val, arrow_params_error)
+        if (arrow_params_error) then
+            self%state%has_error = .true.
+            return
+        end if
         
         ! Update data ranges for streamplot
         call update_streamplot_ranges(self, x, y)
         
         ! Generate streamlines using matplotlib algorithm
-        call generate_streamlines(x, y, u, v, plot_density, trajectories, n_trajectories, trajectory_lengths)
+        call generate_streamlines(x, y, u, v, plot_density, trajectories, &
+            n_trajectories, trajectory_lengths)
 
         ! Always clear queued arrows before recalculating
         call self%clear_backend_arrows()
 
         ! Generate arrows if requested
         if (arrow_size_val > 0.0_wp .and. n_trajectories > 0) then
-            call generate_streamplot_arrows(self, trajectories, n_trajectories, trajectory_lengths, &
-                                          x, y, arrow_size_val, arrow_style_val)
+            call generate_streamplot_arrows(self, trajectories, n_trajectories, &
+                trajectory_lengths, x, y, arrow_size_val, arrow_style_val)
         end if
         
         ! Add trajectories to figure
-        call add_trajectories_to_figure(self, trajectories, n_trajectories, trajectory_lengths, color, x, y)
+        call add_trajectories_to_figure(self, trajectories, n_trajectories, &
+            trajectory_lengths, color, x, y)
     end subroutine setup_streamplot_parameters
-
-    subroutine validate_arrow_parameters(self, arrowsize, arrowstyle, arrow_size_val, arrow_style_val)
-        !! Validate arrow parameters with proper error handling
-        class(figure_t), intent(inout) :: self
-        real(wp), intent(in), optional :: arrowsize
-        character(len=*), intent(in), optional :: arrowstyle
-        real(wp), intent(out) :: arrow_size_val
-        character(len=10), intent(out) :: arrow_style_val
-        
-        ! Handle arrow size validation
-        arrow_size_val = 1.0_wp  ! Default matplotlib-compatible arrow size
-        if (present(arrowsize)) then
-            if (arrowsize < 0.0_wp) then
-                self%state%has_error = .true.
-                return
-            end if
-            arrow_size_val = arrowsize
-        end if
-        
-        ! Handle arrow style validation
-        arrow_style_val = '->'  ! Default matplotlib-compatible arrow style
-        if (present(arrowstyle)) then
-            if (trim(arrowstyle) /= '->' .and. trim(arrowstyle) /= '-' .and. &
-                trim(arrowstyle) /= '<-' .and. trim(arrowstyle) /= '<->') then
-                self%state%has_error = .true.
-                return
-            end if
-            arrow_style_val = trim(arrowstyle)
-        end if
-    end subroutine validate_arrow_parameters
 
     subroutine update_streamplot_ranges(self, x, y)
         !! Update figure data ranges for streamplot
@@ -120,7 +102,8 @@ contains
         end if
     end subroutine update_streamplot_ranges
 
-    subroutine generate_streamlines(x, y, u, v, density, trajectories, n_trajectories, trajectory_lengths)
+    subroutine generate_streamlines(x, y, u, v, density, trajectories, n_trajectories, &
+        trajectory_lengths)
         !! Generate streamlines using matplotlib-compatible algorithm
         real(wp), intent(in) :: x(:), y(:), u(:,:), v(:,:), density
         real, allocatable, intent(out) :: trajectories(:,:,:)
@@ -128,12 +111,13 @@ contains
         integer, allocatable, intent(out) :: trajectory_lengths(:)
         
         ! Delegate to matplotlib implementation
-        call streamplot_matplotlib(x, y, u, v, density, trajectories, n_trajectories, trajectory_lengths)
+        call streamplot_matplotlib(x, y, u, v, density, trajectories, n_trajectories, &
+            trajectory_lengths)
     end subroutine generate_streamlines
 
-    subroutine generate_streamplot_arrows(fig, trajectories, n_trajectories, trajectory_lengths, &
-                                        x_grid, y_grid, arrow_size, arrow_style)
-        !! Generate one arrow per streamline, matching matplotlib placement (midpoint arrow)
+    subroutine generate_streamplot_arrows(fig, trajectories, n_trajectories, &
+        trajectory_lengths, x_grid, y_grid, arrow_size, arrow_style)
+        !! Generate one arrow per streamline using midpoint placement
         class(figure_t), intent(inout) :: fig
         real, intent(in) :: trajectories(:,:,:)
         integer, intent(in) :: n_trajectories, trajectory_lengths(:)
@@ -141,15 +125,8 @@ contains
         real(wp), intent(in) :: arrow_size
         character(len=*), intent(in) :: arrow_style
         
-        integer :: traj_idx, n_points, target_index, arrow_count
-        real(wp), allocatable :: traj_x(:), traj_y(:)
-        real(wp), allocatable :: arc_lengths(:)
-        real(wp) :: total_length, half_length, segment_start_length, segment_length
-        real(wp) :: position_t, arrow_x, arrow_y, segment_dx, segment_dy, direction_norm
-        type(arrow_data_t), allocatable :: arrow_buffer(:), trimmed(:)
+        type(arrow_data_t), allocatable :: computed(:)
         logical :: had_existing
-
-        arrow_count = 0
 
         had_existing = .false.
         if (allocated(fig%state%stream_arrows)) then
@@ -157,134 +134,20 @@ contains
             deallocate(fig%state%stream_arrows)
         end if
 
-        if (n_trajectories <= 0) return
+        call compute_streamplot_arrows(trajectories, n_trajectories, &
+            trajectory_lengths, x_grid, y_grid, arrow_size, arrow_style, &
+            computed)
 
-        allocate(arrow_buffer(n_trajectories))
-
-        do traj_idx = 1, n_trajectories
-            n_points = trajectory_lengths(traj_idx)
-            if (n_points < 2) cycle
-
-            call extract_trajectory_data(trajectories, traj_idx, n_points, x_grid, y_grid, &
-                                         traj_x, traj_y)
-
-            call compute_segment_lengths(traj_x, traj_y, arc_lengths, total_length)
-            if (total_length <= EPSILON_COMPARE) cycle
-
-            half_length = 0.5_wp * total_length
-            target_index = locate_half_length(arc_lengths, half_length)
-            if (target_index < 1 .or. target_index >= n_points) cycle
-
-            if (target_index == 1) then
-                segment_start_length = 0.0_wp
-            else
-                segment_start_length = arc_lengths(target_index - 1)
-            end if
-
-            segment_length = arc_lengths(target_index) - segment_start_length
-            if (segment_length <= EPSILON_COMPARE) cycle
-
-            position_t = (half_length - segment_start_length) / segment_length
-            position_t = max(0.0_wp, min(1.0_wp, position_t))
-
-            segment_dx = traj_x(target_index + 1) - traj_x(target_index)
-            segment_dy = traj_y(target_index + 1) - traj_y(target_index)
-
-            direction_norm = sqrt(segment_dx*segment_dx + segment_dy*segment_dy)
-            if (direction_norm <= EPSILON_COMPARE) cycle
-
-            arrow_x = traj_x(target_index) + position_t * segment_dx
-            arrow_y = traj_y(target_index) + position_t * segment_dy
-
-            arrow_count = arrow_count + 1
-            arrow_buffer(arrow_count)%x = arrow_x
-            arrow_buffer(arrow_count)%y = arrow_y
-            arrow_buffer(arrow_count)%dx = segment_dx / direction_norm
-            arrow_buffer(arrow_count)%dy = segment_dy / direction_norm
-            arrow_buffer(arrow_count)%size = arrow_size
-            arrow_buffer(arrow_count)%style = arrow_style
-        end do
-
-        if (arrow_count > 0) then
-            allocate(trimmed(arrow_count))
-            trimmed = arrow_buffer(1:arrow_count)
-            call move_alloc(trimmed, fig%state%stream_arrows)
+        if (allocated(computed)) then
+            call move_alloc(computed, fig%state%stream_arrows)
             fig%state%rendered = .false.
         else
             if (had_existing) fig%state%rendered = .false.
         end if
-
-        if (allocated(arrow_buffer)) deallocate(arrow_buffer)
-        if (allocated(traj_x)) deallocate(traj_x)
-        if (allocated(traj_y)) deallocate(traj_y)
-        if (allocated(arc_lengths)) deallocate(arc_lengths)
     end subroutine generate_streamplot_arrows
 
-    subroutine extract_trajectory_data(trajectories, traj_idx, n_points, x_grid, y_grid, &
-                                      traj_x, traj_y)
-        !! Convert stored grid indices into data coordinates for a trajectory
-        real, intent(in) :: trajectories(:,:,:)
-        integer, intent(in) :: traj_idx, n_points
-        real(wp), intent(in) :: x_grid(:), y_grid(:)
-        real(wp), allocatable, intent(inout) :: traj_x(:), traj_y(:)
-
-        integer :: j
-
-        if (allocated(traj_x)) deallocate(traj_x)
-        if (allocated(traj_y)) deallocate(traj_y)
-        allocate(traj_x(n_points), traj_y(n_points))
-
-        do j = 1, n_points
-            traj_x(j) = map_grid_index_to_coord(real(trajectories(traj_idx, j, 1), wp), x_grid)
-            traj_y(j) = map_grid_index_to_coord(real(trajectories(traj_idx, j, 2), wp), y_grid)
-        end do
-    end subroutine extract_trajectory_data
-
-    subroutine compute_segment_lengths(traj_x, traj_y, arc_lengths, total_length)
-        !! Compute cumulative arc lengths along a trajectory
-        real(wp), intent(in) :: traj_x(:), traj_y(:)
-        real(wp), allocatable, intent(inout) :: arc_lengths(:)
-        real(wp), intent(out) :: total_length
-
-        integer :: n_segments, i
-        real(wp) :: segment_length
-
-        n_segments = size(traj_x) - 1
-        if (allocated(arc_lengths)) deallocate(arc_lengths)
-
-        if (n_segments <= 0) then
-            total_length = 0.0_wp
-            return
-        end if
-
-        allocate(arc_lengths(n_segments))
-        total_length = 0.0_wp
-
-        do i = 1, n_segments
-            segment_length = sqrt((traj_x(i + 1) - traj_x(i))**2 + &
-                                  (traj_y(i + 1) - traj_y(i))**2)
-            total_length = total_length + segment_length
-            arc_lengths(i) = total_length
-        end do
-    end subroutine compute_segment_lengths
-
-    integer function locate_half_length(arc_lengths, half_length) result(target_index)
-        !! Locate the index of the point just before the halfway distance
-        real(wp), intent(in) :: arc_lengths(:), half_length
-
-        integer :: i
-
-        target_index = size(arc_lengths)
-
-        do i = 1, size(arc_lengths)
-            if (arc_lengths(i) >= half_length) then
-                target_index = i
-                exit
-            end if
-        end do
-    end function locate_half_length
-
-    subroutine add_trajectories_to_figure(fig, trajectories, n_trajectories, lengths, trajectory_color, x_grid, y_grid)
+    subroutine add_trajectories_to_figure(fig, trajectories, n_trajectories, lengths, &
+        trajectory_color, x_grid, y_grid)
         !! Add streamline trajectories to figure as regular plots
         class(figure_t), intent(inout) :: fig
         real, intent(in) :: trajectories(:,:,:)
@@ -300,11 +163,13 @@ contains
         if (present(trajectory_color)) line_color = trajectory_color
         
         do i = 1, n_trajectories
-            call convert_and_add_trajectory(fig, trajectories, i, lengths(i), line_color, x_grid, y_grid)
+            call convert_and_add_trajectory(fig, trajectories, i, lengths(i), &
+                line_color, x_grid, y_grid)
         end do
     end subroutine add_trajectories_to_figure
 
-    subroutine convert_and_add_trajectory(fig, trajectories, traj_idx, n_points, line_color, x_grid, y_grid)
+    subroutine convert_and_add_trajectory(fig, trajectories, traj_idx, n_points, &
+        line_color, x_grid, y_grid)
         !! Convert single trajectory from grid to data coordinates and add to figure
         class(figure_t), intent(inout) :: fig
         real, intent(in) :: trajectories(:,:,:)
@@ -321,10 +186,10 @@ contains
         ! Convert from grid indices to data coordinates
         do j = 1, n_points
             ! trajectory coordinates are grid indices, convert to data coordinates
-            traj_x(j) = map_grid_index_to_coord(real(trajectories(traj_idx, j, 1), wp), &
-                                               x_grid)
-            traj_y(j) = map_grid_index_to_coord(real(trajectories(traj_idx, j, 2), wp), &
-                                               y_grid)
+            traj_x(j) = map_grid_index_to_coord( &
+                real(trajectories(traj_idx, j, 1), wp), x_grid)
+            traj_y(j) = map_grid_index_to_coord( &
+                real(trajectories(traj_idx, j, 2), wp), y_grid)
         end do
         
         ! Add trajectory as line plot to figure
@@ -333,23 +198,6 @@ contains
         if (allocated(traj_x)) deallocate(traj_x)
         if (allocated(traj_y)) deallocate(traj_y)
     end subroutine convert_and_add_trajectory
-
-    pure function map_grid_index_to_coord(grid_index, grid_values) result(coord)
-        !! Convert matplotlib-style grid index to data coordinate
-        real(wp), intent(in) :: grid_index
-        real(wp), intent(in) :: grid_values(:)
-        real(wp) :: coord
-        real(wp) :: span, denom
-
-        if (size(grid_values) <= 1) then
-            coord = grid_values(1)
-            return
-        end if
-
-        span = grid_values(size(grid_values)) - grid_values(1)
-        denom = real(size(grid_values) - 1, wp)
-        coord = grid_values(1) + grid_index * span / denom
-    end function map_grid_index_to_coord
 
     subroutine add_streamline_to_figure(fig, traj_x, traj_y, line_color)
         !! Add streamline trajectory to figure as line plot

--- a/test/test_streamplot.f90
+++ b/test/test_streamplot.f90
@@ -36,9 +36,19 @@ contains
         
         print *, "  Creating streamplot..."
         call fig%streamplot(x, y, u, v)
-        
+
         if (fig%plot_count == 0) then
             print *, "ERROR: No plots generated from streamplot"
+            stop 1
+        end if
+
+        if (.not. allocated(fig%state%stream_arrows)) then
+            print *, "ERROR: Expected streamplot arrows to be generated"
+            stop 1
+        end if
+
+        if (size(fig%state%stream_arrows) == 0) then
+            print *, "ERROR: Streamplot arrows array is empty"
             stop 1
         end if
         ! For now, just check that streamlines were allocated


### PR DESCRIPTION
## Summary
- add dedicated streamplot arrow utilities for shared validation and geometry mapping
- recompute arrow metadata from figure-level streamplot paths and persist in figure state
- extend streamplot test to cover arrow allocation regressions

## Testing
- fpm test --target test_streamplot
