### PR TITLE
fix: ensure pie charts show axes and legend entries

### DIFF
--- a/src/figures/management/fortplot_figure_operations.f90
+++ b/src/figures/management/fortplot_figure_operations.f90
@@ -36,11 +36,10 @@ module fortplot_figure_operations
                                                     render_figure_axes, &
                                                     render_all_plots, &
                                                     render_streamplot_arrows, &
-                                                    render_figure_axes_labels_only, &
-                                                    render_title_only
+                                                    render_figure_axes_labels_only
     use fortplot_figure_grid, only: render_grid_lines
     use fortplot_annotation_rendering, only: render_figure_annotations
-    use fortplot_figure_aspect, only: contains_pie_plot, enforce_pie_axis_equal, only_pie_plots
+    use fortplot_figure_aspect, only: contains_pie_plot, enforce_pie_axis_equal
     implicit none
 
     private
@@ -362,7 +361,6 @@ contains
         real(wp) :: twiny_x_min, twiny_x_max
         real(wp) :: twiny_x_min_trans, twiny_x_max_trans
         logical :: has_pie_plots
-        logical :: pie_only
 
         ! Calculate final data ranges
         call calculate_figure_data_ranges(plots, plot_count, &
@@ -425,10 +423,8 @@ contains
         end if
 
         has_pie_plots = contains_pie_plot(plots, plot_count)
-        pie_only = .false.
         if (has_pie_plots) then
             call enforce_pie_axis_equal(state)
-            pie_only = only_pie_plots(plots, plot_count)
         end if
         
         ! Setup coordinate system
@@ -455,20 +451,15 @@ contains
         end if
         
         ! Render axes or title depending on plot types
-        if (.not. pie_only) then
-            call render_figure_axes(state%backend, state%xscale, state%yscale, &
-                                   state%symlog_threshold, state%x_min, state%x_max, &
-                                   state%y_min, state%y_max, state%title, &
-                                   state%xlabel, state%ylabel, plots, plot_count, &
-                                   has_twinx=state%has_twinx, twinx_y_min=state%twinx_y_min, &
-                                   twinx_y_max=state%twinx_y_max, twinx_ylabel=state%twinx_ylabel, &
-                                   twinx_yscale=state%twinx_yscale, has_twiny=state%has_twiny, &
-                                   twiny_x_min=state%twiny_x_min, twiny_x_max=state%twiny_x_max, &
-                                   twiny_xlabel=state%twiny_xlabel, twiny_xscale=state%twiny_xscale)
-        else
-            call render_title_only(state%backend, state%title, state%x_min, state%x_max, &
-                                   state%y_min, state%y_max)
-        end if
+        call render_figure_axes(state%backend, state%xscale, state%yscale, &
+                               state%symlog_threshold, state%x_min, state%x_max, &
+                               state%y_min, state%y_max, state%title, &
+                               state%xlabel, state%ylabel, plots, plot_count, &
+                               has_twinx=state%has_twinx, twinx_y_min=state%twinx_y_min, &
+                               twinx_y_max=state%twinx_y_max, twinx_ylabel=state%twinx_ylabel, &
+                               twinx_yscale=state%twinx_yscale, has_twiny=state%has_twiny, &
+                               twiny_x_min=state%twiny_x_min, twiny_x_max=state%twiny_x_max, &
+                               twiny_xlabel=state%twiny_xlabel, twiny_xscale=state%twiny_xscale)
         
         ! Render all plots (only if there are plots to render)
         if (plot_count > 0) then
@@ -488,17 +479,15 @@ contains
         end if
         
         ! Render axis labels AFTER plots (for raster backends only to prevent overlap)
-        if (.not. pie_only) then
-            call render_figure_axes_labels_only(state%backend, state%xscale, state%yscale, &
-                                               state%symlog_threshold, state%x_min, state%x_max, &
-                                               state%y_min, state%y_max, state%title, &
-                                               state%xlabel, state%ylabel, plots, plot_count, &
-                                               has_twinx=state%has_twinx, twinx_y_min=state%twinx_y_min, &
-                                               twinx_y_max=state%twinx_y_max, twinx_ylabel=state%twinx_ylabel, &
-                                               twinx_yscale=state%twinx_yscale, has_twiny=state%has_twiny, &
-                                               twiny_x_min=state%twiny_x_min, twiny_x_max=state%twiny_x_max, &
-                                               twiny_xlabel=state%twiny_xlabel, twiny_xscale=state%twiny_xscale)
-        end if
+        call render_figure_axes_labels_only(state%backend, state%xscale, state%yscale, &
+                                           state%symlog_threshold, state%x_min, state%x_max, &
+                                           state%y_min, state%y_max, state%title, &
+                                           state%xlabel, state%ylabel, plots, plot_count, &
+                                           has_twinx=state%has_twinx, twinx_y_min=state%twinx_y_min, &
+                                           twinx_y_max=state%twinx_y_max, twinx_ylabel=state%twinx_ylabel, &
+                                           twinx_yscale=state%twinx_yscale, has_twiny=state%has_twiny, &
+                                           twiny_x_min=state%twiny_x_min, twiny_x_max=state%twiny_x_max, &
+                                           twiny_xlabel=state%twiny_xlabel, twiny_xscale=state%twiny_xscale)
         
         ! Render legend if requested
         if (state%show_legend .and. state%legend_data%num_entries > 0) then


### PR DESCRIPTION
## Summary
- ensure pie-only figures render axes while maintaining equal scaling
- add per-slice legend entries for pie charts with color and label fallbacks
- cover the behaviour with a pie legend regression test

## Testing
- fpm test --target test_pie_chart
- fpm test --target test_pie_axis_equal
- fpm test --target test_pie_axis_equal_oo
