### PR TITLE
refactor: centralize figure render orchestration

### DIFF
--- a/src/figures/management/fortplot_figure_render_engine.f90
+++ b/src/figures/management/fortplot_figure_render_engine.f90
@@ -1,11 +1,12 @@
 module fortplot_figure_render_engine
-    !! Dedicated rendering engine for single-axes figures.
+    !! Shared rendering engine for figure outputs.
     !!
-    !! Provides the shared `figure_render` implementation used by both the
-    !! refactored pipeline and the legacy compatibility entry points.
+    !! Centralises single-axis and subplot rendering so the functional and
+    !! object-oriented APIs share identical drawing behaviour.
 
     use, intrinsic :: iso_fortran_env, only: wp => real64
-    use fortplot_plot_data, only: plot_data_t, AXIS_PRIMARY, AXIS_TWINX, AXIS_TWINY
+    use fortplot_plot_data, only: plot_data_t, subplot_data_t, AXIS_PRIMARY, &
+                                  AXIS_TWINX, AXIS_TWINY
     use fortplot_figure_initialization, only: figure_state_t
     use fortplot_figure_rendering_pipeline, only: calculate_figure_data_ranges, &
                                                     setup_coordinate_system, &
@@ -19,6 +20,11 @@ module fortplot_figure_render_engine
     use fortplot_annotation_rendering, only: render_figure_annotations
     use fortplot_figure_aspect, only: contains_pie_plot, enforce_pie_axis_equal, &
                                       only_pie_plots
+    use fortplot_margins, only: calculate_plot_area
+    use fortplot_pdf_coordinate, only: calculate_pdf_plot_area
+    use fortplot_png, only: png_context
+    use fortplot_pdf, only: pdf_context
+    use fortplot_ascii, only: ascii_context
     implicit none
 
     private
@@ -26,8 +32,39 @@ module fortplot_figure_render_engine
 
 contains
 
-    subroutine figure_render(state, plots, plot_count, annotations, annotation_count)
-        !! Render a single-axis figure using the modern pipeline.
+    subroutine figure_render(state, plots, plot_count, annotations, annotation_count, &
+                             subplots_array, subplot_rows, subplot_cols)
+        !! Render a figure, handling both single-axis and subplot layouts.
+        use fortplot_annotations, only: text_annotation_t
+        type(figure_state_t), intent(inout) :: state
+        type(plot_data_t), intent(inout) :: plots(:)
+        integer, intent(in) :: plot_count
+        type(text_annotation_t), intent(in), optional :: annotations(:)
+        integer, intent(in), optional :: annotation_count
+        type(subplot_data_t), intent(in), optional :: subplots_array(:,:)
+        integer, intent(in), optional :: subplot_rows, subplot_cols
+
+        logical :: have_subplots
+
+        have_subplots = .false.
+        if (present(subplots_array) .and. present(subplot_rows) .and. present(subplot_cols)) then
+            if (size(subplots_array, 1) == subplot_rows .and. &
+                size(subplots_array, 2) == subplot_cols) then
+                have_subplots = subplot_rows > 0 .and. subplot_cols > 0
+            end if
+        end if
+
+        if (have_subplots) then
+            call render_subplots(state, subplots_array, subplot_rows, subplot_cols)
+        else
+            call render_single_axis(state, plots, plot_count, annotations, annotation_count)
+        end if
+
+        state%rendered = .true.
+    end subroutine figure_render
+
+    subroutine render_single_axis(state, plots, plot_count, annotations, annotation_count)
+        !! Render a single-axis figure.
         use fortplot_annotations, only: text_annotation_t
         type(figure_state_t), intent(inout) :: state
         type(plot_data_t), intent(inout) :: plots(:)
@@ -187,8 +224,89 @@ contains
                                                 state%margin_bottom, state%margin_top)
             end if
         end if
+    end subroutine render_single_axis
 
-        state%rendered = .true.
-    end subroutine figure_render
+    subroutine render_subplots(state, subplots_array, subplot_rows, subplot_cols)
+        !! Render a multi-subplot figure layout.
+        type(figure_state_t), intent(inout) :: state
+        type(subplot_data_t), intent(in) :: subplots_array(:,:)
+        integer, intent(in) :: subplot_rows, subplot_cols
+
+        integer :: nr, nc, i, j
+        real(wp) :: base_left, base_right, base_bottom, base_top
+        real(wp) :: cell_w, cell_h, left_f, right_f, bottom_f, top_f
+        real(wp) :: lxmin, lxmax, lymin, lymax
+        real(wp) :: lxmin_t, lxmax_t, lymin_t, lymax_t
+
+        base_left   = 0.10_wp
+        base_right  = 0.95_wp
+        base_bottom = 0.10_wp
+        base_top    = 0.90_wp
+        nr = subplot_rows
+        nc = subplot_cols
+        cell_w = (base_right - base_left) / real(nc, wp)
+        cell_h = (base_top   - base_bottom) / real(nr, wp)
+
+        do i = 1, nr
+            do j = 1, nc
+                left_f   = base_left   + real(j - 1, wp) * cell_w
+                right_f  = base_left   + real(j,     wp) * cell_w
+                bottom_f = base_bottom + real(nr - i, wp) * cell_h
+                top_f    = base_bottom + real(nr - i + 1, wp) * cell_h
+
+                select type (bk => state%backend)
+                class is (png_context)
+                    bk%margins%left = left_f
+                    bk%margins%right = right_f
+                    bk%margins%bottom = bottom_f
+                    bk%margins%top = top_f
+                    call calculate_plot_area(bk%width, bk%height, bk%margins, bk%plot_area)
+                class is (pdf_context)
+                    bk%margins%left = left_f
+                    bk%margins%right = right_f
+                    bk%margins%bottom = bottom_f
+                    bk%margins%top = top_f
+                    call calculate_pdf_plot_area(bk%width, bk%height, bk%margins, bk%plot_area)
+                class is (ascii_context)
+                    ! ASCII backend keeps default layout.
+                class default
+                    ! Unknown backend; leave margins untouched.
+                end select
+
+                call calculate_figure_data_ranges(subplots_array(i, j)%plots, &
+                                                subplots_array(i, j)%plot_count, &
+                                                subplots_array(i, j)%xlim_set, &
+                                                subplots_array(i, j)%ylim_set, &
+                                                lxmin, lxmax, lymin, lymax, &
+                                                lxmin_t, lxmax_t, lymin_t, lymax_t, &
+                                                state%xscale, state%yscale, state%symlog_threshold)
+
+                call setup_coordinate_system(state%backend, lxmin_t, lxmax_t, lymin_t, lymax_t)
+
+                call render_figure_axes(state%backend, state%xscale, state%yscale, &
+                                       state%symlog_threshold, lxmin, lxmax, lymin, lymax, &
+                                       subplots_array(i, j)%title, subplots_array(i, j)%xlabel, &
+                                       subplots_array(i, j)%ylabel, subplots_array(i, j)%plots, &
+                                       subplots_array(i, j)%plot_count, has_twinx=.false., &
+                                       has_twiny=.false.)
+
+                if (subplots_array(i, j)%plot_count > 0) then
+                    call render_all_plots(state%backend, subplots_array(i, j)%plots, &
+                                         subplots_array(i, j)%plot_count, lxmin_t, lxmax_t, &
+                                         lymin_t, lymax_t, state%xscale, state%yscale, &
+                                         state%symlog_threshold, state%width, state%height, &
+                                         state%margin_left, state%margin_right, &
+                                         state%margin_bottom, state%margin_top)
+                end if
+
+                call render_figure_axes_labels_only(state%backend, state%xscale, state%yscale, &
+                                                   state%symlog_threshold, lxmin, lxmax, lymin, lymax, &
+                                                   subplots_array(i, j)%title, subplots_array(i, j)%xlabel, &
+                                                   subplots_array(i, j)%ylabel, subplots_array(i, j)%plots, &
+                                                   subplots_array(i, j)%plot_count, has_twinx=.false., &
+                                                   has_twiny=.false.)
+            end do
+        end do
+    end subroutine render_subplots
 
 end module fortplot_figure_render_engine


### PR DESCRIPTION
## Summary
- replace the compatibility module's bespoke subplot loop with a call into the shared render engine
- teach  to fan out to single-axis or subplot routines based on the presence of optional arguments
- move all subplot margin handling and axis drawing into the shared engine to avoid duplication

## Testing
- fpm test --target test_pie_axis_equal_oo
- fpm test --target test_matplotlib_new_functions
