### PR TITLE
fix: allow log tick labels below epsilon

### DIFF
--- a/src/utilities/ticks/fortplot_tick_formatting.f90
+++ b/src/utilities/ticks/fortplot_tick_formatting.f90
@@ -26,7 +26,7 @@ contains
         
         abs_value = abs(value)
         
-        if (abs_value < 1.0e-10_wp) then
+        if (abs_value <= epsilon(1.0_wp)) then
             formatted = '0'
         else if (range >= 100.0_wp .or. abs_value >= SCIENTIFIC_THRESHOLD_HIGH) then
             ! Use integer format for large ranges
@@ -60,7 +60,7 @@ contains
         abs_value = abs(value)
         
         ! Handle zero
-        if (abs_value < 1.0e-10_wp) then
+        if (abs_value <= epsilon(1.0_wp)) then
             formatted = '0'
             return
         end if


### PR DESCRIPTION
### **User description**
## Summary
- use machine epsilon when detecting zero in tick formatting utilities
- allow log tick labels to emit mathtext for arbitrarily small magnitudes

## Testing
- make test


___

### **PR Type**
Bug fix


___

### **Description**
- Replace hardcoded epsilon with machine epsilon in tick formatting

- Fix zero detection for logarithmic tick labels

- Improve numerical precision for small magnitude values


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Hardcoded epsilon (1.0e-10)"] --> B["Machine epsilon function"]
  B --> C["Improved zero detection"]
  C --> D["Better log tick formatting"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fortplot_tick_formatting.f90</strong><dd><code>Replace hardcoded epsilon with machine epsilon</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/utilities/ticks/fortplot_tick_formatting.f90

<ul><li>Replace hardcoded <code>1.0e-10_wp</code> with <code>epsilon(1.0_wp)</code> in three functions<br> <li> Update zero detection logic from <code><</code> to <code><=</code> comparison<br> <li> Affects <code>format_tick_value</code>, <code>format_tick_value_smart</code>, and <br><code>format_log_tick_value</code></ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortplot/pull/1406/files#diff-b854d288119583f4762e92f3ee5bbc09d35ae2309e32cd9820d42cba62381ab6">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

