### PR TITLE
Fix SIGBUS on Apple Silicon in zlib_compress

### DIFF
--- a/src/external/fortplot_zlib_core.f90
+++ b/src/external/fortplot_zlib_core.f90
@@ -562,7 +562,6 @@ contains
         ! Hash table for LZ77
         integer :: hash_table(0:HASH_SIZE-1)
         integer :: hash_chain(WINDOW_SIZE)
-        save :: hash_table, hash_chain
         
         ! Huffman tables (fixed Huffman for simplicity)
         integer :: literal_codes(0:285)


### PR DESCRIPTION
### **User description**
## Summary
Fixes #1408 - SIGBUS crash on Apple Silicon when saving PNG files

## Root Cause
The `deflate_compress` subroutine declared large arrays (`hash_table` and `hash_chain`, 32768 elements each) with the `SAVE` attribute, causing them to be allocated as static data. ARM64 processors have strict memory alignment requirements, and accessing these statically allocated arrays triggered SIGBUS/EXC_BAD_ACCESS.

## Solution
Removed the `SAVE` attribute from the arrays at src/external/fortplot_zlib_core.f90:565, allowing them to be automatically allocated with proper alignment.

## Testing
- Build passes successfully with `fpm build`
- Awaiting CI verification on macOS ARM64

## Test plan
- [ ] Verify CI passes on macOS ARM64
- [ ] Verify no regression on other platforms (Linux x86_64, macOS x86_64)


___

### **PR Type**
Bug fix


___

### **Description**
- Remove SAVE attribute from hash arrays in deflate_compress

- Fix SIGBUS crash on Apple Silicon ARM64 processors

- Resolve memory alignment issues with static allocation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Static arrays with SAVE"] -- "Remove SAVE attribute" --> B["Automatic allocation"]
  B -- "Proper alignment" --> C["Fixed SIGBUS on ARM64"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fortplot_zlib_core.f90</strong><dd><code>Remove SAVE attribute from hash arrays</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/external/fortplot_zlib_core.f90

<ul><li>Remove SAVE attribute from <code>hash_table</code> and <code>hash_chain</code> arrays<br> <li> Change from static to automatic allocation in <code>deflate_compress</code> <br>subroutine<br> <li> Fix memory alignment issues causing SIGBUS on ARM64 processors</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortplot/pull/1409/files#diff-a88e04b74f6df05653fd8293cdb98c45343981c51bc782a5a54d2ee55e871444">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

