### PR TITLE
Pin final Fortarray revision

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ if(FORTPLOT_BUILD_FORTARRAY_ADAPTER)
         set(FORTARRAY_BUILD_BENCHMARKS OFF CACHE BOOL "" FORCE)
         FetchContent_Declare(fortarray
             GIT_REPOSITORY https://github.com/lazy-fortran/fortarray.git
-            GIT_TAG b39b3e3d9cb16cdf822e0d10875c3306be37b103
+            GIT_TAG a71373a840f068d6a2195efc4a33aa4f5a2792b2
             GIT_SHALLOW FALSE
         )
         FetchContent_MakeAvailable(fortarray)

--- a/fpm.toml
+++ b/fpm.toml
@@ -20,7 +20,7 @@ implicit-external = false
 source-form = "free"
 
 [dependencies]
-fortarray = { git = "https://github.com/lazy-fortran/fortarray.git", rev = "b39b3e3d9cb16cdf822e0d10875c3306be37b103" }
+fortarray = { git = "https://github.com/lazy-fortran/fortarray.git", rev = "a71373a840f068d6a2195efc4a33aa4f5a2792b2" }
 
 # Security: Enable trampoline detection and error on trampolines
 # NOTE: To enable trampoline detection, compile manually with:


### PR DESCRIPTION
## What changed

Pin the optional Fortarray adapter dependency to merged revision `a71373a840f068d6a2195efc4a33aa4f5a2792b2` in both CMake and fpm.

That revision uses final Fortio `e5406149` and preserves the intended one-way composition boundary: Fortplot's adapter depends on Fortarray core; Fortarray does not depend on Fortplot.

## Validation

- Bare `fo`: 295/295 tests, full build/static/lint all pass
- The pinned Fortarray revision independently passed CMake, fpm, and ThreadSanitizer CI
