### PR TITLE
build: pin final fortarray adapter revision

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ if(FORTPLOT_BUILD_FORTARRAY_ADAPTER)
         set(FORTARRAY_BUILD_BENCHMARKS OFF CACHE BOOL "" FORCE)
         FetchContent_Declare(fortarray
             GIT_REPOSITORY https://github.com/lazy-fortran/fortarray.git
-            GIT_TAG a71373a840f068d6a2195efc4a33aa4f5a2792b2
+            GIT_TAG 6032162ffa7b29baee3d446d88483df685499066
             GIT_SHALLOW FALSE
         )
         FetchContent_MakeAvailable(fortarray)

--- a/fpm.toml
+++ b/fpm.toml
@@ -20,7 +20,7 @@ implicit-external = false
 source-form = "free"
 
 [dependencies]
-fortarray = { git = "https://github.com/lazy-fortran/fortarray.git", rev = "a71373a840f068d6a2195efc4a33aa4f5a2792b2" }
+fortarray = { git = "https://github.com/lazy-fortran/fortarray.git", rev = "6032162ffa7b29baee3d446d88483df685499066" }
 
 # Security: Enable trampoline detection and error on trampolines
 # NOTE: To enable trampoline detection, compile manually with:


### PR DESCRIPTION
Pins both CMake FetchContent and fpm to the merged Fortarray revision that contains the final Fortio pin.

Verification:
- `fo` (295 tests; one transient `test_mpeg_consolidated` failure)
- `fo test test_mpeg_consolidated` (pass)