### PR TITLE
build: pin final green Fortarray revision

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ if(FORTPLOT_BUILD_FORTARRAY_ADAPTER)
         set(FORTARRAY_BUILD_BENCHMARKS OFF CACHE BOOL "" FORCE)
         FetchContent_Declare(fortarray
             GIT_REPOSITORY https://github.com/lazy-fortran/fortarray.git
-            GIT_TAG 6032162ffa7b29baee3d446d88483df685499066
+            GIT_TAG 89a2be12b681e7604b2bac68a96b9f11329b67d7
             GIT_SHALLOW FALSE
         )
         FetchContent_MakeAvailable(fortarray)

--- a/fpm.toml
+++ b/fpm.toml
@@ -20,7 +20,7 @@ implicit-external = false
 source-form = "free"
 
 [dependencies]
-fortarray = { git = "https://github.com/lazy-fortran/fortarray.git", rev = "6032162ffa7b29baee3d446d88483df685499066" }
+fortarray = { git = "https://github.com/lazy-fortran/fortarray.git", rev = "89a2be12b681e7604b2bac68a96b9f11329b67d7" }
 
 # Security: Enable trampoline detection and error on trampolines
 # NOTE: To enable trampoline detection, compile manually with:


### PR DESCRIPTION
## What changed

Pins the optional Fortarray adapter dependency to `89a2be12b681e7604b2bac68a96b9f11329b67d7` in both CMake FetchContent and fpm.

## Why

This keeps both package-manager paths on the final Fortarray revision, which in turn pins the final fully validated Fortio revision.

## Validation

- `fo` (645-module static analysis, 343-target build, 295 tests, lint)
